### PR TITLE
Ctrl-d for telnet

### DIFF
--- a/code/espurna/telnet.ino
+++ b/code/espurna/telnet.ino
@@ -67,8 +67,8 @@ void _telnetData(unsigned char clientId, void *data, size_t len) {
     // Capture close connection
     char * p = (char *) data;
 
-    // C-d is sent as two bytes
-    if (len == 2) {
+    // C-d is sent as two bytes (sometimes repeating)
+    if (len >= 2) {
         if ((p[0] == 0xFF) && (p[1] == 0xEC)) {
             _telnetClients[clientId]->close();
             return;

--- a/code/espurna/telnet.ino
+++ b/code/espurna/telnet.ino
@@ -70,7 +70,7 @@ void _telnetData(unsigned char clientId, void *data, size_t len) {
     // C-d is sent as two bytes (sometimes repeating)
     if (len >= 2) {
         if ((p[0] == 0xFF) && (p[1] == 0xEC)) {
-            _telnetClients[clientId]->close();
+            _telnetClients[clientId]->close(true);
             return;
         }
     }

--- a/code/espurna/telnet.ino
+++ b/code/espurna/telnet.ino
@@ -66,6 +66,15 @@ void _telnetData(unsigned char clientId, void *data, size_t len) {
 
     // Capture close connection
     char * p = (char *) data;
+
+    // C-d is sent as two bytes
+    if (len == 2) {
+        if ((p[0] == 0xFF) && (p[1] == 0xEC)) {
+            _telnetClients[clientId]->close();
+            return;
+        }
+    }
+
     if ((strncmp(p, "close", 5) == 0) || (strncmp(p, "quit", 4) == 0)) {
         _telnetClients[clientId]->close();
         return;


### PR DESCRIPTION
Looking at wireshark data, telnet sometimes sends 'ff ec' (xEOF) in sequence multiple times. And without close(true) this trigged watchdog reboot.