### PR TITLE
Correct logic to hide White sliders

### DIFF
--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -975,9 +975,9 @@ function initChannels(num) {
     var max = num;
     if (colors) {
         max = num % 3;
-        if ((max > 0) & useWhite) {
+        if ((max > 0) & !useWhite) {
             max--;
-            if (useCCT) {
+            if (!useCCT) {
               max--;
             }
         }


### PR DESCRIPTION
This corrects the logic to hide the White channel sliders on the Status page, when "Use Color" is enabled and "Use White Channel" and "Use White Color Temperature" are disabled on the Lights configuration screen.  This has no effect when "Use Color" is disabled so sliders are visible for all channels.