### PR TITLE
APP_VERSION suffix

### DIFF
--- a/code/build.sh
+++ b/code/build.sh
@@ -33,9 +33,10 @@ else
     git_tag=
 fi
 
-if [ ! -z $git_tag ]; then
-    version=${version/-dev}
-    sed -i -e "s@$version-dev@$version@" $version_file
+if [[ -n $git_tag ]]; then
+    new_version=${version/-*}
+    sed -i -e "s@$version@$new_version@" $version_file
+    version=$new_version
     trap "git checkout -- $version_file" EXIT
 fi
 

--- a/code/build.sh
+++ b/code/build.sh
@@ -19,14 +19,24 @@ stat_bytes() {
 # Script settings
 
 destination=../firmware
-version=$(grep APP_VERSION espurna/config/version.h | awk '{print $3}' | sed 's/"//g')
+version_file=espurna/config/version.h
+version=$(grep -E '^#define APP_VERSION' $version_file | awk '{print $3}' | sed 's/"//g')
 
-if is_git; then
+if ${TRAVIS:-false}; then
+    git_revision=${TRAVIS_COMMIT::7}
+    git_tag=${TRAVIS_TAG}
+elif is_git; then
     git_revision=$(git rev-parse --short HEAD)
-    git_version=${version}-${git_revision}
+    git_tag=$(git tag --contains HEAD)
 else
-    git_revision=
-    git_version=$version
+    git_revision=unknown
+    git_tag=
+fi
+
+if [ ! -z $git_tag ]; then
+    version=${version/-dev}
+    sed -i -e "s@$version-dev@$version@" $version_file
+    trap "git checkout -- $version_file" EXIT
 fi
 
 par_build=false
@@ -139,7 +149,7 @@ shift $((OPTIND-1))
 # Welcome
 echo "--------------------------------------------------------------"
 echo "ESPURNA FIRMWARE BUILDER"
-echo "Building for version ${git_version}"
+echo "Building for version ${version}" ${git_revision:+($git_revision)}
 
 # Environments to build
 environments=$@

--- a/code/espurna/config/version.h
+++ b/code/espurna/config/version.h
@@ -1,5 +1,5 @@
 #define APP_NAME                "ESPURNA"
-#define APP_VERSION             "1.13.4"
+#define APP_VERSION             "1.13.4-dev"
 #define APP_AUTHOR              "xose.perez@gmail.com"
 #define APP_WEBSITE             "http://tinkerman.cat"
 #define CFG_VERSION             3


### PR DESCRIPTION
Keep -dev in the version all the time
Strip when building from tag, checking `TRAVIS_TAG=something` (CI release) or `git tag --contains HEAD` (local release)
Also do `git checkout -- version.h` after the script exists with tag present, to avoid accidentally committing it.