### PR TITLE
Set PMS sensor type dynamically

### DIFF
--- a/code/espurna/config/progmem.h
+++ b/code/espurna/config/progmem.h
@@ -74,8 +74,8 @@ PROGMEM const char* const magnitude_topics[] = {
 };
 
 PROGMEM const char magnitude_empty[] = "";
-PROGMEM const char magnitude_celsius[] =  "C";
-PROGMEM const char magnitude_fahrenheit[] =  "F";
+PROGMEM const char magnitude_celsius[] =  "°C";
+PROGMEM const char magnitude_fahrenheit[] =  "°F";
 PROGMEM const char magnitude_percentage[] = "%";
 PROGMEM const char magnitude_hectopascals[] = "hPa";
 PROGMEM const char magnitude_amperes[] = "A";
@@ -84,11 +84,12 @@ PROGMEM const char magnitude_watts[] = "W";
 PROGMEM const char magnitude_kw[] = "kW";
 PROGMEM const char magnitude_joules[] = "J";
 PROGMEM const char magnitude_kwh[] = "kWh";
-PROGMEM const char magnitude_ugm3[] = "µg/m3";
+PROGMEM const char magnitude_ugm3[] = "µg/m³";
 PROGMEM const char magnitude_ppm[] = "ppm";
 PROGMEM const char magnitude_lux[] = "lux";
 PROGMEM const char magnitude_uv[] = "uv";
 PROGMEM const char magnitude_distance[] = "m";
+PROGMEM const char magnitude_mgm3[] = "mg/m³";
 
 PROGMEM const char* const magnitude_units[] = {
     magnitude_empty, magnitude_celsius, magnitude_percentage,
@@ -98,7 +99,7 @@ PROGMEM const char* const magnitude_units[] = {
     magnitude_empty, magnitude_empty, magnitude_empty,
     magnitude_ugm3, magnitude_ugm3, magnitude_ugm3,
     magnitude_ppm, magnitude_lux, magnitude_uv,
-    magnitude_distance, magnitude_empty
+    magnitude_distance, magnitude_mgm3
 
 };
 

--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -392,7 +392,7 @@
 
 //------------------------------------------------------------------------------
 // Particle Monitor based on Plantower PMS
-// Enable support by passing PMS_SUPPORT=1 build flag
+// Enable support by passing PMSX003_SUPPORT=1 build flag
 //------------------------------------------------------------------------------
 
 #ifndef PMSX003_SUPPORT

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -501,6 +501,7 @@ void _sensorLoad() {
         PMSX003Sensor * sensor = new PMSX003Sensor();
         sensor->setRX(PMS_RX_PIN);
         sensor->setTX(PMS_TX_PIN);
+        sensor->setType(PMS_TYPE);
         _sensors.push_back(sensor);
     }
     #endif

--- a/code/espurna/sensors/PMSX003Sensor.h
+++ b/code/espurna/sensors/PMSX003Sensor.h
@@ -87,7 +87,7 @@ class PMSX003 {
 
                 int avail = _serial->available();
                 #if SENSOR_DEBUG
-                    //debugSend("[SENSOR] %s: Packet available = %d\n", PMS_TYPE_NAME, avail);
+                    //debugSend("[SENSOR] PMS: Packet available = %d\n", avail);
                 #endif
                 if (avail < PMS_PACKET_SIZE(data_count)) {
                     break;
@@ -97,12 +97,9 @@ class PMSX003 {
 
                     uint16_t sum = 0x42 + 0x4D;
                     uint16_t size = read16(sum);
-                    #if SENSOR_DEBUG
-                        debugSend("[SENSOR] %s: Payload size = %d\n", PMS_TYPE_NAME, size);
-                    #endif
                     if (size != PMS_PAYLOAD_SIZE(data_count)) {
                         #if SENSOR_DEBUG
-                            debugSend(("[SENSOR] %s: Payload size != %d \n"), PMS_TYPE_NAME, PMS_PAYLOAD_SIZE);
+                            debugSend(("[SENSOR] PMS: Payload size: %d != %d.\n"), size, PMS_PAYLOAD_SIZE(data_count));
                         #endif
                         break;
                     }
@@ -110,16 +107,17 @@ class PMSX003 {
                     for (int i = 0; i < data_count; i++) {
                         data[i] = read16(sum);
                         #if SENSOR_DEBUG
-                            //debugSend(("[SENSOR] %s:   data[%d] = %d\n"), PMS_TYPE_NAME, i, data[i]);
+                            //debugSend(("[SENSOR] PMS:   data[%d] = %d\n"), i, data[i]);
                         #endif
                     }
 
                     uint16_t checksum = read16();
-                    #if SENSOR_DEBUG
-                        debugSend(("[SENSOR] %s:   Sum=%04X, Checksum=%04X\n"), PMS_TYPE_NAME, sum, checksum);
-                    #endif
                     if (sum == checksum) {
                         return true;
+                    } else {
+                        #if SENSOR_DEBUG
+                            debugSend(("[SENSOR] PMS checksum: %04X != %04X\n"), sum, checksum);
+                        #endif
                     }
                     break;
                 }
@@ -260,7 +258,7 @@ class PMSX003Sensor : public BaseSensor, PMSX003 {
                     readCycle = _readCount % 30;
                     if (readCycle == 0) {
                         #if SENSOR_DEBUG
-                            debugSend("[SENSOR] %s: Wake up: %d\n", PMS_TYPE_NAME, _readCount);
+                            debugSend("[SENSOR] %s: Wake up: %d\n", pms_specs[_type].name, _readCount);
                         #endif
                         wakeUp();
                         return;
@@ -296,7 +294,7 @@ class PMSX003Sensor : public BaseSensor, PMSX003 {
                 if (readCycle == 6) {
                     sleep();
                     #if SENSOR_DEBUG
-                        debugSend("[SENSOR] %s: Enter sleep mode: %d\n", PMS_TYPE_NAME, _readCount);
+                        debugSend("[SENSOR] %s: Enter sleep mode: %d\n", pms_specs[_type].name, _readCount);
                     #endif
                     return;
                 }


### PR DESCRIPTION
1. Set PMS sensor type dynamically;
2. Refine unit of hcho/temperature/ugm3.

Tested successfully on PMS5003T