### PR TITLE
Missing values in MQTT configuration, hostname define.

### DIFF
--- a/code/espurna/config/defaults.h
+++ b/code/espurna/config/defaults.h
@@ -399,6 +399,11 @@
 // General
 // -----------------------------------------------------------------------------
 
+// Default hostname will be ESPURNA_XXXXXX, where XXXXXX is last 3 octets of chipID
+#ifndef HOSTNAME
+#define HOSTNAME ""
+#endif
+
 // Needed for ESP8285 boards under Windows using PlatformIO (?)
 #ifndef BUTTON_PUSHBUTTON
 #define BUTTON_PUSHBUTTON   0

--- a/code/espurna/espurna.ino
+++ b/code/espurna/espurna.ino
@@ -50,7 +50,7 @@ void setup() {
 
     // Hostname & board name initialization
     if (getSetting("hostname").length() == 0) {
-        setSetting("hostname", getIdentifier());
+        setDefaultHostname();
     }
     setBoardName();
 

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -312,8 +312,8 @@ void _mqttWebSocketOnSend(JsonObject& root) {
     root["mqttQoS"] = _mqtt_qos;
     #if ASYNC_TCP_SSL_ENABLED
         root["mqttsslVisible"] = 1;
-        root["mqttUseSSL"] = getSetting("mqttUseSSL", 0).toInt() == 1;
-        root["mqttFP"] = getSetting("mqttFP");
+        root["mqttUseSSL"] = getSetting("mqttUseSSL", MQTT_SSL_ENABLED).toInt() == 1;
+        root["mqttFP"] = getSetting("mqttFP", MQTT_SSL_FINGERPRINT);
     #endif
     root["mqttTopic"] = getSetting("mqttTopic", MQTT_TOPIC);
     root["mqttUseJson"] = getSetting("mqttUseJson", MQTT_USE_JSON).toInt() == 1;

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -304,9 +304,9 @@ void _mqttWebSocketOnSend(JsonObject& root) {
     root["mqttEnabled"] = mqttEnabled();
     root["mqttServer"] = getSetting("mqttServer", MQTT_SERVER);
     root["mqttPort"] = getSetting("mqttPort", MQTT_PORT);
-    root["mqttUser"] = getSetting("mqttUser");
+    root["mqttUser"] = getSetting("mqttUser", MQTT_USER);
     root["mqttClientID"] = getSetting("mqttClientID");
-    root["mqttPassword"] = getSetting("mqttPassword");
+    root["mqttPassword"] = getSetting("mqttPassword", MQTT_PASS);
     root["mqttKeep"] = _mqtt_keepalive;
     root["mqttRetain"] = _mqtt_retain;
     root["mqttQoS"] = _mqtt_qos;

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -15,6 +15,14 @@ String getIdentifier() {
     return String(buffer);
 }
 
+void setDefaultHostname() {
+    if (strlen(HOSTNAME) > 0) {
+        setSetting("hostname", HOSTNAME);
+    } else {
+        setSetting("hostname", getIdentifier());
+    }
+}
+
 void setBoardName() {
     #ifndef ESPURNA_CORE
         setSetting("boardName", DEVICE_NAME);


### PR DESCRIPTION
Crude solution to #732 

- Actually show current settings in MQTT panel
- For hostname, first try to use HOSTNAME #define and only then generate it via getIdentifier