### PR TITLE
Minor comment error in led.ino

### DIFF
--- a/code/espurna/led.ino
+++ b/code/espurna/led.ino
@@ -293,4 +293,4 @@ void ledLoop() {
 
 }
 
-#endif LED_SUPPORT
+#endif // LED_SUPPORT


### PR DESCRIPTION
> espurna/code/espurna/led.ino:296:8: warning: extra tokens at end of #endif directive [enabled by default]
> #endif LED_SUPPORT
> ^

sidenote: ...i think projenv on extra_script side *can* enable warnings just for project. need to check this...