### PR TITLE
Sonoff RF Bridge better RC coverage bypassing EFN8B1 microcontroller's signal processing

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -622,10 +622,12 @@
     #define LED1_PIN_INVERSE    1
 
     // RFB-Direct
-    #define RFB_DIRECT
+    #ifdef RFB_DIRECT
+    #undef DEVICE
+    #define DEVICE              "SONOFF_RFBRIDGE_DIRECT"
     #define RFB_RX_PIN 4
     #define RFB_TX_PIN 5
-
+    #endif
 
 #elif defined(ITEAD_SONOFF_B1)
 

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -608,7 +608,9 @@
     #endif
 
     // Remove UART noise on serial line
+    #ifndef RFB_DIRECT
     #define TERMINAL_SUPPORT        0
+    #endif
     #define DEBUG_SERIAL_SUPPORT    0
 
     // Buttons
@@ -618,6 +620,12 @@
     // LEDs
     #define LED1_PIN            13
     #define LED1_PIN_INVERSE    1
+
+    // RFB-Direct
+    #define RFB_DIRECT
+    #define RFB_RX_PIN 4
+    #define RFB_TX_PIN 5
+
 
 #elif defined(ITEAD_SONOFF_B1)
 

--- a/code/espurna/rfbridge.ino
+++ b/code/espurna/rfbridge.ino
@@ -127,6 +127,7 @@ void _rfbAck() {
 
 void _rfbLearn() {
     #ifdef RFB_DIRECT
+        DEBUG_MSG_P(PSTR("[RFBRIDGE] Entering LEARN mode\n"));
         _learning = true;
     #else
         DEBUG_MSG_P(PSTR("[RFBRIDGE] Sending LEARN\n"));
@@ -344,15 +345,6 @@ void _rfbReceive() {
                 _rfbDecode();
                 _learning = false;
             }
-        }
-
-        String dump = getSetting("rfb-dump");
-        if (dump.length()) {
-            setSetting("rfb-dump", "");
-            DEBUG_MSG_P(PSTR("[RFBRIDGE] dump rfb:"));
-            for(int j = 0; j < RCSWITCH_MAX_CHANGES; ++j)
-                DEBUG_MSG_P(PSTR(" %d"), RCSwitch::timings[j]);
-            DEBUG_MSG_P(PSTR("\n"));
         }
 
         if (_rfModem->available()) {

--- a/code/espurna/rfbridge.ino
+++ b/code/espurna/rfbridge.ino
@@ -11,6 +11,10 @@ Copyright (C) 2017-2018 by Xose Pérez <xose dot perez at gmail dot com>
 #include <queue>
 #include <Ticker.h>
 
+#ifdef RFB_DIRECT
+#include <RCSwitch.h>
+#endif
+
 // -----------------------------------------------------------------------------
 // DEFINITIONS
 // -----------------------------------------------------------------------------
@@ -50,6 +54,11 @@ typedef struct {
 static std::queue<rfb_message_t> _rfb_message_queue;
 Ticker _rfb_ticker;
 bool _rfb_ticker_active = false;
+
+#ifdef RFB_DIRECT
+RCSwitch * _rfModem;
+bool _learning = false;
+#endif
 
 // -----------------------------------------------------------------------------
 // PRIVATES
@@ -105,6 +114,7 @@ void _rfbWebSocketOnAction(uint32_t client_id, const char * action, JsonObject& 
 }
 
 void _rfbAck() {
+    #ifndef RFB_DIRECT
     DEBUG_MSG_P(PSTR("[RFBRIDGE] Sending ACK\n"));
     Serial.println();
     Serial.write(RF_CODE_START);
@@ -112,17 +122,21 @@ void _rfbAck() {
     Serial.write(RF_CODE_STOP);
     Serial.flush();
     Serial.println();
+    #endif
 }
 
 void _rfbLearn() {
-
-    DEBUG_MSG_P(PSTR("[RFBRIDGE] Sending LEARN\n"));
-    Serial.println();
-    Serial.write(RF_CODE_START);
-    Serial.write(RF_CODE_LEARN);
-    Serial.write(RF_CODE_STOP);
-    Serial.flush();
-    Serial.println();
+    #ifdef RFB_DIRECT
+        _learning = true;
+    #else
+        DEBUG_MSG_P(PSTR("[RFBRIDGE] Sending LEARN\n"));
+        Serial.println();
+        Serial.write(RF_CODE_START);
+        Serial.write(RF_CODE_LEARN);
+        Serial.write(RF_CODE_STOP);
+        Serial.flush();
+        Serial.println();
+    #endif
 
     #if WEB_SUPPORT
         char buffer[100];
@@ -139,13 +153,25 @@ void _rfbSendRaw(const byte *message, const unsigned char n = RF_MESSAGE_SIZE) {
 }
 
 void _rfbSend(byte * message) {
-    Serial.println();
-    Serial.write(RF_CODE_START);
-    Serial.write(RF_CODE_RFOUT);
-    _rfbSendRaw(message);
-    Serial.write(RF_CODE_STOP);
-    Serial.flush();
-    Serial.println();
+    #ifdef RFB_DIRECT
+        unsigned int protocol = message[1];
+        unsigned int bitlength = message[4];
+        unsigned long rf_code =
+            (message[5] << 24) |
+            (message[6] << 16) |
+            (message[7] <<  8) |
+            (message[8] <<  0) ;
+        _rfModem->setProtocol(protocol);
+        _rfModem->send(rf_code, bitlength);
+    #else
+        Serial.println();
+        Serial.write(RF_CODE_START);
+        Serial.write(RF_CODE_RFOUT);
+        _rfbSendRaw(message);
+        Serial.write(RF_CODE_STOP);
+        Serial.flush();
+        Serial.println();
+    #endif
 }
 
 void _rfbSend() {
@@ -301,33 +327,83 @@ void _rfbDecode() {
 }
 
 void _rfbReceive() {
-
-    static bool receiving = false;
-
-    while (Serial.available()) {
-
-        yield();
-        byte c = Serial.read();
-        //DEBUG_MSG_P(PSTR("[RFBRIDGE] Received 0x%02X\n"), c);
-
-        if (receiving) {
-            if (c == RF_CODE_STOP && (_uartpos == 1 || _uartpos == RF_MESSAGE_SIZE + 1)) {
-                _rfbDecode();
-                receiving = false;
-            } else if (_uartpos <= RF_MESSAGE_SIZE) {
-                _uartbuf[_uartpos++] = c;
-            } else {
-                // wrong message, should have received a RF_CODE_STOP
-                receiving = false;
+    #ifdef RFB_DIRECT
+        static long learn_start = 0;
+        if (!_learning && learn_start) {
+            learn_start = 0;
+        }
+        if (_learning) {
+            if (!learn_start) {
+                DEBUG_MSG_P(PSTR("[RFBRIDGE] arming learn timeout\n"));
+                learn_start = millis();
             }
-        } else if (c == RF_CODE_START) {
-            _uartpos = 0;
-            receiving = true;
+            if (learn_start > 0 && millis() - learn_start > RF_LEARN_TIMEOUT) {
+                DEBUG_MSG_P(PSTR("[RFBRIDGE] learn timeout triggered\n"));
+                memset(_uartbuf, 0, sizeof(_uartbuf));
+                _uartbuf[0] = RF_CODE_LEARN_KO;
+                _rfbDecode();
+                _learning = false;
+            }
         }
 
-    }
+        String dump = getSetting("rfb-dump");
+        if (dump.length()) {
+            setSetting("rfb-dump", "");
+            DEBUG_MSG_P(PSTR("[RFBRIDGE] dump rfb:"));
+            for(int j = 0; j < RCSWITCH_MAX_CHANGES; ++j)
+                DEBUG_MSG_P(PSTR(" %d"), RCSwitch::timings[j]);
+            DEBUG_MSG_P(PSTR("\n"));
+        }
 
+        if (_rfModem->available()) {
+            static unsigned long last = 0;
+            if (millis() - last > RF_DEBOUNCE) {
+                last = millis();
+                unsigned long rf_code = _rfModem->getReceivedValue();
+                if ( rf_code > 0) {
+                    DEBUG_MSG_P(PSTR("[RFBRIDGE] Received code: %08X\n"), rf_code);
+                    memset(_uartbuf, 0, sizeof(_uartbuf));
+                    unsigned char *msgbuf = _uartbuf + 1;
+                    _uartbuf[0] = _learning ? RF_CODE_LEARN_OK: RF_CODE_RFIN;
+                    msgbuf[0] = 0xC0;                   
+                    msgbuf[1] = _rfModem->getReceivedProtocol();
+                    msgbuf[4] = _rfModem->getReceivedBitlength();
+                    msgbuf[5] = rf_code >> 24;
+                    msgbuf[6] = rf_code >> 16;
+                    msgbuf[7] = rf_code >>  8;
+                    msgbuf[8] = rf_code >>  0;
+                    _rfbDecode();
+                    _learning = false;
+                }
+            }
+            _rfModem->resetAvailable();
+        }
+    #else
+        static bool receiving = false;
 
+        while (Serial.available()) {
+
+            yield();
+            byte c = Serial.read();
+            //DEBUG_MSG_P(PSTR("[RFBRIDGE] Received 0x%02X\n"), c);
+
+            if (receiving) {
+                if (c == RF_CODE_STOP && (_uartpos == 1 || _uartpos == RF_MESSAGE_SIZE + 1)) {
+                    _rfbDecode();
+                    receiving = false;
+                } else if (_uartpos <= RF_MESSAGE_SIZE) {
+                    _uartbuf[_uartpos++] = c;
+                } else {
+                    // wrong message, should have received a RF_CODE_STOP
+                    receiving = false;
+                }
+            } else if (c == RF_CODE_START) {
+                _uartpos = 0;
+                receiving = true;
+            }
+
+        }
+    #endif
 }
 
 bool _rfbCompare(const char * code1, const char * code2) {
@@ -520,6 +596,14 @@ void rfbSetup() {
     #if WEB_SUPPORT
         wsOnSendRegister(_rfbWebSocketOnSend);
         wsOnActionRegister(_rfbWebSocketOnAction);
+    #endif
+
+    #ifdef RFB_DIRECT
+        _rfModem = new RCSwitch();
+        _rfModem->enableReceive(RFB_RX_PIN);
+        _rfModem->enableTransmit(RFB_TX_PIN);
+        DEBUG_MSG_P(PSTR("[RFBRIDGE] RF receiver on GPIO %u\n"), RFB_RX_PIN);
+        DEBUG_MSG_P(PSTR("[RFBRIDGE] RF transmitter on GPIO %u\n"), RFB_TX_PIN);
     #endif
 
     // Register oop

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -608,6 +608,31 @@ upload_flags = --auth=fibonacci --port 8266
 monitor_baud = 19200
 extra_scripts = ${common.extra_scripts}
 
+[env:itead-sonoff-rfbridge-direct]
+platform = ${common.platform}
+framework = arduino
+board = esp01_1m
+board_flash_mode = dout
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m} -DITEAD_SONOFF_RFBRIDGE -DRFB_DIRECT
+monitor_baud = 19200
+extra_scripts = ${common.extra_scripts}
+
+[env:itead-sonoff-rfbridge-direct-ota]
+platform = ${common.platform}
+framework = arduino
+board = esp01_1m
+board_flash_mode = dout
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m} -DITEAD_SONOFF_RFBRIDGE -DRFB_DIRECT
+upload_speed = 115200
+upload_port = "192.168.4.1"
+upload_flags = --auth=fibonacci --port 8266
+monitor_baud = 19200
+extra_scripts = ${common.extra_scripts}
+
 # ------------------------------------------------------------------------------
 
 [env:itead-slampher]


### PR DESCRIPTION
Hi Xose, I have found a way to make the Sonoff RF Bridge usable with a broader range of remote controllers. You can find here https://github.com/wildwiz/espurna/wiki/Hardware-Itead-Sonoff-RF-Bridge-Hack the details of the hardware modification.

The patch to espurna is activated by defining the macro RFB_DIRECT
The code is happily running on my modified sonoff for some time already.

I am not well sure about where the changes on the header files should go.
Any comment is welcome.