### PR TITLE
Disable CSE7766 by default

### DIFF
--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -243,7 +243,7 @@
 //------------------------------------------------------------------------------
 
 #ifndef CSE7766_SUPPORT
-#define CSE7766_SUPPORT                 1
+#define CSE7766_SUPPORT                 0
 #endif
 
 #ifndef CSE7766_PIN


### PR DESCRIPTION
CSE7766 was left probably by mistake enabled by default. This caused garbage in the serial while monitoring.