### PR TITLE
Don't send device_class for Home Assistant sensor

### DIFF
--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -24,7 +24,6 @@ void _haSendMagnitude(unsigned char i, JsonObject& config) {
     unsigned char type = magnitudeType(i);
     config["name"] = getSetting("hostname") + String(" ") + magnitudeTopic(type);
     config.set("platform", "mqtt");
-    config.set("device_class", "sensor");
     config["state_topic"] = mqttTopic(magnitudeTopicIndex(i).c_str(), false);
     config["unit_of_measurement"] = String("\"") + magnitudeUnits(type) + String("\"");
 


### PR DESCRIPTION
Turns out "sensor" value was just silently ignored as sensor.mqtt did not support it. Current version (0.69.1) throws exceptions about it
https://www.home-assistant.io/components/sensor.mqtt/#device_class
https://www.home-assistant.io/components/sensor/#device-class