### PR TITLE
Add debouncing to pulse meter sensor

### DIFF
--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -601,6 +601,8 @@
 #define PULSEMETER_INTERRUPT_ON         FALLING
 #endif
 
+#define PULSEMETER_DEBOUNCE             50         // Do not register pulses within less than 50 millis
+
 //------------------------------------------------------------------------------
 // PZEM004T based power monitor
 // Enable support by passing PZEM004T_SUPPORT=1 build flag

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -645,6 +645,7 @@ void _sensorLoad() {
         PulseMeterSensor * sensor = new PulseMeterSensor();
         sensor->setGPIO(PULSEMETER_PIN);
         sensor->setEnergyRatio(PULSEMETER_ENERGY_RATIO);
+        sensor->setDebounceTime(PULSEMETER_DEBOUNCE);
         _sensors.push_back(sensor);
     }
     #endif

--- a/code/espurna/sensors/PulseMeterSensor.h
+++ b/code/espurna/sensors/PulseMeterSensor.h
@@ -43,6 +43,10 @@ class PulseMeterSensor : public BaseSensor {
             if (ratio > 0) _ratio = ratio;
         }
 
+        void setDebounceTime(unsigned long debounce) {
+            _debounce = debounce;
+        }
+
         // ---------------------------------------------------------------------
 
         unsigned char getGPIO() {
@@ -51,6 +55,10 @@ class PulseMeterSensor : public BaseSensor {
 
         unsigned char getEnergyRatio() {
             return _ratio;
+        }
+
+        unsigned long getDebounceTime() {
+            return _debounce;
         }
 
         // ---------------------------------------------------------------------
@@ -113,7 +121,10 @@ class PulseMeterSensor : public BaseSensor {
 
         // Handle interrupt calls
         void ICACHE_RAM_ATTR handleInterrupt(unsigned char gpio) {
-            if (gpio == _gpio) {
+            static unsigned long last = 0;
+
+            if (millis() - last > _debounce) {
+                last = millis();
                 _pulses++;
             }
         }
@@ -151,6 +162,7 @@ class PulseMeterSensor : public BaseSensor {
         unsigned char _previous = GPIO_NONE;
         unsigned char _gpio = GPIO_NONE;
         unsigned long _ratio = PULSEMETER_ENERGY_RATIO;
+        unsigned long _debounce = PULSEMETER_DEBOUNCE;
 
         double _active = 0;
         double _energy = 0;


### PR DESCRIPTION
I found debouncing to be required when using a "digital LDR" such as this one;

<img src="https://user-images.githubusercontent.com/1843197/49484350-9f52fc00-f82e-11e8-9806-9917b75d7ccd.jpg" width="200" title="Digital LDR" />

I copied the implementation from the event sensor, as it seemed pretty straightforward.

I don't think a configuration option is required for this, so it's hardcoded to 50ms right now (even then, if your power meter is flashing every 50ms then there's something wrong!).


