### PR TITLE
Add warning about TELNET_PASSWORD

### DIFF
--- a/code/espurna/config/all.h
+++ b/code/espurna/config/all.h
@@ -28,6 +28,7 @@
 #include "arduino.h"
 #include "hardware.h"
 #include "defaults.h"
+#include "deprecated.h"
 #include "general.h"
 #include "dependencies.h"
 #include "debug.h"

--- a/code/espurna/config/deprecated.h
+++ b/code/espurna/config/deprecated.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// 1.13.3 added TELNET_PASSWORD build-only flag
+// 1.13.4 replaces it with TELNET_AUTHENTICATION runtime setting default
+// TODO warning should be removed eventually
+#ifdef TELNET_PASSWORD
+#warning TELNET_PASSWORD is deprecated! Please replace it with TELNET_AUTHENTICATION
+#define TELNET_AUTHENTICATION TELNET_PASSWORD
+#endif


### PR DESCRIPTION
#1382 had changed the define to TELNET_AUTHENTICATION
Seamlessly replace old -> new and show compile time warning