### PR TITLE
Rename cont_t for Core 2.4.2 and higher

### DIFF
--- a/code/espurna/config/all.h
+++ b/code/espurna/config/all.h
@@ -35,7 +35,3 @@
 #include "sensors.h"
 #include "webui.h"
 #include "progmem.h"
-
-#ifdef USE_CORE_VERSION_H
-#include "core_version.h"
-#endif

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -2,6 +2,7 @@
 #include <ArduinoJson.h>
 #include <functional>
 #include <pgmspace.h>
+#include <core_version.h>
 
 extern "C" {
     #include "user_interface.h"

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -6,10 +6,30 @@ Copyright (C) 2017-2018 by Xose Pérez <xose dot perez at gmail dot com>
 
 */
 
+// Core version 2.4.2 and higher changed the cont_t structure to a pointer:
+// https://github.com/esp8266/Arduino/commit/5d5ea92a4d004ab009d5f642629946a0cb8893dd#diff-3fa12668b289ccb95b7ab334833a4ba8L35
+#if defined(ARDUINO_ESP8266_RELEASE_2_3_0) \
+    || defined(ARDUINO_ESP8266_RELEASE_2_4_0) \
+    || defined(ARDUINO_ESP8266_RELEASE_2_4_1)
 extern "C" {
     #include <cont.h>
     extern cont_t g_cont;
+
 }
+
+unsigned int getFreeStack() {
+    return cont_get_free_stack(&g_cont);
+}
+#else
+extern "C" {
+    #include <cont.h>
+    extern cont_t* g_pcont;
+}
+
+unsigned int getFreeStack() {
+    return cont_get_free_stack(g_pcont);
+}
+#endif // defined(ARDUINO_ESP8266_RELEASE_2_3_0/2_4_0/2_4_1)
 
 #include <Ticker.h>
 Ticker _defer_reset;
@@ -79,10 +99,6 @@ unsigned int getInitialFreeHeap() {
 
 unsigned int getUsedHeap() {
     return getInitialFreeHeap() - getFreeHeap();
-}
-
-unsigned int getFreeStack() {
-    return cont_get_free_stack(&g_cont);
 }
 
 String getEspurnaModules() {

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -18,6 +18,7 @@ platform_150 = espressif8266@1.5.0
 platform_160 = espressif8266@1.6.0
 platform_173 = espressif8266@1.7.3
 platform_180 = espressif8266@1.8.0
+platform_latest = ${common.platform_180}
 platform = ${common.platform_150}
 
 # ------------------------------------------------------------------------------
@@ -193,7 +194,7 @@ monitor_speed = ${common.monitor_speed}
 extra_scripts = ${common.extra_scripts}
 
 [env:travis02]
-platform = ${common.platform_173}
+platform = ${common.platform_latest}
 framework = ${common.framework}
 board = ${common.board_4m}
 board_build.flash_mode = ${common.flash_mode}
@@ -204,7 +205,7 @@ monitor_speed = ${common.monitor_speed}
 extra_scripts = ${common.extra_scripts}
 
 [env:travis03]
-platform = ${common.platform_173}
+platform = ${common.platform_latest}
 framework = ${common.framework}
 board = ${common.board_4m}
 board_build.flash_mode = ${common.flash_mode}


### PR DESCRIPTION
https://github.com/xoseperez/espurna/commit/88e2eccccef3846845c2b43d5b58e3a24c61ef2d#diff-bd6de869be74ac5eaf90f23e4b75b857 added extern g_cont:
https://github.com/xoseperez/espurna/blob/88e2eccccef3846845c2b43d5b58e3a24c61ef2d/code/espurna/utils.ino#L9-L12
but it is no longer defined in 'master' of esp8266/Arduino, now it is `cont_t* g_pcont`:
https://github.com/esp8266/Arduino/commit/5d5ea92a4d004ab009d5f642629946a0cb8893dd#diff-3fa12668b289ccb95b7ab334833a4ba8L35

This PR:
- added define check for core version when using g_cont/g_pcont
- updated travis envs to use newest platform, so this is tested

