### PR TITLE
build.sh rework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
 sudo: false
 cache:
   directories:
+  - "~/.npm"
   - "~/.platformio"
   - "$TRAVIS_BUILD_DIR/code/.piolibdeps"
   - "$TRAVIS_BUILD_DIR/code/espurna/node_modules"
@@ -11,15 +12,25 @@ install:
 - pip install -U platformio
 - cd code ; npm install --only=dev ; cd ..
 env:
-    global:
-        - BUILDER_TOTAL_THREADS=4
-    matrix:
-        - BUILDER_THREAD=0
-        - BUILDER_THREAD=1
-        - BUILDER_THREAD=2
-        - BUILDER_THREAD=3
+  global:
+  - BUILDER_TOTAL_THREADS=4
 script:
 - cd code && ./build.sh -p &&  cd ..
+stages:
+- name: Test
+- name: Release
+  if: tag IS present AND branch = master
+jobs:
+  include:
+  - stage: Test
+    script: cd code && ./build.sh travis01
+  - script: cd code && ./build.sh travis02
+  - script: cd code && ./build.sh travis03
+  - stage: Release
+    env: BUILDER_THREAD=0
+  - env: BUILDER_THREAD=1
+  - env: BUILDER_THREAD=2
+  - env: BUILDER_THREAD=3
 before_deploy:
 - mv firmware/*/espurna-*.bin firmware/
 deploy:
@@ -30,8 +41,10 @@ deploy:
   file: firmware/espurna-*.bin
   skip_cleanup: true
   on:
-    all_branches: true
     tags: true
+    branch: master
+    repo: xoseperez/espurna
+    condition: $TRAVIS_BUILD_STAGE_NAME = Release
 notifications:
   pushover:
     api_key:

--- a/code/build.sh
+++ b/code/build.sh
@@ -1,96 +1,133 @@
 #!/bin/bash
+set -e
 
-# Welcome
-echo "--------------------------------------------------------------"
-echo "ESPURNA FIRMWARE BUILDER"
+# Script settings
+version=$(grep APP_VERSION espurna/config/version.h | awk '{print $3}' | sed 's/"//g')
+
+(command -v git && git rev-parse --is-inside-work-tree) 2>&1>/dev/null
+if [ $? -eq 0 ]; then
+    git_revision=$(git rev-parse --short HEAD)
+    git_version=$(git describe --tags)
+else
+    git_revision=
+    git_version=$version
+fi
+
+par_build=0
+par_thread=${BUILDER_THREAD:-0}
+par_total_threads=${BUILDER_TOTAL_THREADS:-4}
+if [ ${par_thread} -ne ${par_thread} -o \
+    ${par_total_threads} -ne ${par_total_threads} ]; then
+    echo "Parallel threads should be a number."
+    exit
+fi
+if [ ${par_thread} -ge ${par_total_threads} ]; then
+    echo "Current thread is greater than total threads. Doesn't make sense"
+    exit
+fi
 
 # Available environments
 travis=$(grep env: platformio.ini | grep travis | sed 's/\[env://' | sed 's/\]/ /' | sort)
 available=$(grep env: platformio.ini | grep -v ota  | grep -v ssl  | grep -v travis | sed 's/\[env://' | sed 's/\]/ /' | sort)
 
+# Build tools settings
+export PLATFORMIO_BUILD_FLAGS="${PLATFORMIO_BUILD_FLAGS} -DAPP_REVISION='\"$git_revision\"'"
+
+# Functions
+print_available() {
+    echo "--------------------------------------------------------------"
+    echo "Available environments:"
+    for environment in $available; do
+        echo "* $environment"
+    done
+}
+
+print_environments() {
+    echo "--------------------------------------------------------------"
+    echo "Current environments:"
+    for environment in $environments; do
+        echo "* $environment"
+    done
+}
+
+set_default_environments() {
+    # Hook to build in parallel when using travis
+    if [[ "${TRAVIS_BUILD_STAGE_NAME}" = "Release" ]] && [ ${par_build} ]; then
+        environments=$(echo ${available} | \
+            awk -v par_thread=${par_thread} -v par_total_threads=${par_total_threads} \
+            '{ for (i = 1; i <= NF; i++) if (++j % par_total_threads == par_thread ) print $i; }')
+        return
+    fi
+
+    # Only build travisN
+    if [[ "${TRAVIS_BUILD_STAGE_NAME}" = "Test" ]]; then
+        environments=$travis
+        return
+    fi
+
+    # Fallback to all available environments
+    environments=$available
+}
+
+build_webui() {
+    # Build system uses gulpscript.js to build web interface
+    if [ ! -e node_modules/gulp/bin/gulp.js ]; then
+        echo "--------------------------------------------------------------"
+        echo "Installing dependencies..."
+        npm install --only=dev
+    fi
+
+    # Recreate web interface (espurna/data/index.html.*.gz.h)
+    echo "--------------------------------------------------------------"
+    echo "Building web interface..."
+    node node_modules/gulp/bin/gulp.js || exit
+}
+
+build_environments() {
+    echo "--------------------------------------------------------------"
+    echo "Building firmware images..."
+    mkdir -p ../firmware/espurna-$version
+
+    for environment in $environments; do
+        echo "* espurna-$version-$environment.bin"
+        platformio run --silent --environment $environment || exit 1
+        [[ "${TRAVIS_BUILD_STAGE_NAME}" = "Test" ]] || \
+            mv .pioenvs/$environment/firmware.bin ../firmware/espurna-$version/espurna-$version-$environment.bin
+    done
+    echo "--------------------------------------------------------------"
+}
+
 # Parameters
 while getopts "lp" opt; do
   case $opt in
     l)
-        echo "--------------------------------------------------------------"
-        echo "Available environments:"
-        for environment in $available; do
-            echo "* $environment"
-        done
+        print_available
         exit
         ;;
     p)
         par_build=1
-        par_thread=${BUILDER_THREAD:-0}
-        par_total_threads=${BUILDER_TOTAL_THREADS:-4}
-        if [ ${par_thread} -ne ${par_thread} -o \
-            ${par_total_threads} -ne ${par_total_threads} ]; then
-                echo "Parallel threads should be a number."
-                exit
-        fi
-        if [ ${par_thread} -ge ${par_total_threads} ]; then
-            echo "Current thread is greater than total threads. Doesn't make sense"
-            exit
-        fi
         ;;
     esac
 done
 
 shift $((OPTIND-1))
 
-environments=$@
+# Welcome
+echo "--------------------------------------------------------------"
+echo "ESPURNA FIRMWARE BUILDER"
+echo "Building for version ${git_version}"
 
 # Environments to build
+environments=$@
+
 if [ $# -eq 0 ]; then
-
-    if [[ "${TRAVIS_BUILD_STAGE_NAME}" = "Release" ]] && [ ${par_build} ]; then
-        environments=$(echo ${available} | \
-            awk -v par_thread=${par_thread} -v par_total_threads=${par_total_threads} \
-            '{ for (i = 1; i <= NF; i++) if (++j % par_total_threads == par_thread ) print $i; }')
-    elif [[ "${TRAVIS_BUILD_STAGE_NAME}" = "Test" ]]; then
-        environments=$travis
-    else
-        environments=$available
-    fi
-
+    set_default_environments
 fi
 
-# Get current version
-version=$(grep APP_VERSION espurna/config/version.h | awk '{print $3}' | sed 's/"//g')
-echo "Building for version $version"
-
-# Create output folder
-mkdir -p firmware
-
-if [ ! -e node_modules/gulp/bin/gulp.js ]; then
-    echo "--------------------------------------------------------------"
-    echo "Installing dependencies..."
-    npm install --only=dev
+if [[ "${CI}" = true ]]; then
+    print_environments
 fi
 
-echo "--------------------------------------------------------------"
-echo "Get revision..."
-revision=$(git rev-parse HEAD)
-revision=${revision:0:7}
-cp espurna/config/version.h espurna/config/version.h.original
-sed -i -e "s/APP_REVISION            \".*\"/APP_REVISION            \"$revision\"/g" espurna/config/version.h
+build_webui
+build_environments
 
-# Recreate web interface
-echo "--------------------------------------------------------------"
-echo "Building web interface..."
-node node_modules/gulp/bin/gulp.js || exit
-
-# Build all the required firmware images
-echo "--------------------------------------------------------------"
-echo "Building firmware images..."
-mkdir -p ../firmware/espurna-$version
-
-for environment in $environments; do
-    echo -n "* espurna-$version-$environment.bin --- "
-    platformio run --silent --environment $environment || exit 1
-    stat -c %s .pioenvs/$environment/firmware.bin
-    mv .pioenvs/$environment/firmware.bin ../firmware/espurna-$version/espurna-$version-$environment.bin
-done
-echo "--------------------------------------------------------------"
-
-mv espurna/config/version.h.original espurna/config/version.h

--- a/code/espurna/config/version.h
+++ b/code/espurna/config/version.h
@@ -1,6 +1,11 @@
 #define APP_NAME                "ESPURNA"
 #define APP_VERSION             "1.13.1a"
-#define APP_REVISION            "d543fee"
+
+#ifndef APP_REVISION
+#define APP_REVISION ""
+#endif
+
 #define APP_AUTHOR              "xose.perez@gmail.com"
 #define APP_WEBSITE             "http://tinkerman.cat"
+
 #define CFG_VERSION             3


### PR DESCRIPTION
- separate statements instead of inline logic
- `-DAPP_REVISION=...` instead of modifying file (see accidental commit of version.h)
- show revision in the log (git describe shows current tag or `<tag>-<n-commits>-<sha1>`)
- set -e to avoid some issues when commands fail in build.sh but build succedes
- check for git command presence, because with `set -e` it will fail without it. source.tar.gz downloaded from releases should still work

Requires #1007