### PR TITLE
Do not use underscore in SSID / hostname

### DIFF
--- a/code/espurna/config/defaults.h
+++ b/code/espurna/config/defaults.h
@@ -399,7 +399,7 @@
 // General
 // -----------------------------------------------------------------------------
 
-// Default hostname will be ESPURNA_XXXXXX, where XXXXXX is last 3 octets of chipID
+// Default hostname will be ESPURNA-XXXXXX, where XXXXXX is last 3 octets of chipID
 #ifndef HOSTNAME
 #define HOSTNAME ""
 #endif

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -11,7 +11,7 @@ Ticker _defer_reset;
 
 String getIdentifier() {
     char buffer[20];
-    snprintf_P(buffer, sizeof(buffer), PSTR("%s_%06X"), APP_NAME, ESP.getChipId());
+    snprintf_P(buffer, sizeof(buffer), PSTR("%s-%06X"), APP_NAME, ESP.getChipId());
     return String(buffer);
 }
 


### PR DESCRIPTION
From #880, #874 - use hyphen instead of underscore