### PR TITLE
Turn off warnings only for external code

### DIFF
--- a/code/extra_scripts.py
+++ b/code/extra_scripts.py
@@ -10,7 +10,7 @@ from platformio import util
 
 import distutils.spawn
 
-Import("env")
+Import("env", "projenv")
 
 # ------------------------------------------------------------------------------
 # Utils
@@ -85,6 +85,9 @@ def check_size(source, target, env):
 # ------------------------------------------------------------------------------
 # Hooks
 # ------------------------------------------------------------------------------
+
+# Always show warnings for project code
+projenv.ProcessUnFlags("-w")
 
 remove_float_support()
 


### PR DESCRIPTION
For example, setting `PLATFORMIO_BUILD_FLAGS=-DRELAY1_PIN=13` and then building `nodemcu-lolin` will not override default `RELAY1_PIN=12` from hardware.h and compiler is quiet about it. This warning, inhibited by -w, would be helpful:
> In file included from espurna/config/all.h:29:0,
> from /home/builder/espurna/code/espurna/espurna.ino:22:
> espurna/config/hardware.h:76:0: warning: "RELAY1_PIN" redefined [enabled by default]
> #define RELAY1_PIN          12
> ^
> <command-line>:0:0: note: this is the location of the previous definition

See [travis02](https://travis-ci.org/xoseperez/espurna/jobs/412021410) and [travis03](https://travis-ci.org/xoseperez/espurna/jobs/412021411) build logs.