### PR TITLE
Fix wrong GPIO value for dummy relay

### DIFF
--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -557,6 +557,8 @@ void _relayBoot() {
 
 void _relayConfigure() {
     for (unsigned int i=0; i<_relays.size(); i++) {
+        if (GPIO_NONE == _relays[i].pin) continue;
+
         pinMode(_relays[i].pin, OUTPUT);
         if (GPIO_NONE != _relays[i].reset_pin) {
             pinMode(_relays[i].reset_pin, OUTPUT);
@@ -1006,7 +1008,7 @@ void relaySetup() {
         // No delay_on or off for these devices to easily allow having more than
         // 8 channels. This behaviour will be recovered with v2.
         for (unsigned char i=0; i < DUMMY_RELAY_COUNT; i++) {
-            _relays.push_back((relay_t) {0, RELAY_TYPE_NORMAL, 0, 0, 0});
+            _relays.push_back((relay_t) {GPIO_NONE, RELAY_TYPE_NORMAL, 0, 0, 0});
         }
 
     #else


### PR DESCRIPTION
`reload` / config update from web will push button 0 via digitalWrite(0)

Actually, no idea what issue to attach this to.
#1134 is rfbridge, but is quite old
#1214 is th16 that uses real relay
And both of them probably related to overwriting eeprom when rebooting / crashing, and that fix is already merged