### PR TITLE
Show true binary size and warning in check_size

### DIFF
--- a/code/extra_scripts.py
+++ b/code/extra_scripts.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-from subprocess import call
-from platformio import util
+from __future__ import print_function
+
 import os
-import time
+import sys
+from subprocess import call
+
+import click
+from platformio import util
 
 Import("env")
 
@@ -31,6 +35,17 @@ class Color(object):
 def clr(color, text):
     return color + str(text) + '\x1b[0m'
 
+def print_warning(message, color=Color.LIGHT_YELLOW):
+    print(clr(color, message), file=sys.stderr)
+
+def print_filler(fill, color=Color.WHITE, err=False):
+    width, _ = click.get_terminal_size()
+    if len(fill) > 1:
+        fill = fill[0]
+
+    out = sys.stderr if err else sys.stdout
+    print(clr(color, fill * width), file=out)
+
 # ------------------------------------------------------------------------------
 # Callbacks
 # ------------------------------------------------------------------------------
@@ -52,12 +67,18 @@ def cpp_check(source, target, env):
     print("Finished cppcheck...\n")
 
 def check_size(source, target, env):
-    time.sleep(2)
-    size = target[0].get_size()
-    print clr(Color.LIGHT_BLUE, "Binary size: %s bytes" % size)
-    #if size > 512000:
-    #    print clr(Color.LIGHT_RED, "File too large for OTA!")
-    #    Exit(1)
+    (binary,) = target
+    path = binary.get_abspath()
+    size = os.stat(path).st_size
+    print(clr(Color.LIGHT_BLUE, "Binary size: {} bytes".format(size)))
+
+    # Warn 1MB variants about exceeding OTA size limit
+    flash_size = int(env.BoardConfig().get("upload.maximum_size", 0))
+    if (flash_size == 1048576) and (size >= 512000):
+        print_filler("*", color=Color.LIGHT_YELLOW, err=True)
+        print_warning("File is too large for OTA! Here you can find instructions on how to flash it:")
+        print_warning("https://github.com/xoseperez/espurna/wiki/TwoStepUpdates", color=Color.LIGHT_CYAN)
+        print_filler("*", color=Color.LIGHT_YELLOW, err=True)
 
 def build_webui(env):
     config = util.load_project_config()


### PR DESCRIPTION
SCons does not think firmware.bin exists on first build, the size is 0. Just get the path and use python method.

Re-enable back OTA size warning for 1MB boards and show it through stderr to circumvent being hidden when pio is ran with --silent
idk about 512000 though (numbers below from ldscript sizes 1m0m1s and 1m0m2s)
should it be ((999 * 1024) / 2) == 511488.0?
or maybe ((995 * 1024 / 2) == 509440.0?