### PR TITLE
Port PROGMEM from 2.5.0

### DIFF
--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -8,6 +8,14 @@ extern "C" {
     #include "user_interface.h"
 }
 
+// ref: esp8266/Arduino/cores/esp8266/pgmspace.h @ 2.5.0
+// __STRINGIZE && __STRINGIZE_NX && PROGMEM definitions port
+#define __TO_STR_(A) #A
+#define __TO_STR(A) __TO_STR_(A)
+
+#undef PROGMEM
+#define PROGMEM      __attribute__((section( "\".irom.text." __FILE__ "." __TO_STR(__LINE__) "."  __TO_STR(__COUNTER__) "\"")))
+
 // -----------------------------------------------------------------------------
 // API
 // -----------------------------------------------------------------------------

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -8,7 +8,7 @@ extern "C" {
     #include "user_interface.h"
 }
 
-// ref: esp8266/Arduino/cores/esp8266/pgmspace.h @ 2.5.0
+// ref: esp8266/Arduino/core/esp8266/pgmspace.h @ 2.5.0
 // __STRINGIZE && __STRINGIZE_NX && PROGMEM definitions port
 #define __TO_STR_(A) #A
 #define __TO_STR(A) __TO_STR_(A)

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -1,20 +1,46 @@
 #include <Arduino.h>
 #include <ArduinoJson.h>
 #include <functional>
-#include <pgmspace.h>
 #include <core_version.h>
 
 extern "C" {
     #include "user_interface.h"
 }
 
-// ref: esp8266/Arduino/core/esp8266/pgmspace.h @ 2.5.0
+// -----------------------------------------------------------------------------
+// PROGMEM
+// -----------------------------------------------------------------------------
+
+#include <pgmspace.h>
+
+// ref: https://github.com/esp8266/Arduino/blob/master/tools/sdk/libc/xtensa-lx106-elf/include/sys/pgmspace.h
 // __STRINGIZE && __STRINGIZE_NX && PROGMEM definitions port
+
+// Do not replace macros unless running version older than 2.5.0
+#if defined(ARDUINO_ESP8266_RELEASE_2_3_0) \
+    || defined(ARDUINO_ESP8266_RELEASE_2_4_0) \
+    || defined(ARDUINO_ESP8266_RELEASE_2_4_1) \
+    || defined(ARDUINO_ESP8266_RELEASE_2_4_2)
+
+// Quoting esp8266/Arduino comments:
+// "Since __section__ is supposed to be only use for global variables,
+// there could be conflicts when a static/inlined function has them in the
+// same file as a non-static PROGMEM object.
+// Ref: https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Variable-Attributes.html
+// Place each progmem object into its own named section, avoiding conflicts"
+
 #define __TO_STR_(A) #A
 #define __TO_STR(A) __TO_STR_(A)
 
 #undef PROGMEM
-#define PROGMEM      __attribute__((section( "\".irom.text." __FILE__ "." __TO_STR(__LINE__) "."  __TO_STR(__COUNTER__) "\"")))
+#define PROGMEM __attribute__((section( "\".irom.text." __FILE__ "." __TO_STR(__LINE__) "."  __TO_STR(__COUNTER__) "\"")))
+
+// "PSTR() macro modified to start on a 32-bit boundary.  This adds on average
+// 1.5 bytes/string, but in return memcpy_P and strcpy_P will work 4~8x faster"
+#undef PSTR
+#define PSTR(s) (__extension__({static const char __c[] __attribute__((__aligned__(4))) PROGMEM = (s); &__c[0];}))
+
+#endif
 
 // -----------------------------------------------------------------------------
 // API


### PR DESCRIPTION
Compilation no longer fails when using F() / DEBUG_MSG_P in some specific cases like sensor classes:
```cpp
/home/builder/.platformio/packages/framework-arduinoespressif8266@1.20300.1/cores/esp8266/pgmspace.h:21:51: error: __c causes a section type conflict with __c
#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
^
```
#1370 as an example of where this did happen in class method