### PR TITLE
Load average

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -169,6 +169,12 @@
 #define HEARTBEAT_REPORT_INTERVAL   0
 
 //------------------------------------------------------------------------------
+// Load average
+//------------------------------------------------------------------------------
+#define LOADAVG_INTERVAL        30000   // Interval between calculating load average (in ms)
+#define LOADAVG_REPORT          1       // Should we report Load average over MQTT?
+
+//------------------------------------------------------------------------------
 // RESET
 //------------------------------------------------------------------------------
 
@@ -595,6 +601,7 @@ PROGMEM const char* const custom_reset_string[] = {
 #define MQTT_TOPIC_RFRAW        "rfraw"
 #define MQTT_TOPIC_UARTIN       "uartin"
 #define MQTT_TOPIC_UARTOUT      "uartout"
+#define MQTT_TOPIC_LOADAVG      "loadavg"
 
 // Light module
 #define MQTT_TOPIC_CHANNEL      "channel"

--- a/code/espurna/system.ino
+++ b/code/espurna/system.ino
@@ -85,12 +85,13 @@ void systemLoop() {
 
     // Increase temporary loop counter
     static unsigned long load_counter_temp = 0;
-    static unsigned long load_counter = 0;
-    static unsigned long load_counter_max = 1;
     static unsigned long last_loadcheck = 0;
 
     load_counter_temp++;
     if (millis() - last_loadcheck > LOADAVG_INTERVAL) {
+      static unsigned long load_counter = 0;
+      static unsigned long load_counter_max = 1;
+
       load_counter = load_counter_temp;
       load_counter_temp = 0;
       if (load_counter > load_counter_max) {

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -172,6 +172,9 @@ void heartbeat() {
             #if (HEARTBEAT_REPORT_STATUS)
                 mqttSend(MQTT_TOPIC_STATUS, MQTT_STATUS_ONLINE, true);
             #endif
+            #if (LOADAVG_REPORT)
+                mqttSend(MQTT_TOPIC_LOADAVG, String(getLoadAverage()).c_str());
+            #endif
         }
     #endif
 

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -220,6 +220,7 @@ void _wsUpdate(JsonObject& root) {
     root["heap"] = getFreeHeap();
     root["uptime"] = getUptime();
     root["rssi"] = WiFi.RSSI();
+    root["loadaverage"] = getLoadAverage();
     #if NTP_SUPPORT
         if (ntpSynced()) root["now"] = now();
     #endif

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -223,6 +223,9 @@
                                     <div class="pure-u-1-2 pure-u-lg-1-4">Uptime</div>
                                     <div class="pure-u-11-24 pure-u-lg-17-24"><span class="right" name="uptime"></span></div>
 
+                                    <div class="pure-u-1-2 pure-u-lg-1-4">Load average</div>
+                                    <div class="pure-u-11-24 pure-u-lg-17-24"><span class="right" name="loadaverage"></span>%</div>
+
                                     <div class="pure-u-1-2 pure-u-lg-1-4">Free heap</div>
                                     <div class="pure-u-11-24 pure-u-lg-17-24"><span class="right" name="heap" post=" bytes"></span></div>
 


### PR DESCRIPTION
Calculate poor-mans load average of CPU utilization and display it on status page and MQTT telemetrics. 

Credits for idea go to ESPEasy team.

Useful for understanding if there's some polling that's holding up the CPU (like sync sensors reading or similar).