### PR TITLE
Add hyphen to valid wifi password chars

### DIFF
--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -155,7 +155,7 @@ function validatePassword(password) {
     // https://en.wikipedia.org/wiki/Wi-Fi_Protected_Access#Target_users_(authentication_key_distribution)
     // https://github.com/xoseperez/espurna/issues/1151
 
-    var re_password = /^(?=.*[A-Z\d])(?=.*[a-z])[\w~!@#$%^&*\(\)<>,.\?;:{}\[\]\\|]{8,63}$/;
+    var re_password = /^(?=.*[A-Z\d])(?=.*[a-z])[\w~!@#$%^&*\(\)<>,.\?;:{}\[\]\\|-]{8,63}$/;
     return (
         (password !== undefined)
         && (typeof password === "string")


### PR DESCRIPTION
Currently is missing in the validation regexp, but it is acceptable at WPA2 passwords

