### PR TITLE
build process should exit with non 0 value on failure.

### DIFF
--- a/code/build.sh
+++ b/code/build.sh
@@ -64,7 +64,7 @@ echo "Building firmware images..."
 mkdir -p ../firmware/espurna-$version
 for environment in $environments; do
     echo "* espurna-$version-$environment.bin"
-    platformio run --silent --environment $environment || break
+    platformio run --silent --environment $environment || exit 1
     mv .pioenvs/$environment/firmware.bin ../firmware/espurna-$version/espurna-$version-$environment.bin
 done
 echo "--------------------------------------------------------------"


### PR DESCRIPTION
Fix build script to exit with non 0 on failure. 
This should give us more accurate travis builds. 