### PR TITLE
invert led on kmc 70011

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1580,7 +1580,7 @@
 
     // LEDs
     #define LED1_PIN            13
-    #define LED1_PIN_INVERSE    0
+    #define LED1_PIN_INVERSE    1
 
     // HLW8012
     #ifndef HLW8012_SUPPORT


### PR DESCRIPTION
When "LED Mode" = "Relay Status", KMC 70011 led was off when relay was on. Fixes by inverting led.
