### PR TITLE
Handle switch toggle events;

### DIFF
--- a/code/espurna/button.ino
+++ b/code/espurna/button.ino
@@ -86,7 +86,7 @@ uint8_t mapEvent(uint8_t event, uint8_t count, uint16_t length) {
         }
         if (count == 2 ) {
             DEBUG_MSG_P(PSTR("[BUTTON] : DBLCLICK"));
-            return BUTTON_MODE_NONE;
+            return BUTTON_EVENT_DBLCLICK;
         }
         DEBUG_MSG_P(PSTR("[BUTTON] : CLICK"));
         return BUTTON_EVENT_CLICK;

--- a/code/espurna/button.ino
+++ b/code/espurna/button.ino
@@ -75,14 +75,39 @@ unsigned long buttonStore(unsigned long pressed, unsigned long click, unsigned l
 
 uint8_t mapEvent(uint8_t event, uint8_t count, uint16_t length) {
     if (event == EVENT_PRESSED) return BUTTON_EVENT_PRESSED;
-    if (event == EVENT_CHANGED) return BUTTON_EVENT_CLICK;
+    if (event == EVENT_CHANGED) {
+        if (count > BUTTON_LNGLNGCLICK_CNT ) {
+            DEBUG_MSG_P(PSTR("[BUTTON] : LNGLNGCLICK"));
+            return BUTTON_EVENT_LNGLNGCLICK;
+        }
+        if (count > BUTTON_LNGCLICK_CNT ) {
+            DEBUG_MSG_P(PSTR("[BUTTON] : LNGCLICK"));
+            return BUTTON_EVENT_LNGCLICK;
+        }
+        if (count == 2 ) {
+            DEBUG_MSG_P(PSTR("[BUTTON] : DBLCLICK"));
+            return BUTTON_MODE_NONE;
+        }
+        DEBUG_MSG_P(PSTR("[BUTTON] : CLICK"));
+        return BUTTON_EVENT_CLICK;
+    }
     if (event == EVENT_RELEASED) {
         if (count == 1) {
-            if (length > BUTTON_LNGLNGCLICK_DELAY) return BUTTON_EVENT_LNGLNGCLICK;
-            if (length > BUTTON_LNGCLICK_DELAY) return BUTTON_EVENT_LNGCLICK;
+            if (length > BUTTON_LNGLNGCLICK_DELAY) {
+                DEBUG_MSG_P(PSTR("[BUTTON] : LNGLNGCLICK"));
+                return BUTTON_EVENT_LNGLNGCLICK;
+            }
+            if (length > BUTTON_LNGCLICK_DELAY) {
+                DEBUG_MSG_P(PSTR("[BUTTON] : LNGCLICK"));
+                return BUTTON_EVENT_LNGCLICK;
+            }
+            DEBUG_MSG_P(PSTR("[BUTTON] : CLICK"));
             return BUTTON_EVENT_CLICK;
         }
-        if (count == 2) return BUTTON_EVENT_DBLCLICK;
+        if (count == 2) {
+            DEBUG_MSG_P(PSTR("[BUTTON] : DBLCLICK"));
+            return BUTTON_EVENT_DBLCLICK;
+        }
     }
 }
 

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -244,6 +244,14 @@ PROGMEM const char* const custom_reset_string[] = {
 #define BUTTON_LNGLNGCLICK_DELAY    10000       // Time in ms holding the button down to get a long-long click
 #endif
 
+#ifndef BUTTON_LNGCLICK_CNT
+#define BUTTON_LNGCLICK_CNT         5          // Number of switch toggles (within BUTTON_DBLCLICK_DELAY timeframe) to get a long click event for switch type
+#endif
+
+#ifndef BUTTON_LNGLNGCLICK_CNT
+#define BUTTON_LNGLNGCLICK_CNT      10         // Number of switch toggles (within BUTTON_DBLCLICK_DELAY timeframe) to get a long-long click event for switch type
+#endif
+
 #define BUTTON_EVENT_NONE           0
 #define BUTTON_EVENT_PRESSED        1
 #define BUTTON_EVENT_RELEASED       2

--- a/code/lib/DebounceEvent/DebounceEvent.cpp
+++ b/code/lib/DebounceEvent/DebounceEvent.cpp
@@ -1,0 +1,124 @@
+/*
+
+  Debounce buttons and trigger events
+  Copyright (C) 2015-2017 by Xose Pérez <xose dot perez at gmail dot com>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include <Arduino.h>
+#include "DebounceEvent.h"
+
+DebounceEvent::DebounceEvent(uint8_t pin, TDebounceEventCallback callback, uint8_t mode, unsigned long delay, unsigned long repeat) {
+    _callback = callback;
+    _init(pin, mode, delay, repeat);
+}
+
+DebounceEvent::DebounceEvent(uint8_t pin, uint8_t mode, unsigned long delay, unsigned long repeat) {
+    _init(pin, mode, delay, repeat);
+}
+
+
+void DebounceEvent::_init(uint8_t pin, uint8_t mode, unsigned long delay, unsigned long repeat) {
+
+    // store configuration
+    _pin = pin;
+    _mode = mode & 0x01;
+    _status = _defaultStatus = (mode & BUTTON_DEFAULT_HIGH) > 0;
+    _delay = delay;
+    _repeat = repeat;
+
+    // set up button
+    if (_pin == 16) {
+        if (_defaultStatus) {
+            pinMode(_pin, INPUT);
+        } else {
+            pinMode(_pin, INPUT_PULLDOWN_16);
+        }
+    } else {
+        if ((mode & BUTTON_SET_PULLUP) > 0) {
+            pinMode(_pin, INPUT_PULLUP);
+        } else {
+            pinMode(_pin, INPUT);
+        }
+    }
+
+}
+
+unsigned char DebounceEvent::loop() {
+
+    unsigned char event = EVENT_NONE;
+
+    if (digitalRead(_pin) != _status) {
+
+        // Debounce
+        unsigned long start = millis();
+        while (millis() - start < _delay) delay(1);
+
+        if (digitalRead(_pin) != _status) {
+
+            _status = !_status;
+
+            if (_mode == BUTTON_SWITCH) {
+                _event_start = millis();
+                if (_reset_count) {
+                    _event_count = 1;
+                    _reset_count = false;
+                } else {
+                    ++_event_count;
+                }
+                _ready = true;
+            } else {
+
+                // released
+                if (_status == _defaultStatus) {
+
+                    _event_length = millis() - _event_start;
+                    _ready = true;
+
+                // pressed
+                } else {
+
+                    event = EVENT_PRESSED;
+                    _event_start = millis();
+                    _event_length = 0;
+                    if (_reset_count) {
+                        _event_count = 1;
+                        _reset_count = false;
+                    } else {
+                        ++_event_count;
+                    }
+                    _ready = false;
+
+                }
+
+            }
+
+        }
+    }
+
+    if (_ready && (millis() - _event_start > _repeat)) {
+        _ready = false;
+        _reset_count = true;
+        event = (_mode == BUTTON_SWITCH) ? EVENT_CHANGED : EVENT_RELEASED ;
+    }
+
+    if (event != EVENT_NONE) {
+        if (_callback) _callback(_pin, event, _event_count, _event_length);
+    }
+
+    return event;
+
+}

--- a/code/lib/DebounceEvent/DebounceEvent.cpp
+++ b/code/lib/DebounceEvent/DebounceEvent.cpp
@@ -39,6 +39,7 @@ void DebounceEvent::_init(uint8_t pin, uint8_t mode, unsigned long delay, unsign
     _status = _defaultStatus = (mode & BUTTON_DEFAULT_HIGH) > 0;
     _delay = delay;
     _repeat = repeat;
+    _event_start = 0;
 
     // set up button
     if (_pin == 16) {
@@ -83,7 +84,7 @@ unsigned char DebounceEvent::loop() {
             } else {
 
                 // released
-                if (_status == _defaultStatus) {
+                if (_status == (bool)_defaultStatus) {
 
                     _event_length = millis() - _event_start;
                     _ready = true;

--- a/code/lib/DebounceEvent/DebounceEvent.h
+++ b/code/lib/DebounceEvent/DebounceEvent.h
@@ -1,0 +1,70 @@
+/*
+
+  Debounce buttons and trigger events
+  Copyright (C) 2015-2017 by Xose PÃ©rez <xose dot perez at gmail dot com>
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#ifndef _DEBOUNCE_EVENT_h
+#define _DEBOUNCE_EVENT_h
+
+#include <functional>
+
+#define BUTTON_PUSHBUTTON       0
+#define BUTTON_SWITCH           1
+#define BUTTON_DEFAULT_HIGH     2
+#define BUTTON_SET_PULLUP       4
+
+#define DEBOUNCE_DELAY          50
+#define REPEAT_DELAY            500
+#define EVENT_NONE              0
+#define EVENT_CHANGED           1
+#define EVENT_PRESSED           2
+#define EVENT_RELEASED          3
+
+class DebounceEvent {
+
+    public:
+
+        typedef std::function<void(uint8_t pin, uint8_t event, uint8_t count, uint16_t length)> TDebounceEventCallback;
+
+        DebounceEvent(uint8_t pin, TDebounceEventCallback callback, uint8_t mode = BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH, unsigned long delay = DEBOUNCE_DELAY, unsigned long repeat = REPEAT_DELAY);
+        DebounceEvent(uint8_t pin, uint8_t mode = BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH, unsigned long delay = DEBOUNCE_DELAY, unsigned long repeat = REPEAT_DELAY);
+        unsigned char loop();
+        bool pressed() { return (_status != _defaultStatus); }
+        unsigned long getEventLength() { return _event_length; }
+        unsigned long getEventCount() { return _event_count; }
+
+    private:
+
+        uint8_t _pin;
+        uint8_t _mode;
+        bool _status;
+        bool _ready = false;
+        bool _reset_count = true;
+        unsigned long _event_start;
+        unsigned long _event_length;
+        unsigned char _event_count = 0;
+        uint8_t _defaultStatus;
+        unsigned long _delay;
+        unsigned long _repeat;
+        TDebounceEventCallback _callback = NULL;
+
+        void _init(uint8_t pin, uint8_t mode, unsigned long delay, unsigned long repeat);
+
+};
+
+#endif

--- a/code/lib/DebounceEvent/DebounceEvent.h
+++ b/code/lib/DebounceEvent/DebounceEvent.h
@@ -61,6 +61,7 @@ class DebounceEvent {
         uint8_t _defaultStatus;
         unsigned long _delay;
         unsigned long _repeat;
+        unsigned long _event_start;
         TDebounceEventCallback _callback = NULL;
 
         void _init(uint8_t pin, uint8_t mode, unsigned long delay, unsigned long repeat);

--- a/code/lib/DebounceEvent/DebounceEvent.h
+++ b/code/lib/DebounceEvent/DebounceEvent.h
@@ -61,7 +61,6 @@ class DebounceEvent {
         uint8_t _defaultStatus;
         unsigned long _delay;
         unsigned long _repeat;
-        unsigned long _event_start;
         TDebounceEventCallback _callback = NULL;
 
         void _init(uint8_t pin, uint8_t mode, unsigned long delay, unsigned long repeat);


### PR DESCRIPTION
The main goal is to allow defining reset events also for toggle type buttons.

Allow to add events for Switch button, by defining number of switch toggles in time frame (based on the same doubleclick delay definition).
This change depends on "DebounceEvent" small code change (file added here)...
The result is getting same button events:
CLICK
DBLCLICK
LNGCLICK
LNGLNGCLICK

also for toggle type switches

two parameters added
BUTTON_LNGCLICK_CNT
BUTTON_LNGLNGCLICK_CNT

to allow defining how many toggles will trigger the events.


 
