### PR TITLE
Use correct arguments for stat on macOS

### DIFF
--- a/code/build.sh
+++ b/code/build.sh
@@ -9,6 +9,13 @@ is_git() {
     return 0
 }
 
+stat_bytes() {
+    case "$(uname -s)" in
+        Darwin) stat -f %z "$1";;
+        *) stat -c %s "$1";;
+    esac
+}
+
 # Script settings
 
 destination=../firmware
@@ -104,7 +111,7 @@ build_environments() {
     for environment in $environments; do
         echo -n "* espurna-$version-$environment.bin --- "
         platformio run --silent --environment $environment || exit 1
-        stat -c %s .pioenvs/$environment/firmware.bin
+        stat_bytes .pioenvs/$environment/firmware.bin
         [[ "${TRAVIS_BUILD_STAGE_NAME}" = "Test" ]] || \
             mv .pioenvs/$environment/firmware.bin $destination/espurna-$version/espurna-$version-$environment.bin
     done


### PR DESCRIPTION
`stat` is a bit weird on `macOS`, requiring the format to be passed using `-f` (instead of `-c`) and representing size in bytes as `%z` (instead of `%s`).

This PR adds some simple OS detection to execute `stat -f %z` on macOS, falling back to `stat -c %s`  on non-darwin systems.

---

Without this fix, building on macOS fails with the following output;

```Text
$ ./build.sh generic
--------------------------------------------------------------
ESPURNA FIRMWARE BUILDER
Building for version 1.13.3-a89b511f
--------------------------------------------------------------
Building web interface...
[20:07:10] Using gulpfile code/gulpfile.js
[20:07:10] Starting 'webui'...
[20:07:10] Starting 'webui_small'...
[20:07:10] Starting 'webui_sensor'...
[20:07:10] Starting 'webui_light'...
[20:07:10] Starting 'webui_rfbridge'...
[20:07:10] Starting 'webui_rfm69'...
[20:07:10] Starting 'webui_all'...
Image index.small.html.gz 	size: 50662 bytes
Image index.rfbridge.html.gz 	size: 51539 bytes
Image index.sensor.html.gz 	size: 52648 bytes
Image index.light.html.gz 	size: 59440 bytes
Image index.all.html.gz 	size: 62324 bytes
[20:07:21] Finished 'webui_small' after 11 s
[20:07:21] Finished 'webui_rfbridge' after 11 s
[20:07:21] Finished 'webui_sensor' after 11 s
Image index.rfm69.html.gz 	size: 81069 bytes
[20:07:21] Finished 'webui_light' after 11 s
[20:07:21] Finished 'webui_all' after 11 s
[20:07:21] Finished 'webui_rfm69' after 11 s
[20:07:21] Finished 'webui' after 11 s
[20:07:21] Starting 'default'...
[20:07:21] Finished 'default' after 18 μs
--------------------------------------------------------------
Building firmware images...
* espurna-1.13.3-generic.bin --- stat: illegal option -- c
usage: stat [-FlLnqrsx] [-f format] [-t timefmt] [file ...]
```
