### PR TITLE
Resize WebUI elements for narrow screen

### DIFF
--- a/code/html/custom.css
+++ b/code/html/custom.css
@@ -30,8 +30,11 @@
     color: #777777;
 }
 
-.header > h1 {
-    line-height: 100%;
+@media screen and (max-width: 32em) {
+    .header > h1 {
+        line-height: 100%;
+        font-size: 2em;
+    }
 }
 
 h2 {

--- a/code/html/custom.css
+++ b/code/html/custom.css
@@ -30,6 +30,10 @@
     color: #777777;
 }
 
+.header > h1 {
+    line-height: 100%;
+}
+
 h2 {
     font-size: 1em;
 }

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -539,7 +539,7 @@
                                     <div class=" pure-u-1-4 pure-u-lg-1-8"><button class="pure-button button-upgrade-browse pure-u-23-24">Browse</button></div>
                                     <div class=" pure-u-1-4 pure-u-lg-1-8"><button class="pure-button button-upgrade pure-u-23-24">Upgrade</button></div>
                                     <div class="pure-u-0 pure-u-lg-1-4"></div>
-                                    <div class="pure-u-0 pure-u-lg-3-4 hint">The device has <span name="free_size"></span> bytes available for OTA updates. If your image is larger than this consider doing a <a href="https://github.com/xoseperez/espurna/wiki/TwoStepUpdates" target="_blank"><strong>two-step update</strong></a>.</div>
+                                    <div class="pure-u-1 pure-u-lg-3-4 hint">The device has <span name="free_size"></span> bytes available for OTA updates. If your image is larger than this consider doing a <a href="https://github.com/xoseperez/espurna/wiki/TwoStepUpdates" target="_blank"><strong>two-step update</strong></a>.</div>
                                     <div class="pure-u-0 pure-u-lg-1-4"></div>
                                     <div class="pure-u-1 pure-u-lg-3-4"><progress id="upgrade-progress"></progress></div>
                                     <input name="upgrade" type="file" tabindex="16" />

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -448,6 +448,13 @@
                             <fieldset>
 
                                 <div class="pure-g">
+                                    <label class="pure-u-1 pure-u-lg-1-4">Settings</label>
+                                    <div class="pure-u-1-3 pure-u-lg-1-4"><button class="pure-button button-settings-backup pure-u-23-24">Backup</button></div>
+                                    <div class="pure-u-1-3 pure-u-lg-1-4"><button class="pure-button button-settings-restore pure-u-23-24">Restore</button></div>
+                                    <div class="pure-u-1-3 pure-u-lg-1-4"><button class="pure-button button-settings-factory pure-u-1">Factory Reset</button></div>
+                                </div>
+
+                                <div class="pure-g">
                                     <label class="pure-u-1 pure-u-lg-1-4">Admin password</label>
                                     <input name="adminPass" class="pure-u-1 pure-u-lg-3-4" type="password" action="reboot" tabindex="11" autocomplete="false" />
                                     <div class="pure-u-0 pure-u-lg-1-4"></div>
@@ -524,13 +531,6 @@
                                     <input name="nofussServer" class="pure-u-1 pure-u-lg-3-4" type="text" tabindex="15" />
                                     <div class="pure-u-0 pure-u-lg-1-4"></div>
                                     <div class="pure-u-1 pure-u-lg-3-4 hint">This name address of the NoFUSS server for automatic remote updates (see https://bitbucket.org/xoseperez/nofuss).</div>
-                                </div>
-
-                                <div class="pure-g">
-                                    <label class="pure-u-1 pure-u-lg-1-4">Settings</label>
-                                    <div class="pure-u-1-2 pure-u-lg-1-8"><button class="pure-button button-settings-backup pure-u-23-24">Backup</button></div>
-                                    <div class="pure-u-1-2 pure-u-lg-1-8"><button class="pure-button button-settings-restore pure-u-23-24">Restore</button></div>
-                                    <div class="pure-u-1-4 pure-u-lg-1-4"><button class="pure-button button-settings-factory pure-u-1">Factory Reset</button></div>
                                 </div>
 
                                 <div class="pure-g">


### PR DESCRIPTION
It says that `div .header > h1` inherits line-height value of 1.6em from .content class. And it looks like this in portrait mode:
<img src="https://user-images.githubusercontent.com/132763/37881304-90e4032e-309e-11e8-94b8-695ee01b92f8.png" width="50%"/><img src="https://user-images.githubusercontent.com/132763/37881307-99abdc84-309e-11e8-9083-c9c4c0a49864.png" width="50%"/>