### PR TITLE
WebUI url parsing

### DIFF
--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -4,7 +4,8 @@ var maxNetworks;
 var maxSchedules;
 var messages = [];
 var free_size = 0;
-var webhost;
+
+var urls = {};
 
 var numChanged = 0;
 var numReboot = 0;
@@ -322,7 +323,7 @@ function doUpgrade() {
         $.ajax({
 
             // Your server script to process the upload
-            url: webhost + "upgrade",
+            url: urls.upgrade.href,
             type: "POST",
 
             // Form data
@@ -466,7 +467,7 @@ function doUpdate() {
 }
 
 function doBackup() {
-    document.getElementById("downloader").src = webhost + "config";
+    document.getElementById("downloader").src = urls.config.href;
     return false;
 }
 
@@ -1291,22 +1292,22 @@ function hasChanged() {
 // Init & connect
 // -----------------------------------------------------------------------------
 
-function connect(host) {
+function initUrls(root) {
 
-    if (typeof host === "undefined") {
-        host = window.location.href.replace("#", "");
-    } else {
-        if (host.indexOf("http") !== 0) {
-            host = "http://" + host + "/";
-        }
-    }
-    if (host.indexOf("http") !== 0) { return; }
+    var paths = ["ws", "upgrade", "config"];
 
-    webhost = host;
-    var wshost = host.replace("http", "ws") + "ws";
+    urls["root"] = root;
+    paths.forEach(function(path) {
+        urls[path] = new URL(path, root);
+    });
 
+    urls.ws.protocol = "ws";
+}
+
+function connectToURL(url) {
+    initUrls(url);
     if (websock) { websock.close(); }
-    websock = new WebSocket(wshost);
+    websock = new WebSocket(urls.ws.href);
     websock.onmessage = function(evt) {
         var data = getJson(evt.data.replace(/\n/g, "\\n").replace(/\r/g, "\\r").replace(/\t/g, "\\t"));
         if (data) {
@@ -1314,6 +1315,20 @@ function connect(host) {
         }
     };
 }
+
+function connect(host) {
+
+    if (!host.startsWith("http:") && !host.startsWith("https:")) {
+        host = "http://" + host;
+    }
+
+    connectToURL(new URL(host));
+}
+
+function connectToCurrentURL() {
+    connectToURL(new URL(window.location));
+}
+
 
 $(function() {
 
@@ -1360,6 +1375,6 @@ $(function() {
 
     // don't autoconnect when opening from filesystem
     if (window.location.protocol === "file:") { return; }
-    connect();
+    connectToCurrentURL();
 
 });

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -1358,6 +1358,8 @@ $(function() {
     $(document).on("change", "input", hasChanged);
     $(document).on("change", "select", hasChanged);
 
+    // don't autoconnect when opening from filesystem
+    if (window.location.protocol === "file:") { return; }
     connect();
 
 });

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -66,7 +66,7 @@
 
         <div id="layout" class="webmode">
 
-            <a href="#menu" id="menuLink" class="menu-link">
+            <a id="menuLink" class="menu-link">
                 <span></span>
             </a>
 


### PR DESCRIPTION
Before looking into separate urls for menu I wanted to fix this interaction with menu button on mobile.
- Remove `#menu` from menu button href
Going to web page on mobile and pressing menu button once locks url with `#menu`
Refreshing without pressing any menu item or just pressing menu again breaks `connect()` - websocket tries to open `ws://<ip>/menuws`
- Using URL API to get `/config`, `/ws` and `/upgrade` urls
Just to be safe
`new URL()` already skips hash from inherited root and is easier to read than string manipulation.