### PR TITLE
Fix homecube 3rd led setting

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -2529,7 +2529,7 @@
     // Red
     #define LED3_PIN                    0
     #define LED3_PIN_INVERSE            0
-    #define LED2_MODE                   LED_MODE_OFF
+    #define LED3_MODE                   LED_MODE_OFF
 
     // HJL01 / BL0937
     #ifndef HLW8012_SUPPORT


### PR DESCRIPTION
> from espurna/code/espurna/espurna.ino:22:
> espurna/config/hardware.h:2532:0: warning: "LED2_MODE" redefined [enabled by default]
> #define LED2_MODE                   LED_MODE_OFF
> ^ 
> espurna/config/hardware.h:2527:0: note: this is the location of the previous definition
> #define LED2_MODE                   LED_MODE_RELAY
> ^