### PR TITLE
Add 'board' to the MQTT heartbeat

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -181,6 +181,7 @@
 #define HEARTBEAT_REPORT_HOSTNAME   1
 #define HEARTBEAT_REPORT_APP        1
 #define HEARTBEAT_REPORT_VERSION    1
+#define HEARTBEAT_REPORT_BOARD      1
 #define HEARTBEAT_REPORT_INTERVAL   0
 
 //------------------------------------------------------------------------------
@@ -617,6 +618,7 @@ PROGMEM const char* const custom_reset_string[] = {
 #define MQTT_TOPIC_UARTIN       "uartin"
 #define MQTT_TOPIC_UARTOUT      "uartout"
 #define MQTT_TOPIC_LOADAVG      "loadavg"
+#define MQTT_TOPIC_BOARD        "board"
 
 // Light module
 #define MQTT_TOPIC_CHANNEL      "channel"

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -137,6 +137,9 @@ void heartbeat() {
             #if (HEARTBEAT_REPORT_VERSION)
                 mqttSend(MQTT_TOPIC_VERSION, APP_VERSION);
             #endif
+            #if (HEARTBEAT_REPORT_BOARD)
+                mqttSend(MQTT_TOPIC_BOARD, getBoardName().c_str());
+            #endif
             #if (HEARTBEAT_REPORT_HOSTNAME)
                 mqttSend(MQTT_TOPIC_HOSTNAME, getSetting("hostname").c_str());
             #endif


### PR DESCRIPTION
On a par with information provided by mDNS, telnet and web. Can be useful to know for OTA, as device can be unreachable with telnet/web or be on separate network.