### PR TITLE
add support for rf remote of arilux lc11

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1283,6 +1283,9 @@
 
     #define RF_BUTTON_COUNT 21
 
+    #define RF_BUTTON_LEARN_CODE 0x000013  // YELLOW
+    #define RF_BUTTON_LEARN_MASK 0x0000FF  // use first two bytes for home code
+
     const unsigned long RF_BUTTON[RF_BUTTON_COUNT][3] PROGMEM = {
 
         { 0x000001, RF_BUTTON_MODE_STATE,    1 },   // ON

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1246,6 +1246,10 @@
 #define RF_PIN                      14
 #endif
 
+#ifndef RF_ENABLE_PIN_INVERSE
+#define RF_ENABLE_PIN_INVERSE       0
+#endif
+
 #define RF_DEBOUNCE                 500
 #define RF_LEARN_TIMEOUT            60000
 

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1253,6 +1253,70 @@
 #define RF_DEBOUNCE                 500
 #define RF_LEARN_TIMEOUT            60000
 
+#ifndef RF_BUTTON_SET
+#define RF_BUTTON_SET               0
+#endif
+
+#if RF_SUPPORT
+//RF Remote Buttons SET 1 (for the original Remote shipped with the Arilux LC11 controller)
+#if RF_BUTTON_SET == 1
+/*
+   RF Remote
+   Encoding: Chinese Protocol 1
+   Codes provided by KmanOz (https://github.com/KmanOz)
+   +--------+--------+--------+
+   |   ON   | Toggle |   OFF  |
+   +--------+--------+--------+
+   | Speed+ | Mode+  | Bright+|
+   +--------+--------+--------+
+   | Speed- | Mode-  | Bright-|
+   +--------+--------+--------+
+   |  RED   | GREEN  |  BLUE  |
+   +--------+--------+--------+
+   | ORANGE | LT GRN | LT BLUE|
+   +--------+--------+--------+
+   | AMBER  |  CYAN  | PURPLE |
+   +--------+--------+--------+
+   | YELLOW |  PINK  | WHITE  |
+   +--------+--------+--------+
+*/
+
+    #define RF_BUTTON_COUNT 21
+
+    const unsigned long RF_BUTTON[RF_BUTTON_COUNT][3] PROGMEM = {
+
+        { 0x000001, RF_BUTTON_MODE_STATE,    1 },   // ON
+        { 0x000002, RF_BUTTON_MODE_TOGGLE,   0 },   // Toggle
+        { 0x000003, RF_BUTTON_MODE_STATE,    0 },   // OFF
+
+        { 0x000004, RF_BUTTON_MODE_SPEED,    1 },   // Speed+
+        { 0x000005, RF_BUTTON_MODE_MODE,     1 },   // Mode+
+        { 0x000006, RF_BUTTON_MODE_BRIGHTER, 1 },   // Bright+
+
+        { 0x000007, RF_BUTTON_MODE_SPEED,    0 },   // Speed-
+        { 0x000008, RF_BUTTON_MODE_MODE,     0 },   // Mode-
+        { 0x000009, RF_BUTTON_MODE_BRIGHTER, 0 },   // Bright-
+
+        { 0x00000A, RF_BUTTON_MODE_RGB, 0xFF0000 }, // RED
+        { 0x00000B, RF_BUTTON_MODE_RGB, 0x00FF00 }, // GREEN
+        { 0x00000C, RF_BUTTON_MODE_RGB, 0x0000FF }, // BLUE
+
+        { 0x00000D, RF_BUTTON_MODE_RGB, 0xFFA500 }, // ORANGE
+        { 0x00000E, RF_BUTTON_MODE_RGB, 0x90EE90 }, // LT GRN
+        { 0x00000F, RF_BUTTON_MODE_RGB, 0xADD8E6 }, // LT BLUE
+
+        { 0x000010, RF_BUTTON_MODE_RGB, 0xFFC200 }, // AMBER
+        { 0x000011, RF_BUTTON_MODE_RGB, 0x00FFFF }, // CYAN
+        { 0x000012, RF_BUTTON_MODE_RGB, 0x800080 }, // PURPLE
+
+        { 0x000013, RF_BUTTON_MODE_RGB, 0xFFFF00 }, // YELLOW
+        { 0x000014, RF_BUTTON_MODE_RGB, 0xFFC0CB }, // PINK
+        { 0x000015, RF_BUTTON_MODE_RGB, 0xFFFFFF }, // WHITE
+
+    };
+#endif
+#endif // RF_SUPPORT
+
 //--------------------------------------------------------------------------------
 // Custom RFM69 to MQTT bridge
 // Check http://tinkerman.cat/rfm69-wifi-gateway/

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1477,6 +1477,13 @@
     #define LIGHT_CH4_INVERSE   0
     #define LIGHT_CH5_INVERSE   0
 
+    // RF
+    #define RF_SUPPORT              1
+    #define RF_PIN                  15   // https://github.com/arendst/Sonoff-Tasmota/blob/development_display/sonoff/sonoff_template.h
+    #define RF_ENABLE_PIN           2    // https://github.com/arendst/Sonoff-Tasmota/pull/1310/commits/db4a3a4a1ee8964accd60e2b9acf182ab5514f62
+    #define RF_ENABLE_PIN_INVERSE   1
+    #define RF_BUTTON_SET           1
+
 #elif defined(ARILUX_E27)
 
     // Info

--- a/code/espurna/config/types.h
+++ b/code/espurna/config/types.h
@@ -183,6 +183,21 @@
 #define LIGHT_EFFECT_FADE           3
 #define LIGHT_EFFECT_SMOOTH         4
 
+// -----------------------------------------------------------------------------
+// RF
+// -----------------------------------------------------------------------------
+
+// RF Button modes
+#define RF_BUTTON_MODE_NONE         0
+#define RF_BUTTON_MODE_RGB          1
+#define RF_BUTTON_MODE_HSV          2
+#define RF_BUTTON_MODE_BRIGHTER     3
+#define RF_BUTTON_MODE_STATE        4
+#define RF_BUTTON_MODE_EFFECT       5
+#define RF_BUTTON_MODE_TOGGLE       6
+#define RF_BUTTON_MODE_MODE         7
+#define RF_BUTTON_MODE_SPEED        8
+
 //------------------------------------------------------------------------------
 // RESET
 //------------------------------------------------------------------------------

--- a/code/espurna/rf.ino
+++ b/code/espurna/rf.ino
@@ -175,8 +175,19 @@ void rfLoop() {
 
 void rfSetup() {
 
+    #if RF_ENABLE_PIN
+        pinMode(RF_ENABLE_PIN, OUTPUT);
+        #if RF_ENABLE_PIN_INVERSE == 1
+            digitalWrite(RF_ENABLE_PIN,LOW);
+            DEBUG_MSG_P(PSTR("[RF] RF enable PIN on GPIO %u set to LOW\n"), RF_ENABLE_PIN);
+        #else
+            digitalWrite(RF_ENABLE_PIN,HIGH);
+            DEBUG_MSG_P(PSTR("[RF] RF enable PIN on GPIO %u set to HIGH\n"), RF_ENABLE_PIN);
+        #endif
+    #endif
+
     _rfModem = new RCSwitch();
-    _rfModem->enableReceive(RF_PIN);
+    _rfModem->enableReceive(digitalPinToInterrupt(RF_PIN));
     DEBUG_MSG_P(PSTR("[RF] RF receiver on GPIO %u\n"), RF_PIN);
 
     #if WEB_SUPPORT


### PR DESCRIPTION
Based on information found in issue #469.

Hardware config is just for LC11 but other models should work too.

Button functions:
- On/Off, Brightness and the color buttons buttons do the corresponding action
- Toggle switches between On and Off

And in addition (but maybe a bit experimental):
- S+/- changes the color saturation
- M+/- changes the white color temperature

The individual home code of a remote can be learned by pressing the yellow button for about 10 seconds.