### PR TITLE
Fix some typos in the Hass info

### DIFF
--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -26,7 +26,7 @@ void _haSendMagnitude(unsigned char i, JsonObject& config) {
     config["platform"] = "mqtt";
     config["device_class"] = "sensor";
     config["state_topic"] = mqttTopic(magnitudeTopicIndex(i).c_str(), false);
-    config["unit_of_measurement"] = magnitudeUnits(type);
+    config["unit_of_measurement"] = String("\"") + magnitudeUnits(type) + String("\"");
 
 }
 

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -857,7 +857,7 @@
                                     <div class="pure-u-0 pure-u-lg-1-4"></div>
                                     <div class="pure-u-1 pure-u-lg-3-4 hint">
                                         These are the settings you should copy to your Home Assistant "configuration.yaml" file.
-                                        If any of the sections below (switch, light, sensor) already exists, do not dupplicate it,
+                                        If any of the sections below (switch, light, sensor) already exists, do not duplicate it,
                                         simply copy the contents of the section below the ones already present.
                                     </div>
                                 </div>


### PR DESCRIPTION
One of the HASS Units is a % which needs to be quoted or Home Assistant rejects the config.  No harm in quoting the others as well.  