### PR TITLE
Stubborn HASS MQTT Discovery

### DIFF
--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -8,6 +8,14 @@ extern "C" {
     #include "user_interface.h"
 }
 
+// ref: esp8266/Arduino/cores/esp8266/pgmspace.h @ 2.5.0
+// __STRINGIZE && __STRINGIZE_NX && PROGMEM definitions port
+#define __TO_STR_(A) #A
+#define __TO_STR(A) __TO_STR_(A)
+
+#undef PROGMEM
+#define PROGMEM      __attribute__((section( "\".irom.text." __FILE__ "." __TO_STR(__LINE__) "."  __TO_STR(__COUNTER__) "\"")))
+
 // -----------------------------------------------------------------------------
 // API
 // -----------------------------------------------------------------------------

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -72,6 +72,17 @@ extern "C" {
 #endif
 
 // -----------------------------------------------------------------------------
+// Home Assistant
+// -----------------------------------------------------------------------------
+#if HOMEASSISTANT_SUPPORT
+    enum class ha_discovery_t;
+    enum class ha_entity_t;
+
+    typedef void (*ha_send_f)(unsigned char, JsonObject&);
+    typedef uint8_t (*ha_count_f)();
+#endif
+
+// -----------------------------------------------------------------------------
 // EEPROM_ROTATE
 // -----------------------------------------------------------------------------
 #include <EEPROM_Rotate.h>

--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -61,9 +61,9 @@ class HaDiscovery {
 
 public:
     HaDiscovery(const String& prefix, const String& name) :
+        index{0},
         prefix(prefix),
         name(name),
-        index{0},
         topic_length(10 + 6 + 4 + 3 + name.length() + prefix.length())
     {}
 
@@ -76,7 +76,7 @@ public:
 
         String entity = _haEntity(entity_type);
         uint8_t idx = static_cast<uint8_t>(entity_type);
-        if ((idx + 1) > index.size()) index.resize((idx + 1));
+        if ((idx + 1u) > index.size()) index.resize((idx + 1));
 
         for (; index[idx]<entities_limit; index[idx] += 1) {
             topic = prefix + "/" + entity + "/" + name + "_" + String(index[idx]) + F("/config");

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -496,25 +496,29 @@ String mqttTopic(const char * magnitude, unsigned int index, bool is_set) {
 
 // -----------------------------------------------------------------------------
 
-void mqttSendRaw(const char * topic, const char * message, bool retain) {
+bool mqttSendRaw(const char * topic, const char * message, bool retain) {
+    bool res = false;
 
     if (_mqtt.connected()) {
         #if MQTT_USE_ASYNC
             unsigned int packetId = _mqtt.publish(topic, _mqtt_qos, retain, message);
             DEBUG_MSG_P(PSTR("[MQTT] Sending %s => %s (PID %d)\n"), topic, message, packetId);
+            res = (packetId > 0);
         #else
-            _mqtt.publish(topic, message, retain);
+            res = _mqtt.publish(topic, message, retain);
             DEBUG_MSG_P(PSTR("[MQTT] Sending %s => %s\n"), topic, message);
         #endif
     }
+
+    return res;
 }
 
 
-void mqttSendRaw(const char * topic, const char * message) {
-    mqttSendRaw (topic, message, _mqtt_retain);
+bool mqttSendRaw(const char * topic, const char * message) {
+    return mqttSendRaw (topic, message, _mqtt_retain);
 }
 
-void mqttSend(const char * topic, const char * message, bool force, bool retain) {
+bool mqttSend(const char * topic, const char * message, bool force, bool retain) {
 
     bool useJson = force ? false : _mqtt_use_json;
 
@@ -532,32 +536,34 @@ void mqttSend(const char * topic, const char * message, bool force, bool retain)
 
     // Send it right away
     } else {
-        mqttSendRaw(mqttTopic(topic, false).c_str(), message, retain);
+        return mqttSendRaw(mqttTopic(topic, false).c_str(), message, retain);
 
     }
 
+    return false;
+
 }
 
-void mqttSend(const char * topic, const char * message, bool force) {
-    mqttSend(topic, message, force, _mqtt_retain);
+bool mqttSend(const char * topic, const char * message, bool force) {
+    return mqttSend(topic, message, force, _mqtt_retain);
 }
 
-void mqttSend(const char * topic, const char * message) {
-    mqttSend(topic, message, false);
+bool mqttSend(const char * topic, const char * message) {
+    return mqttSend(topic, message, false);
 }
 
-void mqttSend(const char * topic, unsigned int index, const char * message, bool force, bool retain) {
+bool mqttSend(const char * topic, unsigned int index, const char * message, bool force, bool retain) {
     char buffer[strlen(topic)+5];
     snprintf_P(buffer, sizeof(buffer), PSTR("%s/%d"), topic, index);
-    mqttSend(buffer, message, force, retain);
+    return mqttSend(buffer, message, force, retain);
 }
 
-void mqttSend(const char * topic, unsigned int index, const char * message, bool force) {
-    mqttSend(topic, index, message, force, _mqtt_retain);
+bool mqttSend(const char * topic, unsigned int index, const char * message, bool force) {
+    return mqttSend(topic, index, message, force, _mqtt_retain);
 }
 
-void mqttSend(const char * topic, unsigned int index, const char * message) {
-    mqttSend(topic, index, message, false);
+bool mqttSend(const char * topic, unsigned int index, const char * message) {
+    return mqttSend(topic, index, message, false);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
`AsyncMqttClient::publish` method returns packet id > 0 when it is actually accepted by the network layer. worked for me with both QoS 0 (PID 1 is success) and QoS 1.
limited testing with lwip2/536mss+git, lwip2/1460mss+git and lwip1.4+2.3.0
pubsubclient works the same way, returning bool right from the .publish method.

Modified mqttSend... variants to check PID validity and check what they return in the discovery sender. Both ha relays and sensors methods modified into a helper class to store last sent internal array ID.

Additionally, this approach should also be applied to the config generator.

Depends on #1374 *// F() could be removed for it to work without it*
Fixes #1346
cc @peterhoeg 