### PR TITLE
Migrate from {identifier} to {hostname}

### DIFF
--- a/code/espurna/migrate.ino
+++ b/code/espurna/migrate.ino
@@ -1001,6 +1001,15 @@ void migrate() {
 
     }
 
+    #if MQTT_SUPPORT
+        // Deprecated MQTT substitution
+        String mqttTopic = getSetting("mqttTopic", MQTT_TOPIC);
+        if (mqttTopic.indexOf("{identifier}") > 0) {
+            mqttTopic.replace("{identifier}", "{hostname}");
+            setSetting("mqttTopic", mqttTopic);
+        }
+    #endif
+
     saveSettings();
 
 }

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -218,7 +218,6 @@ void _mqttConfigure() {
     if (_mqtt_topic.endsWith("/")) _mqtt_topic.remove(_mqtt_topic.length()-1);
 
     // Placeholders
-    _mqtt_topic.replace("{identifier}", getSetting("hostname"));
     _mqtt_topic.replace("{hostname}", getSetting("hostname"));
     _mqtt_topic.replace("{magnitude}", "#");
     if (_mqtt_topic.indexOf("#") == -1) _mqtt_topic = _mqtt_topic + "/#";


### PR DESCRIPTION
It is marked as deprecated since 1.12.2
Maybe do this instead?