### PR TITLE
Free jsonBuffer after printing

### DIFF
--- a/code/espurna/api.ino
+++ b/code/espurna/api.ino
@@ -134,6 +134,7 @@ void _onAPIs(AsyncWebServerRequest *request) {
             root[_apis[i].key] = String(buffer);
         }
         root.printTo(output);
+        jsonBuffer.clear();
         request->send(200, "application/json", output);
 
     } else {

--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -44,6 +44,7 @@ void _haSendMagnitudes() {
             JsonObject& config = jsonBuffer.createObject();
             _haSendMagnitude(i, config);
             config.printTo(output);
+            jsonBuffer.clear();
         }
 
         mqttSendRaw(topic.c_str(), output.c_str());
@@ -123,6 +124,7 @@ void _haSendSwitches() {
             JsonObject& config = jsonBuffer.createObject();
             _haSendSwitch(i, config);
             config.printTo(output);
+            jsonBuffer.clear();
         }
 
         mqttSendRaw(topic.c_str(), output.c_str());
@@ -163,6 +165,8 @@ String _haGetConfig() {
         }
         output += "\n";
 
+        jsonBuffer.clear();
+
     }
 
     #if SENSOR_SUPPORT
@@ -185,6 +189,8 @@ String _haGetConfig() {
                 output += kv.key + String(": ") + kv.value.as<String>() + String("\n");
             }
             output += "\n";
+
+            jsonBuffer.clear();
 
         }
 

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -613,6 +613,8 @@ void mqttFlush() {
     // Send
     String output;
     root.printTo(output);
+    jsonBuffer.clear();
+
     mqttSendRaw(_mqtt_topic_json.c_str(), output.c_str(), false);
 
     // Clear queue

--- a/code/espurna/web.ino
+++ b/code/espurna/web.ino
@@ -55,6 +55,7 @@ void _onGetConfig(AsyncWebServerRequest *request) {
     root["version"] = APP_VERSION;
     settingsGetJson(root);
     root.prettyPrintTo(*response);
+    jsonBuffer.clear();
 
     char buffer[100];
     snprintf_P(buffer, sizeof(buffer), PSTR("attachment; filename=\"%s-backup.json\""), (char *) getSetting("hostname").c_str());

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -440,6 +440,7 @@ void wsSend(ws_on_send_callback_f callback) {
         callback(root);
         String output;
         root.printTo(output);
+        jsonBuffer.clear();
         _ws.textAll((char *) output.c_str());
     }
 }
@@ -464,6 +465,7 @@ void wsSend(uint32_t client_id, ws_on_send_callback_f callback) {
     callback(root);
     String output;
     root.printTo(output);
+    jsonBuffer.clear();
     _ws.text(client_id, (char *) output.c_str());
 }
 


### PR DESCRIPTION
Solving heap problems from #896. Limited testng prefilling eeprom with bunch of "a"*64 strings and accessing /config when websocket is active.
For example, _onGetConfig method when settings size is `3236/4096`

|state|getFreeHeap()|jsonBuffer.size()|
|---|---|---|
|initial|22512|40|
|after settingsGetJson()|14768|4370|
|after printTo()|12528|4370|
|after clear()|20544|0|