### PR TITLE
Reworked git pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ ESPurna ("spark" in Catalan) is a custom firmware for ESP8285/ESP8266 based smar
 It uses the Arduino Core for ESP8266 framework and a number of 3rd party libraries.
 
 [![version](https://img.shields.io/badge/version-1.12.6a-brightgreen.svg)](CHANGELOG.md)
-![branch](https://img.shields.io/badge/branch-dev-orange.svg)
+[![branch](https://img.shields.io/badge/branch-dev-orange.svg)](https://github.com/xoseperez/espurna/tree/dev/)
 [![travis](https://travis-ci.org/xoseperez/espurna.svg?branch=dev)](https://travis-ci.org/xoseperez/espurna)
 [![codacy](https://img.shields.io/codacy/grade/c9496e25cf07434cba786b462cb15f49/dev.svg)](https://www.codacy.com/app/xoseperez/espurna/dashboard)
 [![license](https://img.shields.io/github/license/xoseperez/espurna.svg)](LICENSE)

--- a/pre-commit
+++ b/pre-commit
@@ -80,17 +80,15 @@ def espurna_get_version(base, version_h="code/espurna/config/version.h"):
 
     return version
 
-
-SHIELD_TRAVIS = "[![travis](https://travis-ci.org/{USER}/{REPO}.svg?branch={BRANCH})]" \
-    "(https://travis-ci.org/{USER}/{REPO})"
-
-SHIELD_VERSION = "[![version](https://img.shields.io/badge/version-{VERSION}-brightgreen.svg)](CHANGELOG.md)"
-
-SHIELD_BRANCH = "[![branch](https://img.shields.io/badge/branch-{BRANCH}-orange.svg)]" \
-    "(https://github.org/{USER}/{REPO}/tree/{BRANCH}/)"
-
-SHIELD_CODACY = "[![codacy](https://img.shields.io/codacy/grade/c9496e25cf07434cba786b462cb15f49/{BRANCH}.svg)]" \
-    "(https://www.codacy.com/app/{USER}/{REPO}/dashboard)"
+TEMPLATES = {
+    "![travis]": "[![travis](https://travis-ci.org/{USER}/{REPO}.svg?branch={BRANCH})]" \
+        "(https://travis-ci.org/{USER}/{REPO})\n",
+    "![version]": "[![version](https://img.shields.io/badge/version-{VERSION}-brightgreen.svg)](CHANGELOG.md)\n",
+    "![branch]": "[![branch](https://img.shields.io/badge/branch-{BRANCH}-orange.svg)]" \
+        "(https://github.org/{USER}/{REPO}/tree/{BRANCH}/)\n",
+    "![codacy]": "[![codacy](https://img.shields.io/codacy/grade/c9496e25cf07434cba786b462cb15f49/{BRANCH}.svg)]" \
+        "(https://www.codacy.com/app/{USER}/{REPO}/dashboard)\n"
+}
 
 README = "README.md"
 
@@ -99,31 +97,28 @@ if __name__ == "__main__":
     base = os.getcwd()
 
     user, repo = git_parse_remote()
-    template = {
+    fmt = {
         "USER": user,
         "REPO": repo,
         "BRANCH": git_branch(),
         "VERSION": espurna_get_version(base)
     }
+    templates = [
+        (k, tmpl.format(**fmt))
+        for k, tmpl in TEMPLATES.items()
+    ]
 
-    shield_travis = SHIELD_TRAVIS.format(**template)
-    shield_version = SHIELD_VERSION.format(**template)
-    shield_branch = SHIELD_BRANCH.format(**template)
-    shield_codacy = SHIELD_CODACY.format(**template)
+    def fmt_line(line):
+        for match, tmpl in templates:
+            if match in line:
+                return tmpl
+
+        return line
 
     path = os.path.join(base, README)
 
     with FileInput(path, inplace=True) as readme:
         for line in readme:
-            if "![travis]" in line:
-                print(shield_travis)
-            elif "![version]" in line:
-                print(shield_version)
-            elif "![branch]" in line:
-                print(shield_branch)
-            elif "![codacy]" in line:
-                print(shield_codacy)
-            else:
-                print(line, end="")
+            print(fmt_line(line), end='')
 
-    sys.exit(call(["git", "add", README], cwd=base))
+    sys.exit(call(["git", "add", README]))

--- a/pre-commit
+++ b/pre-commit
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 """
 
 Referencing current branch in github README.md [1]

--- a/pre-commit
+++ b/pre-commit
@@ -41,7 +41,10 @@ version = "[![version](https://img.shields.io/badge/version-{VERSION}-brightgree
     VERSION = VERSION
 )
 
-branch = "![branch](https://img.shields.io/badge/branch-{BRANCH}-orange.svg)\n".format(
+branch = "[![branch](https://img.shields.io/badge/branch-{BRANCH}-orange.svg)] "
+    "(https://github.com/{USER}/{REPO}/tree/{BRANCH}/)\n".format(
+    USER = USER,
+    REPO = REPO,
     BRANCH = BRANCH
 )
 

--- a/pre-commit
+++ b/pre-commit
@@ -13,68 +13,117 @@ Travis badge with the current branch. Based on [4].
 Copy this file to .git/hooks/
 
 """
+from __future__ import print_function
 
 import os
 import sys
 import re
-import subprocess
 
-BASE = os.path.dirname(os.path.realpath(__file__)) + "/../../"
-README = BASE + "README.md"
-remote = subprocess.check_output(["git", "remote", "-v"]).strip().split('\n')[0]
-parts = re.split('[/\.: ]', remote)
-REPO = parts[ len(parts) - 3]
-USER = parts[ len(parts) - 4]
-BRANCH = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"]).strip()
+from subprocess import call, check_output
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
-def getVersion():
-    file_name = BASE + "code/espurna/config/version.h"
-    lines = open(file_name).readlines()
-    for line in lines:
-        if "APP_VERSION" in line:
-            parts = line.split('"')
-            return parts[1]
-    return "unknown"
-VERSION = getVersion()
+from fileinput import FileInput
+# https://github.com/python/cpython/commit/6cb7b659#diff-78790b53ff259619377058acd4f74672
+if sys.version_info[0] < 3:
+    class FileInputCtx(FileInput):
+        def __enter__(self):
+            return self
 
-version = "[![version](https://img.shields.io/badge/version-{VERSION}-brightgreen.svg)](CHANGELOG.md)\n".format(
-    VERSION = VERSION
-)
+        def __exit__(self, type, value, traceback):
+            self.close()
 
-branch = "[![branch](https://img.shields.io/badge/branch-{BRANCH}-orange.svg)] "
-    "(https://github.com/{USER}/{REPO}/tree/{BRANCH}/)\n".format(
-    USER = USER,
-    REPO = REPO,
-    BRANCH = BRANCH
-)
+    FileInput = FileInputCtx
 
-travis = "[![travis](https://travis-ci.org/{USER}/{REPO}.svg?branch={BRANCH})]" \
-    "(https://travis-ci.org/{USER}/{REPO})\n".format(
-    USER = USER,
-    REPO = REPO,
-    BRANCH = BRANCH
-)
 
-codacy = "[![codacy](https://img.shields.io/codacy/grade/{HASH}/{BRANCH}.svg)]" \
-    "(https://www.codacy.com/app/{USER}/{REPO}/dashboard)\n".format(
-    HASH = "c9496e25cf07434cba786b462cb15f49",
-    USER = USER,
-    REPO = REPO,
-    BRANCH = BRANCH
-)
+def run(cmd, cwd=None):
+    out = check_output(cmd, cwd=cwd)
+    out = out.decode("latin1").strip()
 
-lines = open(README).readlines()
-with open(README, "w") as fh:
-    for line in lines:
-        if "![travis]" in line:
-            fh.write(travis)
-        elif "![version]" in line:
-            fh.write(version)
-        elif "![branch]" in line:
-            fh.write(branch)
-        elif "![codacy]" in line:
-            fh.write(codacy)
-        else:
-            fh.write(line)
+    return out
 
-subprocess.check_output(["git", "add", README ])
+
+def parse_h_string(define, r_quotes=re.compile("\"(.*)\"")):
+    string = r_quotes.search(define).group(1)
+    return string
+
+
+def git_parse_remote(cwd=None, remote="origin"):
+    remote_url = run([
+        "git", "config", "--local",
+        "--get", "remote.{}.url".format(remote)], cwd)
+
+    if remote_url.startswith("git"):
+        _, _, repo = remote_url.partition(":")
+        path = repo.replace(".git", "")
+    elif remote_url.startswith("https"):
+        parsed = urlparse(remote_url)
+        path = parsed.path[1:]
+    return path.split("/")
+
+
+def git_branch(cwd=None):
+    return run(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd)
+
+
+def espurna_get_version(base, version_h="code/espurna/config/version.h"):
+    version = "unknown"
+
+    path = os.path.join(base, version_h)
+    with open(path, "r") as version_f:
+        for line in version_f:
+            if line.startswith("#define") and "APP_VERSION" in line:
+                version = parse_h_string(line)
+                break
+
+    return version
+
+
+SHIELD_TRAVIS = "[![travis](https://travis-ci.org/{USER}/{REPO}.svg?branch={BRANCH})]" \
+    "(https://travis-ci.org/{USER}/{REPO})"
+
+SHIELD_VERSION = "[![version](https://img.shields.io/badge/version-{VERSION}-brightgreen.svg)](CHANGELOG.md)"
+
+SHIELD_BRANCH = "[![branch](https://img.shields.io/badge/branch-{BRANCH}-orange.svg)]" \
+    "(https://github.org/{USER}/{REPO}/tree/{BRANCH}/)"
+
+SHIELD_CODACY = "[![codacy](https://img.shields.io/codacy/grade/c9496e25cf07434cba786b462cb15f49/{BRANCH}.svg)]" \
+    "(https://www.codacy.com/app/{USER}/{REPO}/dashboard)"
+
+README = "README.md"
+
+
+if __name__ == "__main__":
+    base = os.getcwd()
+
+    user, repo = git_parse_remote()
+    template = {
+        "USER": user,
+        "REPO": repo,
+        "BRANCH": git_branch(),
+        "VERSION": espurna_get_version(base)
+    }
+
+    shield_travis = SHIELD_TRAVIS.format(**template)
+    shield_version = SHIELD_VERSION.format(**template)
+    shield_branch = SHIELD_BRANCH.format(**template)
+    shield_codacy = SHIELD_CODACY.format(**template)
+
+    path = os.path.join(base, README)
+
+    with FileInput(path, inplace=True) as readme:
+        for line in readme:
+            if "![travis]" in line:
+                print(shield_travis)
+            elif "![version]" in line:
+                print(shield_version)
+            elif "![branch]" in line:
+                print(shield_branch)
+            elif "![codacy]" in line:
+                print(shield_codacy)
+            else:
+                print(line, end="")
+
+    sys.exit(call(["git", "add", README], cwd=base))

--- a/pre-commit
+++ b/pre-commit
@@ -13,7 +13,6 @@ Travis badge with the current branch. Based on [4].
 Copy this file to .git/hooks/
 
 """
-from __future__ import print_function
 
 import os
 import sys
@@ -119,6 +118,6 @@ if __name__ == "__main__":
 
     with FileInput(path, inplace=True) as readme:
         for line in readme:
-            print(fmt_line(line), end='')
+            sys.stdout.write(fmt_line(line))
 
     sys.exit(call(["git", "add", README]))


### PR DESCRIPTION
I was looking into extending extra_scripts.py to have git related functions. For example, to add APP_REVISION using -DAPP_REVISION=... or replace PROGNAME of firmware to have git short commit and tag. Starting with this as it also uses that info. Will properly extract them later.

- Fixed cwd assumptions, pre-commit always starts at the repo base
- Extract USER and REPO from "origin" url directly
- Refactored into separate functions and \_\_main\_\_
- pre-commit can now be symlinked into .git/hooks, not only copied. This happened before:
```bash
$ git commit
Traceback (most recent call last):
  File ".git/hooks/pre-commit", line 39, in <module>
    VERSION = getVersion()
  File ".git/hooks/pre-commit", line 33, in getVersion
    lines = open(file_name).readlines()
IOError: [Errno 2] No such file or directory: '/home/maxim/espurna/../../code/espurna/config/version.h'
```