### PR TITLE
Really track changed input in WebUI

### DIFF
--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -300,10 +300,18 @@ function sendConfig(data) {
     websock.send(JSON.stringify({config: data}));
 }
 
-function resetOriginals() {
+function setOriginalsFromValues(force) {
+    var force = (true === force);
     $("input,select").each(function() {
-        $(this).attr("original", $(this).val());
+        var initial = (null === $(this).attr("original"));
+        if (force || initial) {
+            $(this).attr("original", $(this).val());
+        }
     });
+}
+
+function resetOriginals() {
+    setOriginalsFromValues(true);
     numReboot = numReconnect = numReload = 0;
 }
 
@@ -1458,7 +1466,7 @@ function processData(data) {
         generateAPIKey();
     }
 
-    resetOriginals();
+    setOriginalsFromValues();
 
 }
 

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -182,8 +182,8 @@ function validateForm(form) {
     var re_hostname = new RegExp('^(?!-)[A-Za-z0-9-]{0,30}[A-Za-z0-9]$');
 
     var hostname = $("input[name='hostname']", form);
-    var hasChanged = hostname.attr("hasChanged") || 0;
-    if (0 === hasChanged) {
+    var hasChanged = ("true" === hostname.attr("hasChanged"));
+    if (!hasChanged) {
         return true;
     }
 
@@ -1472,27 +1472,27 @@ function hasChanged() {
         newValue = $(this).val();
         originalValue = $(this).attr("original");
     }
-    var hasChanged = $(this).attr("hasChanged") || 0;
+    var hasChanged = ("true" === $(this).attr("hasChanged"));
     var action = $(this).attr("action");
 
     if (typeof originalValue === "undefined") { return; }
     if ("none" === action) { return; }
 
     if (newValue !== originalValue) {
-        if (0 === hasChanged) {
+        if (!hasChanged) {
             ++numChanged;
             if ("reconnect" === action) { ++numReconnect; }
             if ("reboot" === action) { ++numReboot; }
             if ("reload" === action) { ++numReload; }
-            $(this).attr("hasChanged", 1);
+            $(this).attr("hasChanged", true);
         }
     } else {
-        if (1 === hasChanged) {
+        if (hasChanged) {
             --numChanged;
             if ("reconnect" === action) { --numReconnect; }
             if ("reboot" === action) { --numReboot; }
             if ("reload" === action) { --numReload; }
-            $(this).attr("hasChanged", 0);
+            $(this).attr("hasChanged", false);
         }
     }
 


### PR DESCRIPTION
two bugs in one, closely related

'processData' called 'resetOriginals' every ws message, which resulted in zeroing numReboot/numReload/numReconnect and changing 'original' to user-edited value at random intervals.

i assume 'haschanged' was intended to track 'original' value until it is saved. but it only did so the first time input was edited, because attr() returns text and === comparison with integer fails on both branches.