### PR TITLE
Safari needs -webkit- prefix for clip-path

### DIFF
--- a/code/html/custom.css
+++ b/code/html/custom.css
@@ -267,6 +267,7 @@ span.slider {
 .inner-container:nth-child(2) {
 	background: #c00000;
 	color: white;
+	-webkit-clip-path: inset(0 50% 0 0);
 	clip-path: inset(0 50% 0 0);
 	transition: .3s cubic-bezier(0,0,0,1);
 }

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -820,10 +820,12 @@ function initCheckboxes() {
     var setCheckbox = function(element, value) {
         var container = $(".toggle-container", $(element));
         if (value) {
-            container.css("clipPath", "inset(0 0 0 50%)");
+            container.css("-webkit-clip-path", "inset(0 0 0 50%)");
+            container.css("clip-path", "inset(0 0 0 50%)");
             container.css("backgroundColor", "#00c000");
         } else {
-            container.css("clipPath", "inset(0 50% 0 0)");
+            container.css("-webkit-clip-path", "inset(0 50% 0 0)");
+            container.css("clip-path", "inset(0 50% 0 0)");
             container.css("backgroundColor", "#c00000");
         }
     }


### PR DESCRIPTION
Resolve #1028 (nvm commit in the issue, used webui and forgot how it works. forcepushed over it later)

Safari only supports clip-path with `-webkit-` prefix: https://caniuse.com/#feat=css-clip-path
I assume `clipPath` === `clip-path` and hyphen-less css property is just <s>jquery</s>js magic camelCase conversion. Still works with hyphen
