### PR TITLE
Minor: Change libs from URLs to names

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -46,20 +46,20 @@ upload_flags = --auth=fibonacci --port 8266
 # ------------------------------------------------------------------------------
 lib_deps =
     ArduinoJson
-    https://github.com/marvinroger/async-mqtt-client#v0.8.1
+    AsyncMqttClient@0.8.1
     Brzo I2C
-    https://bitbucket.org/xoseperez/debounceevent.git#2.0.1
+    DebounceEvent@2.0.1
     Embedis
-    https://github.com/plerup/espsoftwareserial#3.4.1
+    EspSoftwareSerial@3.4.1
     https://github.com/me-no-dev/ESPAsyncTCP#55cd520
     https://github.com/me-no-dev/ESPAsyncWebServer#232b87a
-    https://bitbucket.org/xoseperez/fauxmoesp.git#2.4.2
-    https://github.com/xoseperez/hlw8012.git#1.1.0
-    https://github.com/markszabo/IRremoteESP8266#v2.2.0
-    https://bitbucket.org/xoseperez/justwifi.git#1.1.7
-    https://github.com/madpilot/mDNSResolver#4cfcda1
-    https://github.com/xoseperez/my92xx#3.0.1
-    https://bitbucket.org/xoseperez/nofuss.git#0.2.5
+    fauxmoesp.git@2.4.2
+    hlw8012.git@1.1.0
+    IRremoteESP8266@2.2.0
+    JustWifi@1.2.0
+    mDNSResolver@0.2
+    my92xx@3.0.1
+    NoFUSS0.2.5
     https://github.com/xoseperez/NtpClient.git#0016a59
     OneWire
     PMS Library

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -61,13 +61,13 @@ lib_deps =
     EspSoftwareSerial@3.4.1
     https://github.com/me-no-dev/ESPAsyncTCP#55cd520
     https://github.com/me-no-dev/ESPAsyncWebServer#232b87a
-    fauxmoesp.git@2.4.2
-    hlw8012.git@1.1.0
+    fauxmoesp@2.4.2
+    hlw8012@1.1.0
     IRremoteESP8266@2.2.0
     JustWifi@1.2.0
     mDNSResolver@0.2
     my92xx@3.0.1
-    NoFUSS0.2.5
+    NoFUSS@0.2.5
     https://github.com/xoseperez/NtpClient.git#0016a59
     OneWire
     PMS Library


### PR DESCRIPTION
PlatformIO tracks most of the libs by name now, so we can use it.
Kept strict versioning of the libs, to avoid issues. 
