### PR TITLE
Escape hyphens in img.shields.io urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ESPurna ("spark" in Catalan) is a custom firmware for ESP8285/ESP8266 based smart switches, lights and sensors.
 It uses the Arduino Core for ESP8266 framework and a number of 3rd party libraries.
 
-[![version](https://img.shields.io/badge/version-1.13.4-dev-brightgreen.svg)](CHANGELOG.md)
+[![version](https://img.shields.io/badge/version-1.13.4--dev-brightgreen.svg)](CHANGELOG.md)
 [![branch](https://img.shields.io/badge/branch-dev-orange.svg)](https://github.com/xoseperez/espurna/tree/dev/)
 [![license](https://img.shields.io/github/license/xoseperez/espurna.svg)](LICENSE)
 [![travis](https://travis-ci.org/xoseperez/espurna.svg?branch=dev)](https://travis-ci.org/xoseperez/espurna)

--- a/pre-commit
+++ b/pre-commit
@@ -16,6 +16,7 @@ Copy this file to .git/hooks/
 
 import os
 import sys
+import string
 import re
 
 from subprocess import call, check_output
@@ -35,6 +36,14 @@ if sys.version_info[0] < 3:
             self.close()
 
     FileInput = FileInputCtx
+
+
+class CustomFormatter(string.Formatter):
+    def format_field(self, value, spec):
+        if spec == "escape_hyphen":
+            return value.replace("-", "--")
+        else:
+            return super(CustomFormatter, self).format_field(value, spec)
 
 
 def run(cmd, cwd=None):
@@ -79,12 +88,13 @@ def espurna_get_version(base, version_h="code/espurna/config/version.h"):
 
     return version
 
+
 TEMPLATES = {
-    "![travis]": "[![travis](https://travis-ci.org/{USER}/{REPO}.svg?branch={BRANCH})]" \
+    "![travis]": "[![travis](https://travis-ci.org/{USER}/{REPO}.svg?branch={BRANCH})]"
         "(https://travis-ci.org/{USER}/{REPO})\n",
-    "![version]": "[![version](https://img.shields.io/badge/version-{VERSION}-brightgreen.svg)](CHANGELOG.md)\n",
-    "![branch]": "[![branch](https://img.shields.io/badge/branch-{BRANCH}-orange.svg)]" \
-        "(https://github.com/{USER}/{REPO}/tree/{BRANCH}/)\n"
+    "![version]": "[![version](https://img.shields.io/badge/version-{VERSION:escape_hyphen}-brightgreen.svg)](CHANGELOG.md)\n",
+    "![branch]": "[![branch](https://img.shields.io/badge/branch-{BRANCH:escape_hyphen}-orange.svg)]"
+        "(https://github.com/{USER}/{REPO}/tree/{BRANCH}/)\n",
 }
 
 README = "README.md"
@@ -98,10 +108,12 @@ if __name__ == "__main__":
         "USER": user,
         "REPO": repo,
         "BRANCH": git_branch(),
-        "VERSION": espurna_get_version(base)
+        "VERSION": espurna_get_version(base),
     }
+
+    formatter = CustomFormatter()
     templates = [
-        (k, tmpl.format(**fmt))
+        (k, formatter.format(tmpl, **fmt))
         for k, tmpl in TEMPLATES.items()
     ]
 
@@ -121,4 +133,4 @@ if __name__ == "__main__":
     if call(["git", "add", README]):
         sys.exit(1)
 
-    sys.exit(0);
+    sys.exit(0)


### PR DESCRIPTION
Minor README branch / version images issue. img.shields will not properly generate the image otherwise.

Not really obvious, as img.shields.io returns 404 + "error" image in the body, but github is making it look like network issue by not displaying any image at all