### PR TITLE
support board with 2 relays and stm8s103

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -275,6 +275,7 @@ PROGMEM const char* const custom_reset_string[] = {
 #define RELAY_PROVIDER_DUAL     1
 #define RELAY_PROVIDER_LIGHT    2
 #define RELAY_PROVIDER_RFBRIDGE 3
+#define RELAY_PROVIDER_STM      4
 
 // Default boot mode: 0 means OFF, 1 ON and 2 whatever was before
 #define RELAY_BOOT_MODE         RELAY_BOOT_OFF

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1423,6 +1423,20 @@
 
 // -----------------------------------------------------------------------------
 
+#elif defined(STM_RELAY)
+
+    // Info
+    #define MANUFACTURER            "STM_RELAY"
+    #define DEVICE                  "2CH"
+
+    // Relays
+    #define DUMMY_RELAY_COUNT       2
+    #define RELAY_PROVIDER          RELAY_PROVIDER_STM
+
+    // Remove UART noise on serial line
+    #define TERMINAL_SUPPORT        0
+    #define DEBUG_SERIAL_SUPPORT    0
+
 #endif
 
 // -----------------------------------------------------------------------------

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -77,6 +77,15 @@ void _relayProviderStatus(unsigned char id, bool status) {
 
     #endif
 
+    #if RELAY_PROVIDER == RELAY_PROVIDER_STM
+        Serial.flush();
+        Serial.write(0xA0);
+        Serial.write(id + 1);
+        Serial.write(status);
+        Serial.write(0xA1 + status + id);
+        Serial.flush();
+    #endif
+
     #if RELAY_PROVIDER == RELAY_PROVIDER_LIGHT
 
         // If the number of relays matches the number of light channels

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -394,7 +394,11 @@ void _relayBoot() {
         }
         _relays[i].current_status = !status;
         _relays[i].target_status = status;
-        _relays[i].change_time = millis();
+        #ifdef RELAY_PROVIDER_STM
+            _relays[i].change_time = millis() + 3000 + 1000 * i;
+        #else
+            _relays[i].change_time = millis();
+        #endif
         bit <<= 1;
     }
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1388,6 +1388,31 @@ upload_speed = 460800
 monitor_baud = 115200
 extra_scripts = ${common.extra_scripts}
 
+[env:stm-relay-ota]
+platform = ${common.platform}
+framework = arduino
+board = esp01_1m
+board_flash_mode = dout
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m} -DSTM_RELAY
+monitor_baud = 115200
+extra_scripts = ${common.extra_scripts}
+
+[env:stm-relay-ota]
+platform = ${common.platform}
+framework = arduino
+board = esp01_1m
+board_flash_mode = dout
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m} -DSTM_RELAY
+upload_speed = 115200
+upload_port = "192.168.4.1"
+upload_flags = --auth=fibonacci --port 8266
+monitor_baud = 115200
+extra_scripts = ${common.extra_scripts}
+
 # ------------------------------------------------------------------------------
 # GENERIC OTA ENVIRONMENTS
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Hi
This pull request adds support for generic board which is based on esp-01 module and stm8s103 microcontroller.

Microcontroller is connected to esp8266 by serial port and is listening for commands to turn on and off relays.

Here is the link to the module:
https://www.aliexpress.com/item/5V-ESP8266-ESP-01-2-Channel-WiFi-Relay-Module-2-Channel-Relay-Module-For-IOT-Smart/32843970608.html

The buttons on board are inaccessible - they are connected to the stm8s103, and are used to restore/reset settings when using ESP-01 with Ai-Thinker firmware, they just send some AT+RST, AT+RESTORE commands when being hold.

The firmware in stm8s103 takes few seconds to start, and doesn't allow sending commands one after another - 8c629ba7ab1e0a915f230a40d730769270379b7b - this fixes the state of relays after boot up