### PR TITLE
removing hardcoded ota settings still in some platformio environments

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -738,8 +738,8 @@ lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
 build_flags = ${common.build_flags_1m} -DITEAD_SONOFF_RFBRIDGE -DRFB_DIRECT
 upload_speed = 115200
-upload_port = "192.168.4.1"
-upload_flags = --auth=fibonacci --port 8266
+upload_port = "${env.ESPURNA_IP}"
+upload_flags = --auth=${env.ESPURNA_AUTH} --port 8266
 monitor_baud = 19200
 extra_scripts = ${common.extra_scripts}
 
@@ -888,8 +888,8 @@ board_flash_mode = dout
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
 build_flags = ${common.build_flags_1m} -DITEAD_SONOFF_S31
-upload_port = "192.168.4.1"
-upload_flags = --auth=fibonacci --port 8266
+upload_port = "${env.ESPURNA_IP}"
+upload_flags = --auth=${env.ESPURNA_AUTH} --port 8266
 monitor_baud = 115200
 extra_scripts = ${common.extra_scripts}
 
@@ -1926,8 +1926,8 @@ lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
 build_flags = ${common.build_flags_1m} -DZHILDE_EU44_W
 upload_speed = 115200
-upload_port = "192.168.4.1"
-upload_flags = --auth=fibonacci --port 8266
+upload_port = "${env.ESPURNA_IP}"
+upload_flags = --auth=${env.ESPURNA_AUTH} --port 8266
 monitor_baud = 115200
 extra_scripts = ${common.extra_scripts}
 


### PR DESCRIPTION
itead-sonoff-rfbridge-direct-ota, itead-sonoff-s31-ota and zhilde-eu44-w-ota were still pointing to the hardcoded 192.168.4.1/fibonacci target, moved them to use the environment variables.