### PR TITLE
Fixes USE_CUSTOM_H to allow to override (back) any default settings

### DIFF
--- a/code/espurna/config/all.h
+++ b/code/espurna/config/all.h
@@ -19,10 +19,6 @@
 
 */
 
-#ifdef USE_CUSTOM_H
-#include "custom.h"
-#endif
-
 #include "version.h"
 #include "arduino.h"
 #include "hardware.h"
@@ -36,3 +32,7 @@
 #endif
 
 #include "build.h"
+
+#ifdef USE_CUSTOM_H
+#include "custom.h"
+#endif

--- a/code/espurna/config/all.h
+++ b/code/espurna/config/all.h
@@ -3,19 +3,22 @@
     If you want to modify the stock configuration but you don't want to touch
     the repo files you can define USE_CUSTOM_H in your build settings.
 
-    Arduino IDE:
-    define it in your boards.txt for the board of your choice.
+    * Using Arduino IDE: **********************************************************
+    Define it in your boards.txt for the board of your choice.
     For instance, for the "Generic ESP8266 Module" with prefix "generic" just add:
 
         generic.build.extra_flags=-DESP8266 -DUSE_CUSTOM_H
 
-    PlatformIO:
-    add the setting to your environment or just define global PLATFORMIO_BUILD_FLAGS
+    * Using PlatformIO: ************************************************************
+    Add the setting to your environment or just define global PLATFORMIO_BUILD_FLAGS
 
         export PLATFORMIO_BUILD_FLAGS="'-DUSE_CUSTOM_H'"
 
-    Check https://github.com/xoseperez/espurna/issues/104
-    for an example on how to use this file.
+
+    * Then add all your settings into a custom.h file ******************************
+	- rename the "custom-sample.h" file to "custom.h" 
+	- Modify custom.h according to your needs
+	- BTW the custom.h file is ignored by git (so it will survive any future update)
 
 */
 

--- a/code/espurna/config/custom-sample.h
+++ b/code/espurna/config/custom-sample.h
@@ -1,0 +1,49 @@
+/*
+	To modify the stock configuration without changing any of the *.h files in this folder:
+
+	1) rename this file to "custom.h" (It is ignored by Git)
+
+	2) define your own settings below 
+
+    3) define USE_CUSTOM_H as a build flags
+        * Using Arduino IDE: **********************************************************
+        Define it in your boards.txt for the board of your choice.
+        For instance, for the "Generic ESP8266 Module" with prefix "generic" just add:
+
+               generic.build.extra_flags=-DESP8266 -DUSE_CUSTOM_H
+
+        * Using PlatformIO: ************************************************************
+        Add the setting to your environment or just define global PLATFORMIO_BUILD_FLAGS
+
+               export PLATFORMIO_BUILD_FLAGS="'-DUSE_CUSTOM_H'"
+*/
+
+
+// make the compiler show a warning to confirm that this file is inlcuded
+#warning "**** Using Settings from custom.h File **********"
+
+
+
+/*
+#######################################################################################################
+Your Own Default Settings
+#######################################################################################################
+
+	You can basically ovveride ALL settings.
+	Don't forget to first #undef each existing #define that you add below.
+	Here are some examples:
+*/
+
+
+
+//#undef	ADMIN_PASS
+//#define ADMIN_PASS              "MyVerySecretPassort"
+
+//#undef	NTP_SERVER
+//#define NTP_SERVER              "it.pool.ntp.org"
+
+//#undef WIFI1_SSID
+//#define WIFI1_SSID              "MySSID"
+
+//#undef WIFI1_PASS
+//#define WIFI1_PASS              "MyVerySecretWifiPassword"


### PR DESCRIPTION
This PR :

**(1)** allows to really override ANY settings , because this has been broken by 1087134 . Commit 1087134 only allowed to override settings that are previously enclosed by #ifndef macros. 

But as you can see, most of the VERY useful settings (in fact most if not all, listed as example by the user in #104 that leaded to get the custom.h file implemented) are just NOT currently enclosed by #ifndef, and thus can no longer be overridden. 

So either  ALL settings must be enclosed by #ifndef, which make the code unnecessarily long and uggly, either this PR revert to the situation before 1087134, where absolutely ALL macros can be overridden, easily.

**(2)** it also adds a detailed explanation on how to use custom.h as well as an example file.

HTH