### PR TITLE
Fix incorrect PMS_SUPPORT reference on sensor endif

### DIFF
--- a/code/espurna/sensors/PMSX003Sensor.h
+++ b/code/espurna/sensors/PMSX003Sensor.h
@@ -322,4 +322,4 @@ class PMSX003Sensor : public BaseSensor, PMSX003 {
 
 };
 
-#endif // SENSOR_SUPPORT && PMS_SUPPORT
+#endif // SENSOR_SUPPORT && PMSX003_SUPPORT


### PR DESCRIPTION
I actually think all `PMS_` variables should be renamed to `PMSX003_` otherwise there is `PMSX003_SUPPORT` and then everything else is just `PMS_`.