### PR TITLE
espurna plugins hooks

### DIFF
--- a/code/espurna/espurna.ino
+++ b/code/espurna/espurna.ino
@@ -24,6 +24,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 std::vector<void (*)()> _loop_callbacks;
 
+#if USE_EXTRA
+std::vector<void (*)()> _hooks_callbacks;
+std::vector<std::string> _hooks_names;
+#endif
 // -----------------------------------------------------------------------------
 // REGISTER
 // -----------------------------------------------------------------------------
@@ -32,6 +36,18 @@ void espurnaRegisterLoop(void (*callback)()) {
     _loop_callbacks.push_back(callback);
 }
 
+#if USE_EXTRA
+void espurnaRegisterHook(void (*callback)(), std::string _hookName) {
+    _hooks_callbacks.push_back(callback);
+    _hooks_names.push_back(_hookName);
+}
+void espurnaDoHook(std::string _hookName) {
+  // Call registered hook callbacks
+  for (unsigned char i = 0; i < _hooks_names.size(); i++) {
+      if (_hooks_names[i] == _hookName) (_hooks_callbacks[i])();
+  }
+}
+#endif
 // -----------------------------------------------------------------------------
 // BOOTING
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
A very basic to support plugin 3rd party code integration (https://github.com/xoseperez/espurna/wiki/3rd-Party-Plugins), including hooks.

usage:
For every core hook (reasonable ask), just add 
```
#if USE_EXTRA
espurnaDoHook(hookName);
#endif
``` 
(with any hook name.)

3rd party plugin code only needs to register to any hook by 
```
espurnaRegisterHook(_pluginCallbackFunction, _hookName);
```

The plugin template and hook system will allow to divert some none core enhancement requests to plugins, and just give easy support by adding hook calls.
plugin developers can add hook call until core supports the hooks they need, (very small diversion from core code).  
