### PR TITLE
Escape html for weblog in the client

### DIFF
--- a/code/espurna/debug.ino
+++ b/code/espurna/debug.ino
@@ -62,15 +62,11 @@ void _debugSend(char * message) {
 
     #if DEBUG_WEB_SUPPORT
         if (wsConnected() && (getFreeHeap() > 10000)) {
-            String m = String(message);
-            m.replace("\"", "&quot;");
-            m.replace("{", "&#123");
-            m.replace("}", "&#125");
-            char buffer[m.length() + 24];
+            char buffer[strlen(message) + 24]; // 8 char timestamp [234567] + space + 14 char json wrap
             #if DEBUG_ADD_TIMESTAMP
-                snprintf_P(buffer, sizeof(buffer), PSTR("{\"weblog\": \"%s%s\"}"), timestamp, m.c_str());
+                snprintf_P(buffer, sizeof(buffer), PSTR("{\"weblog\": \"%s%s\"}"), timestamp, message);
             #else
-                snprintf_P(buffer, sizeof(buffer), PSTR("{\"weblog\": \"%s\"}"), m.c_str());
+                snprintf_P(buffer, sizeof(buffer), PSTR("{\"weblog\": \"%s\"}"), message);
             #endif
             wsSend(buffer);
         }

--- a/code/html/custom.css
+++ b/code/html/custom.css
@@ -122,7 +122,7 @@ div.state {
 }
 
 .pure-g span.terminal,
-.pure-g textarea.terminal {
+.pure-g ul.terminal {
     font-family: 'Courier New', monospace;
     font-size: 80%;
     line-height: 100%;
@@ -309,5 +309,8 @@ span.slider {
 
 #weblog {
     height: 400px;
+    padding: 0.5em 0.6em;
     margin-bottom: 10px;
+    list-style: none;
+    overflow-y: scroll;
 }

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -1161,7 +1161,7 @@ function processData(data) {
 
         // Web log
         if ("weblog" === key) {
-            $("#weblog").append(value);
+            $("<li></li>").addClass("weblog-event").text(value).appendTo("#weblog");
             $("#weblog").scrollTop($("#weblog")[0].scrollHeight - $("#weblog").height());
             return;
         }

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -983,8 +983,8 @@
                                 </div>
 
                                 <div class="pure-g">
-                                    <textarea class="pure-u-1 terminal" id="weblog" name="weblog" wrap="off" readonly></textarea>
-                                    <div class=" pure-u-1-4 pure-u-lg-1-4"><button class="pure-button button-dbg-clear pure-u-23-24">Clear</button></div>
+                                    <ul class="pure-u-1 terminal" id="weblog" name="weblog"></ul>
+                                    <div class="pure-u-1-4 pure-u-lg-1-4"><button class="pure-button button-dbg-clear pure-u-23-24">Clear</button></div>
                                 </div>
 
                             </fieldset>


### PR DESCRIPTION
I noticed that 04cdb22 escapes some chars for the weblog.
This way client handles the escaping through jquery `text` (which is a wrapper for `textContent` attribute) and esp doesn't waste time rebuilding the string, as there are also `&lt;`,`&gt;` etc.

```javascript
> var test = $("<li></li>").text("<div>{escapeme}</div>");
> test.children().length
0
> test.text()
"<div>{escapeme}</div>"
```