### PR TITLE
Documentation fix: general.h INFLUXDB_SUPPORT comment: Disable by default

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -766,7 +766,7 @@ PROGMEM const char* const custom_reset_string[] = {
 // -----------------------------------------------------------------------------
 
 #ifndef INFLUXDB_SUPPORT
-#define INFLUXDB_SUPPORT        0               // Enable InfluxDB support by default (4.38Kb)
+#define INFLUXDB_SUPPORT        0               // Disable InfluxDB support by default (4.38Kb)
 #endif
 
 #define INFLUXDB_ENABLED        0               // InfluxDB disabled by default


### PR DESCRIPTION
5d10a6ff5562dfaa7c69a51bb566b4239ff1e6e6 disabled InfluxDB support by default, but did not adjust the comment on the same line.

Not sure if this is accurate, but it does not match the other settings in:
- 0 disabled
- 1 enabled

Cheers.