### PR TITLE
Add support for new Blitzwolf BW-SHP2 board version (V2.3)

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -2576,6 +2576,47 @@
     #define HLW8012_POWER_RATIO         3414290
     #define HLW8012_INTERRUPT_ON        FALLING
 
+// -----------------------------------------------------------------------------
+// Same as the above but new board version marked V2.3
+// -----------------------------------------------------------------------------
+
+#elif defined(BLITZWOLF_BWSHP2_V23)
+
+    // Info
+    #define MANUFACTURER                "BLITZWOLF"
+    #define DEVICE                      "BWSHP2V2.3"
+
+    // Buttons
+    #define BUTTON1_PIN                 3
+    #define BUTTON1_MODE                BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_RELAY               1
+
+    // Relays
+    #define RELAY1_PIN                  14
+    #define RELAY1_TYPE                 RELAY_TYPE_NORMAL
+
+    // LEDs
+    #define LED1_PIN                    1
+    #define LED1_PIN_INVERSE            1
+    #define LED2_PIN                    13
+    #define LED2_PIN_INVERSE            1
+    #define LED2_MODE                   LED_MODE_FINDME
+    #define LED2_RELAY                  1
+
+    // HJL01 / BL0937
+    #ifndef HLW8012_SUPPORT
+    #define HLW8012_SUPPORT             1
+    #endif
+    #define HLW8012_SEL_PIN             12
+    #define HLW8012_CF1_PIN             5
+    #define HLW8012_CF_PIN              4
+
+    #define HLW8012_SEL_CURRENT         LOW
+    #define HLW8012_CURRENT_RATIO       25740
+    #define HLW8012_VOLTAGE_RATIO       313400
+    #define HLW8012_POWER_RATIO         3414290
+    #define HLW8012_INTERRUPT_ON        FALLING
+
 // ----------------------------------------------------------------------------------------
 //  Homecube 16A is similar but some pins differ and it also has RGB LEDs
 //  https://www.amazon.de/gp/product/B07D7RVF56/ref=oh_aui_detailpage_o00_s01?ie=UTF8&psc=1

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -2551,6 +2551,32 @@ upload_port = ${common.upload_port}
 upload_flags = ${common.upload_flags}
 extra_scripts = ${common.extra_scripts}
 
+[env:blitzwolf-bwshp2-v23]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board_1m}
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m0m} -DBLITZWOLF_BWSHP2_V23
+upload_speed = ${common.upload_speed}
+monitor_speed = ${common.monitor_speed}
+extra_scripts = ${common.extra_scripts}
+
+[env:blitzwolf-bwshp2-v23-ota]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board_1m}
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m0m} -DBLITZWOLF_BWSHP2_V23
+upload_speed = ${common.upload_speed}
+monitor_speed = ${common.monitor_speed}
+upload_port = ${common.upload_port}
+upload_flags = ${common.upload_flags}
+extra_scripts = ${common.extra_scripts}
+
 [env:homecube-16a]
 platform = ${common.platform}
 framework = ${common.framework}


### PR DESCRIPTION
Fixes #1350 
The Blitzwolf BW-SHP2 (and others) comes with a new board version marked V2.3.
Thanks to @Valcob for the suggested settings