### PR TITLE
WakeUp PMSX003 sensor on first reading cycle

### DIFF
--- a/code/espurna/sensors/PMSX003Sensor.h
+++ b/code/espurna/sensors/PMSX003Sensor.h
@@ -269,6 +269,9 @@ class PMSX003Sensor : public BaseSensor, PMSX003 {
                     }
                 } else {
                    readCycle  = -1;
+                   if (_readCount == 1) {
+                       wakeUp();
+                   }
                 }
             #endif
 


### PR DESCRIPTION
Call wakeUp PMS on first reading cycle to avoid not data in a long period (e.g. PMS entered sleeping and then espurna reboot, we should wake up PMS right now)