### PR TITLE
Fix: Add Debug flag for compilation of wifiDebug() function

### DIFF
--- a/code/espurna/wifi.ino
+++ b/code/espurna/wifi.ino
@@ -467,10 +467,9 @@ void _wifiWebSocketOnAction(uint32_t client_id, const char * action, JsonObject&
 // INFO
 // -----------------------------------------------------------------------------
 
-#if DEBUG_SUPPORT || TERMINAL_SUPPORT
-
 void wifiDebug(WiFiMode_t modes) {
 
+    #if DEBUG_SUPPORT || TERMINAL_SUPPORT
     bool footer = false;
 
     if (((modes & WIFI_STA) > 0) && ((WiFi.getMode() & WIFI_STA) > 0)) {
@@ -511,14 +510,13 @@ void wifiDebug(WiFiMode_t modes) {
     if (footer) {
         DEBUG_MSG_P(PSTR("[WIFI] ----------------------------------------------\n"));
     }
+    #endif //DEBUG_SUPPORT
 
 }
 
 void wifiDebug() {
     wifiDebug(WIFI_AP_STA);
 }
-
-#endif //DEBUG_SUPPORT
 
 // -----------------------------------------------------------------------------
 // API

--- a/code/espurna/wifi.ino
+++ b/code/espurna/wifi.ino
@@ -467,6 +467,8 @@ void _wifiWebSocketOnAction(uint32_t client_id, const char * action, JsonObject&
 // INFO
 // -----------------------------------------------------------------------------
 
+#if DEBUG_SUPPORT
+
 void wifiDebug(WiFiMode_t modes) {
 
     bool footer = false;
@@ -515,6 +517,8 @@ void wifiDebug(WiFiMode_t modes) {
 void wifiDebug() {
     wifiDebug(WIFI_AP_STA);
 }
+
+#endif //DEBUG_SUPPORT
 
 // -----------------------------------------------------------------------------
 // API

--- a/code/espurna/wifi.ino
+++ b/code/espurna/wifi.ino
@@ -469,7 +469,7 @@ void _wifiWebSocketOnAction(uint32_t client_id, const char * action, JsonObject&
 
 void wifiDebug(WiFiMode_t modes) {
 
-    #if DEBUG_SUPPORT || TERMINAL_SUPPORT
+    #if DEBUG_SUPPORT
     bool footer = false;
 
     if (((modes & WIFI_STA) > 0) && ((WiFi.getMode() & WIFI_STA) > 0)) {

--- a/code/espurna/wifi.ino
+++ b/code/espurna/wifi.ino
@@ -467,7 +467,7 @@ void _wifiWebSocketOnAction(uint32_t client_id, const char * action, JsonObject&
 // INFO
 // -----------------------------------------------------------------------------
 
-#if DEBUG_SUPPORT
+#if DEBUG_SUPPORT || TERMINAL_SUPPORT
 
 void wifiDebug(WiFiMode_t modes) {
 


### PR DESCRIPTION
Won't compile the Debug code in the final build which will help reduce the size of the build.