### PR TITLE
Add support for wemos-d1mini dev board

### DIFF
--- a/code/espurna/config/arduino.h
+++ b/code/espurna/config/arduino.h
@@ -8,6 +8,7 @@
 //--------------------------------------------------------------------------------
 
 //#define NODEMCU_LOLIN
+//#define WEMOS_D1_MINI
 //#define WEMOS_D1_MINI_RELAYSHIELD
 //#define TINKERMAN_ESPURNA_H06
 //#define TINKERMAN_ESPURNA_H08

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -86,6 +86,26 @@
     #define MANUFACTURER        "NODEMCU"
     #define DEVICE              "BASIC"
 
+#elif defined(WEMOS_D1_MINI)
+
+    // Info
+    #define MANUFACTURER        "WEMOS"
+    #define DEVICE              "D1_MINI"
+
+    // Buttons
+    // No buttons on the D1 MINI alone, but defining it without adding a button doen't create problems
+    #define BUTTON1_PIN         0   // Connect a pushbutton between D3 and GND,
+                                    // it's the same as using a Wemos one button shield
+    #define BUTTON1_MODE        BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_RELAY       1
+
+    // LEDs
+    #define LED1_PIN            2
+    #define LED1_PIN_INVERSE    1
+
+    #define I2C_SDA_PIN         4  // D2
+    #define I2C_SCL_PIN         5  // D1
+
 #elif defined(WEMOS_D1_MINI_RELAYSHIELD)
 
     // Info

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -188,6 +188,18 @@ extra_scripts = ${common.extra_scripts}
 # DEVELOPMENT BOARDS
 # ------------------------------------------------------------------------------
 
+[env:wemos-d1mini]
+platform = ${common.platform}
+framework = ${common.framework}
+board = d1_mini
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags} -DWEMOS_D1_MINI -DDEBUG_FAUXMO=Serial -DNOWSAUTH
+upload_speed = ${common.upload_speed_fast}
+monitor_speed = ${common.monitor_speed}
+extra_scripts = ${common.extra_scripts}
+
 [env:wemos-d1mini-relayshield]
 platform = ${common.platform}
 framework = ${common.framework}


### PR DESCRIPTION
I don't know if this is actually required since espurna already has the `wemos-d1mini-relayshield` environment but since I don't operate my wemos with this shield, I thought it could be helpful for others to have this one available as well.