### PR TITLE
Process commands with telnet / WebUI debug enabled

### DIFF
--- a/code/espurna/settings.ino
+++ b/code/espurna/settings.ino
@@ -447,30 +447,25 @@ void settingsLoop() {
         _settings_save = false;
     }
 
+    #if TERMINAL_SUPPORT && DEBUG_SERIAL_SUPPORT
+        while (DEBUG_PORT.available()) {
+            _serial.inject(DEBUG_PORT.read());
+        }
+    #endif
 
-    #if TERMINAL_SUPPORT
-
-        #if DEBUG_SERIAL_SUPPORT
-            while (DEBUG_PORT.available()) {
-                _serial.inject(DEBUG_PORT.read());
-            }
-        #endif
-
+    #if TERMINAL_SUPPORT || DEBUG_WEB_SUPPORT || TELNET_SUPPORT
         embedis.process();
+    #endif
 
-        #if SERIAL_RX_ENABLED
-
-            while (SERIAL_RX_PORT.available() > 0) {
-                char rc = Serial.read();
-                _serial_rx_buffer[_serial_rx_pointer++] = rc;
-                if ((_serial_rx_pointer == TERMINAL_BUFFER_SIZE) || (rc == 10)) {
-                    settingsInject(_serial_rx_buffer, (size_t) _serial_rx_pointer);
-                    _serial_rx_pointer = 0;
-                }
+    #if TERMINAL_SUPPORT && SERIAL_RX_ENABLED
+        while (SERIAL_RX_PORT.available() > 0) {
+            char rc = Serial.read();
+            _serial_rx_buffer[_serial_rx_pointer++] = rc;
+            if ((_serial_rx_pointer == TERMINAL_BUFFER_SIZE) || (rc == 10)) {
+                settingsInject(_serial_rx_buffer, (size_t) _serial_rx_pointer);
+                _serial_rx_pointer = 0;
             }
-
-        #endif // SERIAL_RX_ENABLED
-
-    #endif // TERMINAL_SUPPORT
+        }
+    #endif
 
 }

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -300,7 +300,7 @@ void _wsOnStart(JsonObject& root) {
         root["btnDelay"] = getSetting("btnDelay", BUTTON_DBLCLICK_DELAY).toInt();
         root["webPort"] = getSetting("webPort", WEB_PORT).toInt();
         root["wsAuth"] = getSetting("wsAuth", WS_AUTHENTICATION).toInt() == 1;
-        #if TERMINAL_SUPPORT
+        #if DEBUG_WEB_SUPPORT
             root["cmdVisible"] = 1;
         #endif
 


### PR DESCRIPTION
Following #787 
embedis.process() only checks for terminal support - it should also check for other possible sources.

Running this with rfbridge, looks ok so far.

*Edit:* oops. that was configuration mistake on my part and this is not needed. TERMINAL_SUPPORT != DEBUG_SERIAL_SUPPORT