### PR TITLE
logic for determining travis builds is already in build.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
 - pip install -U platformio
 - cd code ; npm install --only=dev ; cd ..
 script:
-- cd code && ./build.sh travis01 &&  cd ..
+- cd code && ./build.sh &&  cd ..
 before_deploy:
 - mv firmware/*/espurna-*.bin firmware/
 deploy:


### PR DESCRIPTION
Since there's already logic to determine travis builds in build.sh, no need to explicitly pass the list of builds in .travis.yaml