### PR TITLE
Always set white inputValue to 0

### DIFF
--- a/code/espurna/light.ino
+++ b/code/espurna/light.ino
@@ -99,6 +99,7 @@ void _generateBrightness() {
             _light_channel[i].value = _light_channel[i].inputValue - white;
         }
         _light_channel[3].value = white;
+        _light_channel[3].inputValue = 0;
 
         max_out = std::max(std::max(_light_channel[0].value, _light_channel[1].value), std::max(_light_channel[2].value, _light_channel[3].value));
         if (max_out > 0) {


### PR DESCRIPTION
I've noticed the inputValue can get out-of-sync if the user switch between `_light_use_white` true and false. The out-of-sync value would be saved on reboot and is therefor also persistent. And MQTT light would always send wrong data for this channel.