### PR TITLE
Add support for NewPing

### DIFF
--- a/code/espurna/config/arduino.h
+++ b/code/espurna/config/arduino.h
@@ -142,7 +142,7 @@
 //#define EMON_ANALOG_SUPPORT    1
 //#define EVENTS_SUPPORT         1
 //#define GUVAS12SD_SUPPORT      1
-//#define HCSR04_SUPPORT         1
+//#define SONAR_SUPPORT          1
 //#define HLW8012_SUPPORT        1
 //#define MHZ19_SUPPORT          1
 //#define NTC_SUPPORT            1

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -132,6 +132,9 @@
     #define I2C_SDA_PIN         12  // D6
     #define I2C_SCL_PIN         14  // D5
 
+    #define SONAR_TRIGGER       12  // D6
+    #define SONAR_ECHO          13  // D7
+
 #elif defined(WEMOS_D1_TARPUNA_SHIELD)
 
     // Info
@@ -2665,10 +2668,10 @@
     #define EVENTS_SUPPORT      1
     #define EVENTS_PIN          6
 
-    // HC-RS04
-    #define HCSR04_SUPPORT      1
-    #define HCSR04_TRIGGER      7
-    #define HCSR04_ECHO         8
+    // Sonar
+    #define SONAR_SUPPORT       1
+    #define SONAR_TRIGGER       7
+    #define SONAR_ECHO          8
 
     // MHZ19
     #define MHZ19_SUPPORT       1

--- a/code/espurna/config/progmem.h
+++ b/code/espurna/config/progmem.h
@@ -166,8 +166,8 @@ PROGMEM const char espurna_sensors[] =
     #if GUVAS12SD_SUPPORT
         "GUVAS12SD "
     #endif
-    #if HCSR04_SUPPORT
-        "HCSR04 "
+    #if SONAR_SUPPORT
+        "SONAR "
     #endif
     #if HLW8012_SUPPORT
         "HLW8012 "

--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -343,21 +343,29 @@
 #endif
 
 //------------------------------------------------------------------------------
-// HC-SR04
-// Enable support by passing HCSR04_SUPPORT=1 build flag
+// Sonar
+// Enable support by passing SONAR_SUPPORT=1 build flag
 //------------------------------------------------------------------------------
 
-#ifndef HCSR04_SUPPORT
-#define HCSR04_SUPPORT                  0
+#ifndef SONAR_SUPPORT
+#define SONAR_SUPPORT                  0
 #endif
 
-#ifndef HCSR04_TRIGGER
-#define HCSR04_TRIGGER                  12      // GPIO for the trigger pin (output)
+#ifndef SONAR_TRIGGER
+#define SONAR_TRIGGER                  12                            // GPIO for the trigger pin (output)
 #endif
 
-#ifndef HCSR04_ECHO
-#define HCSR04_ECHO                     14      // GPIO for the echo pin (input)
+#ifndef SONAR_ECHO
+#define SONAR_ECHO                     14                            // GPIO for the echo pin (input)
 #endif
+
+#ifndef SONAR_MAX_DISTANCE
+#define SONAR_MAX_DISTANCE             MAX_SENSOR_DISTANCE           // Max sensor distance in cm
+#endif
+
+#ifndef SONAR_ITERATIONS
+#define SONAR_ITERATIONS               5                             // Number of iterations to ping for
+#endif                                                               // error correction.
 
 //------------------------------------------------------------------------------
 // HLW8012 Energy monitor IC
@@ -628,7 +636,7 @@
     EVENTS_SUPPORT || \
     GEIGER_SUPPORT || \
     GUVAS12SD_SUPPORT || \
-    HCSR04_SUPPORT || \
+    SONAR_SUPPORT || \
     HLW8012_SUPPORT || \
     MHZ19_SUPPORT || \
     NTC_SUPPORT || \
@@ -748,8 +756,8 @@
     #include "../sensors/GUVAS12SDSensor.h"
 #endif
 
-#if HCSR04_SUPPORT
-    #include "../sensors/HCSR04Sensor.h"
+#if SONAR_SUPPORT
+    #include "../sensors/SonarSensor.h"
 #endif
 
 #if HLW8012_SUPPORT

--- a/code/espurna/config/types.h
+++ b/code/espurna/config/types.h
@@ -265,7 +265,7 @@
 #define SENSOR_GUVAS12SD_ID         0x20
 #define SENSOR_CSE7766_ID           0x21
 #define SENSOR_TMP3X_ID             0x22
-#define SENSOR_HCSR04_ID            0x23
+#define SENSOR_SONAR_ID             0x23
 #define SENSOR_SENSEAIR_ID          0x24
 #define SENSOR_GEIGER_ID            0x25
 #define SENSOR_NTC_ID               0x26

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -476,11 +476,13 @@ void _sensorLoad() {
     }
     #endif
 
-    #if HCSR04_SUPPORT
+    #if SONAR_SUPPORT
     {
-        HCSR04Sensor * sensor = new HCSR04Sensor();
-        sensor->setTrigger(HCSR04_TRIGGER);
-        sensor->setEcho(HCSR04_ECHO);
+        SonarSensor * sensor = new SonarSensor();
+        sensor->setEcho(SONAR_ECHO);
+        sensor->setIterations(SONAR_ITERATIONS);
+        sensor->setMaxDistance(SONAR_MAX_DISTANCE);
+        sensor->setTrigger(SONAR_TRIGGER);
         _sensors.push_back(sensor);
     }
     #endif

--- a/code/espurna/sensors/SonarSensor.h
+++ b/code/espurna/sensors/SonarSensor.h
@@ -3,14 +3,15 @@
 // Copyright (C) 2018 by Xose Pérez <xose dot perez at gmail dot com>
 // -----------------------------------------------------------------------------
 
-#if SENSOR_SUPPORT && HCSR04_SUPPORT
+#if SENSOR_SUPPORT && SONAR_SUPPORT
 
 #pragma once
 
 #include "Arduino.h"
 #include "BaseSensor.h"
+#include "NewPing.h"
 
-class HCSR04Sensor : public BaseSensor {
+class SonarSensor : public BaseSensor {
 
     public:
 
@@ -18,17 +19,30 @@ class HCSR04Sensor : public BaseSensor {
         // Public
         // ---------------------------------------------------------------------
 
-        HCSR04Sensor(): BaseSensor() {
+        SonarSensor(): BaseSensor() {
             _count = 1;
-            _sensor_id = SENSOR_HCSR04_ID;
+            _sensor_id = SENSOR_SONAR_ID;
         }
 
         // ---------------------------------------------------------------------
 
+        // Echo pin.
         void setEcho(unsigned char echo) {
             _echo = echo;
         }
 
+        // Number of iterations to ping in order to filter out erroneous readings
+        // using a digital filter.
+        void setIterations(unsigned int iterations) {
+            _iterations = iterations;
+        }
+
+        // Max sensor distance in centimeters.
+        void setMaxDistance(unsigned int distance) {
+            _max_distance = distance;
+        }
+
+        // Trigger pin.
         void setTrigger(unsigned char trigger) {
             _trigger = trigger;
         }
@@ -43,22 +57,28 @@ class HCSR04Sensor : public BaseSensor {
             return _trigger;
         }
 
+        unsigned int getMaxDistance() {
+            return _max_distance;
+        }
+
+        unsigned int getIterations() {
+            return _iterations;
+        }
+
         // ---------------------------------------------------------------------
         // Sensor API
         // ---------------------------------------------------------------------
 
         // Initialization method, must be idempotent
         void begin() {
-            pinMode(_echo, INPUT);
-            pinMode(_trigger, OUTPUT);
-            digitalWrite(_trigger, LOW);
+            _sonar = new NewPing(getTrigger(), getEcho(), getMaxDistance());
             _ready = true;
         }
 
         // Descriptive name of the sensor
         String description() {
-            char buffer[24];
-            snprintf(buffer, sizeof(buffer), "HCSR04 @ GPIO(%u, %u)", _trigger, _echo);
+            char buffer[23];
+            snprintf(buffer, sizeof(buffer), "Sonar @ GPIO(%u, %u)", _trigger, _echo);
             return String(buffer);
         }
 
@@ -80,28 +100,13 @@ class HCSR04Sensor : public BaseSensor {
 
         // Current value for slot # index
         double value(unsigned char index) {
+            if (index != 0) return 0;
 
-            if (index == 0) {
-
-                // Trigger pulse
-                digitalWrite(_trigger, HIGH);
-                delayMicroseconds(10);
-                digitalWrite(_trigger, LOW);
-
-                // Wait for echo pulse low-high-low
-                while ( digitalRead(_echo) == 0 ) yield();
-                unsigned long start = micros();
-                while ( digitalRead(_echo) == 1 ) yield();
-                unsigned long travel_time = micros() - start;
-
-                // Assuming a speed of sound of 340m/s
-                // Dividing by 2 since it is a round trip
-                return 340.0 * (double) travel_time / 1000000.0 / 2;
-
+            if (getIterations() > 0) {
+              return NewPing::convert_cm(_sonar->ping_median(getIterations())) / 100.0;
             }
 
-            return 0;
-
+            return _sonar->ping_cm() / 100.0;
         }
 
 
@@ -113,7 +118,10 @@ class HCSR04Sensor : public BaseSensor {
 
         unsigned char _trigger;
         unsigned char _echo;
+        unsigned int _max_distance;
+        unsigned int _iterations;
+        NewPing * _sonar = NULL;
 
 };
 
-#endif // SENSOR_SUPPORT && HCSR04_SUPPORT
+#endif // SENSOR_SUPPORT && SONAR_SUPPORT

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -46,7 +46,7 @@ function sensorName(id) {
         "HLW8012", "V9261F", "ECH1560", "Analog", "Digital",
         "Events", "PMSX003", "BMX280", "MHZ19", "SI7021",
         "SHT3X I2C", "BH1750", "PZEM004T", "AM2320 I2C", "GUVAS12SD",
-        "TMP3X", "HC-SR04", "SenseAir", "GeigerTicks", "GeigerCPM"
+        "TMP3X", "Sonar", "SenseAir", "GeigerTicks", "GeigerCPM"
     ];
     if (1 <= id && id <= names.length) {
         return names[id - 1];

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -90,6 +90,7 @@ lib_deps =
     rc-switch
     https://github.com/LowPowerLab/RFM69#1.1.3
     https://github.com/xoseperez/Time
+    NewPing
 lib_ignore =
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
* Works with many different ultrasonic sensor models: HC-SR04, SRF05,  SRF06, DYP-ME007, JSN-SR04T & Parallax PING)))™.
* Built-in digital filter method ping_median() for easy error correction (use `SONAR_ITERATIONS` build flag to configure).
* Allows setting of a maximum distance where pings beyond that distance are read as no ping or clear (use `SONAR_MAX_DISTANCE` build flag).