### PR TITLE
Improve build.sh -ota envs detection

### DIFF
--- a/code/build.sh
+++ b/code/build.sh
@@ -27,8 +27,12 @@ if [ ${par_thread} -ge ${par_total_threads} ]; then
 fi
 
 # Available environments
-travis=$(grep env: platformio.ini | grep travis | sed 's/\[env://' | sed 's/\]/ /' | sort)
-available=$(grep env: platformio.ini | grep -v ota  | grep -v ssl  | grep -v travis | sed 's/\[env://' | sed 's/\]/ /' | sort)
+list_envs() {
+    grep env: platformio.ini | sed 's/\[env:\(.*\)\]/\1/g'
+}
+
+travis=$(list_envs | grep travis | sort)
+available=$(list_envs | grep -Ev -- '-ota$|-ssl$|^travis' | sort)
 
 # Build tools settings
 export PLATFORMIO_BUILD_FLAGS="${PLATFORMIO_BUILD_FLAGS} -DAPP_REVISION='\"$git_revision\"'"

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -545,7 +545,7 @@ lib_ignore = ${common.lib_ignore}
 build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_DUAL_R2
 extra_scripts = ${common.extra_scripts}
 
-[env:itead-sonoff-dual-ota-r2]
+[env:itead-sonoff-dual-r2-ota]
 platform = ${common.platform}
 framework = ${common.framework}
 board = ${common.board_1m}


### PR DESCRIPTION
* `env:pilotak-esp-din-v1` got caught by `ota` grep and left out of releases
* `env:itead-sonoff-dual-r2-ota` had -r2 and -ota swapped
* switch to egrep syntax and filter envs more strictly