### PR TITLE
Export max system check for build configuration

### DIFF
--- a/code/.gitignore
+++ b/code/.gitignore
@@ -7,3 +7,4 @@ core_version.h
 .pioenvs
 .piolibdeps
 .DS_Store
+.python-version

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -61,8 +61,8 @@
 
 #ifndef SERIAL_RX_PORT
 #define SERIAL_RX_PORT          Serial			// This setting is usually defined
-												// in the hardware.h file for those
-												// boards that require it
+                                            // in the hardware.h file for those
+                                            // boards that require it
 #endif
 
 #ifndef SERIAL_RX_BAUDRATE
@@ -139,8 +139,10 @@
 #endif
 
 #define SYSTEM_CHECK_TIME       60000           // The system is considered stable after these many millis
+#ifndef SYSTEM_CHECK_MAX
 #define SYSTEM_CHECK_MAX        5               // After this many crashes on boot
                                                 // the system is flagged as unstable
+#endif
 
 //------------------------------------------------------------------------------
 // EEPROM


### PR DESCRIPTION
My kid loves to play with this switch ( turn on and off a lot) and sometimes it reaches the max unstable count so I need increase that number at build time.