### PR TITLE
Adding support for MAXCIO W-DE004 Plugs 

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1921,6 +1921,30 @@
     #define HLW8012_VOLTAGE_R_UP            ( 2 * 1000000 )  // Upstream voltage resistor
 
 // -----------------------------------------------------------------------------
+// Maxcio W-DE004
+// -----------------------------------------------------------------------------
+
+#elif defined(MAXCIO_WDE004)
+
+    // Info
+    #define MANUFACTURER		"MAXCIO"
+    #define DEVICE				"WDE004"
+
+    // Buttons
+    #define BUTTON1_PIN			1
+    #define BUTTON1_MODE		BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_RELAY		1
+
+    // Relays
+    #define RELAY1_PIN			14
+    #define RELAY1_TYPE			RELAY_TYPE_NORMAL
+
+    // LEDs
+    #define LED1_PIN			13
+    #define LED1_PIN_INVERSE	1
+
+
+// -----------------------------------------------------------------------------
 // YiDian XS-SSA05
 // -----------------------------------------------------------------------------
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -2010,6 +2010,19 @@ upload_port = ${common.upload_port}
 upload_flags = ${common.upload_flags}
 extra_scripts = ${common.extra_scripts}
 
+[env:maxcio-wde004-ota]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board_1m}
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m0m} -DMAXCIO_WDE004
+upload_speed = ${common.upload_speed}
+upload_port = ${common.upload_port}
+upload_flags = ${common.upload_flags}
+extra_scripts = ${common.extra_scripts}
+
 [env:yidian-xsssa05]
 platform = ${common.platform}
 framework = ${common.framework}


### PR DESCRIPTION
This is based on Michael Herwerth´s work, see attached file (unfortunately in German, but pictures are quite informative. 
[Umbauanleitung Steckdosen.pdf](https://github.com/kerk1v/espurna/files/2544068/Umbauanleitung.Steckdosen.pdf)

The way of connecting 3.3V for flashing is missing, he feeds power to the device via the USB port. 