### PR TITLE
Add support for VL53L1X sensor

### DIFF
--- a/code/espurna/config/arduino.h
+++ b/code/espurna/config/arduino.h
@@ -172,3 +172,4 @@
 //#define SONAR_SUPPORT          1
 //#define TMP3X_SUPPORT          1
 //#define V9261F_SUPPORT         1
+//#define VL53L1X_SUPPORT        1

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -2896,6 +2896,7 @@
     #define SI7021_SUPPORT        1
     #define PMSX003_SUPPORT       1
     #define SENSEAIR_SUPPORT1
+    #define VL53L1X_SUPPORT       1
 
 
     // A bit of lights - pin 5

--- a/code/espurna/config/progmem.h
+++ b/code/espurna/config/progmem.h
@@ -223,6 +223,9 @@ PROGMEM const char espurna_sensors[] =
     #if V9261F_SUPPORT
         "V9261F "
     #endif
+    #if VL53L1X_SUPPORT
+        "VL53L1X "
+    #endif
     "";
 
 

--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -116,6 +116,39 @@
 #define BH1750_MODE                     BH1750_CONTINUOUS_HIGH_RES_MODE
 
 //------------------------------------------------------------------------------
+// VL53L1X
+// Enable support by passing VL53L1X_SUPPORT=1 build flag
+//------------------------------------------------------------------------------
+
+#ifndef VL53L1X_SUPPORT
+#define VL53L1X_SUPPORT                              0
+#endif
+
+#ifndef VL53L1X_I2C_ADDRESS
+#define VL53L1X_I2C_ADDRESS                          0x00          // 0x00 means auto
+#endif
+
+#ifndef VL53L1X_DISTANCE_MODE
+#define VL53L1X_DISTANCE_MODE                        VL53L1X::Long // The distance mode of the sensor. Can be one of
+#endif                                                             // `VL53L1X::Short`, `VL53L1X::Medium`, or `VL53L1X::Long.
+                                                                   // Shorter distance modes are less affected by ambient light
+                                                                   // but have lower maximum ranges, especially in the dark.
+
+
+#ifndef VL53L1X_MEASUREMENT_TIMING_BUDGET
+#define VL53L1X_MEASUREMENT_TIMING_BUDGET            140000        // The time, in microseconds, allocated for a single
+                                                                   // measurement. A longer timing budget allows for more
+                                                                   // accurate at the cost of power. The minimum budget is
+                                                                   // 20 ms (20000 us) in short distance mode and 33 ms for
+                                                                   // medium and long distance modes.
+#endif
+
+#ifndef VL53L1X_INTER_MEASUREMENT_PERIOD
+#define VL53L1X_INTER_MEASUREMENT_PERIOD             50            // Period, in milliseconds, determining how
+#endif                                                             // often the sensor takes a measurement.
+
+
+//------------------------------------------------------------------------------
 // BME280/BMP280
 // Enable support by passing BMX280_SUPPORT=1 build flag
 //------------------------------------------------------------------------------
@@ -724,7 +757,8 @@
     SI7021_SUPPORT || \
     SONAR_SUPPORT || \
     TMP3X_SUPPORT || \
-    V9261F_SUPPORT \
+    V9261F_SUPPORT || \
+    VL53L1X_SUPPORT \
 )
 #endif
 
@@ -880,6 +914,10 @@
 
 #if V9261F_SUPPORT
     #include "../sensors/V9261FSensor.h"
+#endif
+
+#if VL53L1X_SUPPORT
+    #include "../sensors/VL53L1XSensor.h"
 #endif
 
 #endif // SENSOR_SUPPORT

--- a/code/espurna/config/types.h
+++ b/code/espurna/config/types.h
@@ -279,6 +279,7 @@
 #define SENSOR_SDS011_ID            0x27
 #define SENSOR_MICS2710_ID          0x28
 #define SENSOR_MICS5525_ID          0x29
+#define SENSOR_VL53L1X_ID           0x30
 
 //--------------------------------------------------------------------------------
 // Magnitudes

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -637,6 +637,15 @@ void _sensorLoad() {
     }
     #endif
 
+    #if VL53L1X_SUPPORT
+    {
+        VL53L1XSensor * sensor = new VL53L1XSensor();
+        sensor->setInterMeasurementPeriod(VL53L1X_INTER_MEASUREMENT_PERIOD);
+        sensor->setDistanceMode(VL53L1X_DISTANCE_MODE);
+        sensor->setMeasurementTimingBudget(VL53L1X_MEASUREMENT_TIMING_BUDGET);
+        _sensors.push_back(sensor);
+    }
+    #endif
 }
 
 void _sensorCallback(unsigned char i, unsigned char type, double value) {

--- a/code/espurna/sensors/VL53L1XSensor.h
+++ b/code/espurna/sensors/VL53L1XSensor.h
@@ -1,0 +1,119 @@
+// -----------------------------------------------------------------------------
+// VL53L1X Sensor over I2C
+// Copyright (C) 2017-2018 by Xose Pérez <xose dot perez at gmail dot com>
+// -----------------------------------------------------------------------------
+
+#if SENSOR_SUPPORT && VL53L1X_SUPPORT
+
+#pragma once
+
+#undef I2C_SUPPORT
+#define I2C_SUPPORT 1 // Explicitly request I2C support.
+
+
+#include "Arduino.h"
+#include "I2CSensor.h"
+#include "VL53L1X.h"
+
+class VL53L1XSensor : public I2CSensor {
+
+    public:
+
+        // ---------------------------------------------------------------------
+        // Public
+        // ---------------------------------------------------------------------
+
+        VL53L1XSensor(): I2CSensor() {
+            _count = 1;
+            _sensor_id = SENSOR_VL53L1X_ID;
+            _vl53l1x = new VL53L1X();
+        }
+
+        ~VL53L1XSensor() {
+          delete _vl53l1x;
+        }
+
+        // ---------------------------------------------------------------------
+
+        void setDistanceMode(VL53L1X::DistanceMode mode) {
+          _vl53l1x->setDistanceMode(mode);
+        }
+
+        void setMeasurementTimingBudget(uint32_t budget_us) {
+          _vl53l1x->setMeasurementTimingBudget(budget_us);
+        }
+
+        void setInterMeasurementPeriod(unsigned int period) {
+          if (_inter_measurement_period == period) return;
+          _inter_measurement_period = period;
+          _dirty = true;
+        }
+
+        // ---------------------------------------------------------------------
+        // Sensor API
+        // ---------------------------------------------------------------------
+
+        void begin() {
+          if (!_dirty) {
+            return;
+          }
+
+          // I2C auto-discover
+          unsigned char addresses[] = {0x29};
+          _address = _begin_i2c(_address, sizeof(addresses), addresses);
+          if (_address == 0) return;
+
+          _vl53l1x->setAddress(_address);
+
+          if (!_vl53l1x->init()) {
+            return;
+          };
+
+          _vl53l1x->startContinuous(_inter_measurement_period);
+
+          _ready = true;
+          _dirty = false;
+        }
+
+        // Descriptive name of the sensor
+        String description() {
+            char buffer[21];
+            snprintf(buffer, sizeof(buffer), "VL53L1X @ I2C (0x%02X)", _address);
+            return String(buffer);
+        }
+
+        // Descriptive name of the slot # index
+        String slot(unsigned char index) {
+            return description();
+        };
+
+        // Type for slot # index
+        unsigned char type(unsigned char index) {
+            if (index == 0) return MAGNITUDE_DISTANCE;
+            return MAGNITUDE_NONE;
+        }
+
+        // Pre-read hook (usually to populate registers with up-to-date data)
+        void pre() {
+            if (!_vl53l1x->dataReady()) {
+              return;
+            }
+
+            _distance = (double) _vl53l1x->read(false) / 1000.00;
+        }
+
+        // Current value for slot # index
+        double value(unsigned char index) {
+            if (index != 0) return 0;
+            return _distance;
+        }
+
+    protected:
+
+        VL53L1X * _vl53l1x = NULL;
+        unsigned int _inter_measurement_period;
+        double _distance = 0;
+
+};
+
+#endif // SENSOR_SUPPORT && VL53L1X_SUPPORT

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -47,7 +47,7 @@ function sensorName(id) {
         "Events", "PMSX003", "BMX280", "MHZ19", "SI7021",
         "SHT3X I2C", "BH1750", "PZEM004T", "AM2320 I2C", "GUVAS12SD",
         "TMP3X", "Sonar", "SenseAir", "GeigerTicks", "GeigerCPM",
-        "NTC", "SDS011", "MICS2710", "MICS5525"
+        "NTC", "SDS011", "MICS2710", "MICS5525", "VL53L1X"
     ];
     if (1 <= id && id <= names.length) {
         return names[id - 1];

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -97,6 +97,7 @@ lib_deps =
     https://github.com/LowPowerLab/RFM69#1.1.3
     https://github.com/xoseperez/Time
     NewPing
+    https://github.com/pololu/vl53l1x-arduino#1.0.1
 lib_ignore =
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Support for VL53L1X Time-of-Flight Distance Sensor Carrier with Voltage Regulator, 400cm Max.

> This sensor is a carrier/breakout board for ST’s VL53L1X laser-ranging sensor, which offers fast and accurate ranging up to 4 m. It uses the time of flight (ToF) of invisible, eye-safe laser pulses to measure absolute distances independent of ambient lighting conditions and target characteristics like color, shape, and texture (though these things will affect the maximum range). The VL53L1X also features a programmable region of interest (ROI), so the full field of view can be reduced or divided into multiple zones. Distance measurements can be read through a digital I²C interface. The board includes a 2.8 V linear regulator and level-shifters that allow it to work over an input voltage range of 2.6 V to 5.5 V, and the 0.1″ pin spacing makes it easy to use with standard solderless breadboards and 0.1″ perfboards. Learn more at [Pololu](https://www.pololu.com/product/3415).