### PR TITLE
Hotfix travis release condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
 - '2.7'
 sudo: false
+conditions: v1
 cache:
   directories:
   - "~/.npm"
@@ -19,7 +20,7 @@ script:
 stages:
 - name: Test
 - name: Release
-  if: tag IS present AND branch = master
+  if: tag IS present AND tag =~ ^\d+\.\d+\.\d+$
 jobs:
   include:
   - stage: Test
@@ -42,7 +43,6 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    branch: master
     repo: xoseperez/espurna
     condition: $TRAVIS_BUILD_STAGE_NAME = Release
 notifications:


### PR DESCRIPTION
Travis pulls tag as branch, so branch === tag.
Use same regexp as earlier build.sh did, matching ^ MAJOR dot MINOR dot PATCH $

Sorry, only noticed it yesterday tweaking nightlies conditions with [this at the top for tagged builds](https://travis-ci.org/mcspr/espurna-travis-test/builds/401542380#L407):
> git clone --depth=50 --branch=20180708 https://github.com/mcspr/espurna-travis-test.git mcspr/espurna-travis-test