### PR TITLE
Separate test and release stages in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 sudo: false
 cache:
   directories:
+  - "~/.npm"
   - "~/.platformio"
   - "$TRAVIS_BUILD_DIR/code/.piolibdeps"
   - "$TRAVIS_BUILD_DIR/code/espurna/node_modules"
@@ -11,15 +12,25 @@ install:
 - pip install -U platformio
 - cd code ; npm install --only=dev ; cd ..
 env:
-    global:
-        - BUILDER_TOTAL_THREADS=4
-    matrix:
-        - BUILDER_THREAD=0
-        - BUILDER_THREAD=1
-        - BUILDER_THREAD=2
-        - BUILDER_THREAD=3
+  global:
+  - BUILDER_TOTAL_THREADS=4
 script:
 - cd code && ./build.sh -p &&  cd ..
+stages:
+- name: Test
+- name: Release
+  if: tag IS present AND branch = master
+jobs:
+  include:
+  - stage: Test
+    script: cd code && ./build.sh travis01
+  - script: cd code && ./build.sh travis02
+  - script: cd code && ./build.sh travis03
+  - stage: Release
+    env: BUILDER_THREAD=0
+  - env: BUILDER_THREAD=1
+  - env: BUILDER_THREAD=2
+  - env: BUILDER_THREAD=3
 before_deploy:
 - mv firmware/*/espurna-*.bin firmware/
 deploy:
@@ -30,8 +41,10 @@ deploy:
   file: firmware/espurna-*.bin
   skip_cleanup: true
   on:
-    all_branches: true
     tags: true
+    branch: master
+    repo: xoseperez/espurna
+    condition: $TRAVIS_BUILD_STAGE_NAME = Release
 notifications:
   pushover:
     api_key:


### PR DESCRIPTION
- Revert test to being serial. Releases are using parallel jobs.
- Some cosmetic changes in build.sh

Matrix expansion is somehow slower? I did watch #986 merge build, 10 minutes per 10 minutes total. Which is strange, bc jobs did not start parallel at all.