### PR TITLE
Check for NTP_SUPPORT in sensors

### DIFF
--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -286,9 +286,11 @@ void _sensorPost() {
 }
 
 void _sensorReset() {
-    if (ntpSynced()) {
-        _sensor_energy_reset_ts = String(" (since ") + ntpDateTime() + String(")");
-    }
+    #if NTP_SUPPORT
+        if (ntpSynced()) {
+            _sensor_energy_reset_ts = String(" (since ") + ntpDateTime() + String(")");
+        }
+    #endif
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
```
.pioenvs/itead-sonoff-pow/src/espurna.ino.cpp.o:(.text._Z12_sensorResetv+0xc): undefined reference to `ntpSynced()'
.pioenvs/itead-sonoff-pow/src/espurna.ino.cpp.o:(.text._Z12_sensorResetv+0x10): undefined reference to `ntpDateTime()'
.pioenvs/itead-sonoff-pow/src/espurna.ino.cpp.o:(.text._Z12_sensorResetv+0x1b): undefined reference to `ntpSynced()'
.pioenvs/itead-sonoff-pow/src/espurna.ino.cpp.o:(.text._Z12_sensorResetv+0x38): undefined reference to `ntpDateTime()'
collect2: error: ld returned 1 exit status
*** [.pioenvs/itead-sonoff-pow/firmware.elf] Error 1
```