### PR TITLE
Define HOMEASSISTANT_PAYLOAD_AVAILABLE for payload_available (instead of HOMEASSISTANT_PAYLOAD_ON)

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -919,6 +919,14 @@
 #define HOMEASSISTANT_PAYLOAD_OFF   "0"         // Payload for OFF and unavailable messages
 #endif
 
+#ifndef HOMEASSISTANT_PAYLOAD_AVAILABLE
+#define HOMEASSISTANT_PAYLOAD_AVAILABLE     "1" // Payload for available messages
+#endif
+
+#ifndef HOMEASSISTANT_PAYLOAD_NOT_AVAILABLE
+#define HOMEASSISTANT_PAYLOAD_NOT_AVAILABLE "0" // Payload for available messages
+#endif
+
 // -----------------------------------------------------------------------------
 // INFLUXDB
 // -----------------------------------------------------------------------------

--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -87,8 +87,8 @@ void _haSendSwitch(unsigned char i, JsonObject& config) {
         config["payload_on"] = String(HOMEASSISTANT_PAYLOAD_ON);
         config["payload_off"] = String(HOMEASSISTANT_PAYLOAD_OFF);
         config["availability_topic"] = mqttTopic(MQTT_TOPIC_STATUS, false);
-        config["payload_available"] = String(HOMEASSISTANT_PAYLOAD_ON);
-        config["payload_not_available"] = String(HOMEASSISTANT_PAYLOAD_OFF);
+        config["payload_available"] = String(HOMEASSISTANT_PAYLOAD_AVAILABLE);
+        config["payload_not_available"] = String(HOMEASSISTANT_PAYLOAD_NOT_AVAILABLE);
     }
 
     #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE


### PR DESCRIPTION
Since `payload_on` and `payload_available` is not the same on HomeAssistant default implementation, I suggest use HOMEASSISTANT_PAYLOAD_AVAILABLE for payload_available (instead of HOMEASSISTANT_PAYLOAD_ON).