### PR TITLE
(partial) fix for YiDian XS-SSA05 configs

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1932,7 +1932,7 @@
 
     // Buttons
     #define BUTTON1_PIN			13
-    #define BUTTON1_MODE		BUTTON_PUSHBUTTON
+    #define BUTTON1_MODE		BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
     #define BUTTON1_RELAY		1
 
     // Relays
@@ -1940,9 +1940,14 @@
     #define RELAY1_TYPE			RELAY_TYPE_NORMAL
 
     // LEDs
-    #define LED1_PIN			4
-    #define LED1_PIN_INVERSE	0
-
+    #define LED1_PIN			0  // red
+    #define LED1_PIN_INVERSE	1
+    #define LED1_MODE           LED_MODE_WIFI
+    
+    #define LED2_PIN			15  // blue
+    #define LED2_PIN_INVERSE	1
+    #define LED2_MODE           LED_MODE_RELAY
+    
     // HLW8012
     #ifndef HLW8012_SUPPORT
     #define HLW8012_SUPPORT     1
@@ -1953,6 +1958,8 @@
 
     #define HLW8012_CURRENT_R               0.001            // Current resistor
     #define HLW8012_VOLTAGE_R_UP            ( 2 * 1200000 )  // Upstream voltage resistor
+    #define HLW8012_SEL_CURRENT             LOW
+    #define HLW8012_INTERRUPT_ON            FALLING
 
 // -----------------------------------------------------------------------------
 // TONBUX XS-SSA06

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1956,10 +1956,11 @@
     #define HLW8012_CF1_PIN     14
     #define HLW8012_CF_PIN      5
 
-    #define HLW8012_CURRENT_R               0.001            // Current resistor
-    #define HLW8012_VOLTAGE_R_UP            ( 2 * 1200000 )  // Upstream voltage resistor
-    #define HLW8012_SEL_CURRENT             LOW
-    #define HLW8012_INTERRUPT_ON            FALLING
+    #define HLW8012_SEL_CURRENT         LOW
+    #define HLW8012_CURRENT_RATIO       25740
+    #define HLW8012_VOLTAGE_RATIO       313400
+    #define HLW8012_POWER_RATIO         3414290
+    #define HLW8012_INTERRUPT_ON        FALLING
 
 // -----------------------------------------------------------------------------
 // TONBUX XS-SSA06


### PR DESCRIPTION
Developed against a [SM800-type device](https://fccid.io/2ANOO-SM800/Internal-Photos/Internal-Photos-3601477) (more-or-less equivalent Amazon products [1](https://www.amazon.com/Monitoring-Control-Smartphone-Compatibles-Assistant/dp/B0793RSYTV) [2](https://www.amazon.com/gp/product/B07837B9C1)), which has a similar circuit structure (ESP8266 module, pin assignments, LED polarity, switch polarity, energy monitoring chips and resistor values) to the XS-SSA05.

Changes:
- The LEDs are active-low (they are connected to the MCU pin on the low side)
- There are two LEDs, one red, one blue. I don't know if you have a convention for which one should be LED1 (which seems the only one editable from the web UI)
- The switch is active-low (pressing shorts to ground, pulled high by external circuitry)
- The energy monitor is a HJL-01 chip, and the SEL / interrupt polarity constants are changed accordingly. The voltage readings seem accurate.

Problems remaining:
- The energy monitor reading is highly inaccurate (comparing against a Kill-A-Watt P4400.01)
  - The current reads about half of what the Kill-A-Watt reads (and the apparent power is ~half of the Kill-A-Watt in VA mode)
  - The active power is twice of what the Kill-A-Watt reads in Watt mode
  - The reactive power just reads zero, even on loads where the Kill-A-Watt reports a PF of <0.6. This might just be an artifact of the active/apparent power being super off
- **This suggests that there's some different calibration constants between the HJL-01 and HLW8012 chips. I can't find any information for the HJL-01 chip, though...**