### PR TITLE
Add support for Lombex Lux Nova 2 Tunable White smart bulb

### DIFF
--- a/code/espurna/config/arduino.h
+++ b/code/espurna/config/arduino.h
@@ -102,6 +102,7 @@
 //#define IWOOLE_LED_TABLE_LAMP
 //#define EXS_WIFI_RELAY_V50
 //#define TECKIN_SP22_V14
+//#define LOMBEX_LUX_NOVA2_TUNABLE_WHITE
 
 //--------------------------------------------------------------------------------
 // Features (values below are non-default values)

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -2958,6 +2958,29 @@
     #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
+// Lombex Lux Nova 2 Tunable White
+// https://www.amazon.com/Lombex-Compatible-Equivalent-Dimmable-2700K-6500K/dp/B07B8K72PR
+// -----------------------------------------------------------------------------
+#elif defined(LOMBEX_LUX_NOVA2_TUNABLE_WHITE)
+
+    // Info
+    #define MANUFACTURER        "LOMBEX"
+    #define DEVICE              "LUX_NOVA2_TUNABLE_WHITE"
+    #define RELAY_PROVIDER      RELAY_PROVIDER_LIGHT
+    #define LIGHT_PROVIDER      LIGHT_PROVIDER_MY92XX
+    #define DUMMY_RELAY_COUNT   1
+
+    // Light
+    #define LIGHT_CHANNELS      5
+    #define MY92XX_MODEL        MY92XX_MODEL_MY9291
+    #define MY92XX_CHIPS        1
+    #define MY92XX_DI_PIN       4
+    #define MY92XX_DCKI_PIN     5
+    #define MY92XX_COMMAND      MY92XX_COMMAND_DEFAULT
+    // No RGB on this bulb. Warm white on channel 0, cool white on channel 3
+    #define MY92XX_MAPPING      255, 255, 255, 3, 0
+
+// -----------------------------------------------------------------------------
 // Bestek Smart Plug with 2 USB ports
 // https://www.bestekcorp.com/bestek-smart-plug-works-with-amazon-alexa-google-assistant-and-ifttt-with-2-usb
 // -----------------------------------------------------------------------------

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -2304,6 +2304,30 @@ upload_flags = ${common.upload_flags}
 monitor_speed = ${common.monitor_speed}
 extra_scripts = ${common.extra_scripts}
 
+[env:lombex-lux-nova2-tunable-white]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board_1m}
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m0m} -DLOMBEX_LUX_NOVA2_TUNABLE_WHITE
+monitor_speed = ${common.monitor_speed}
+extra_scripts = ${common.extra_scripts}
+
+[env:lombex-lux-nova2-tunable-white-ota]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board_1m}
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m0m} -DLOMBEX_LUX_NOVA2_TUNABLE_WHITE
+upload_speed = ${common.upload_speed}
+upload_port = ${common.upload_port}
+upload_flags = ${common.upload_flags}
+monitor_speed = ${common.monitor_speed}
+extra_scripts = ${common.extra_scripts}
 
 # ------------------------------------------------------------------------------
 # GENERIC OTA ENVIRONMENTS


### PR DESCRIPTION
Back again with a newer bulb from the same company.
This one doesn't have RGB, it just has cool and warm leds.
To make it work well in the interface I had to put in dummy values (I used 255) for the RGB channels. The "white color temperature" feature is important for this bulb, since that behavior seems equivalent to what the regular firmware provides and disallows full power to both channels at the same time. Which *might* blow up the bulb as I've found out with the other one.

I did not see dummy values being used for the other bulbs, perhaps it simply hasn't been necessary. A nicer fix would probably involve a refactoring of the light channel code to not use hardcoded indices for the channels.
I don't know enough about your code to have confidence doing that. Let me know if the dummy values are okay for now or if you would rather pull this in after a refactor (or if I am being dumb :)).

If this goes in I can provide info on flashing to the wiki, as well as support for another Nova 2 bulb with color support.