### PR TITLE
Support for RGB(WW) controlled using Domoticz MQTT messages

### DIFF
--- a/code/espurna/domoticz.ino
+++ b/code/espurna/domoticz.ino
@@ -68,68 +68,71 @@ void _domoticzMqtt(unsigned int type, const char * topic, const char * payload) 
             // IDX
             unsigned int idx = root["idx"];
             String stype = root["stype"];
-
             if (
                 (stype.equals("RGB") || stype.equals("RGBW") || stype.equals("RGBWW"))
-                && lightHasColor()
             ) {
+#if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
+                if (lightHasColor()) {
 
-                // m field contains information about color mode (enum ColorMode from domoticz ColorSwitch.h):
-                unsigned int cmode = root["Color"]["m"];
-                unsigned int cval;
-                
-                if (cmode == 3 || cmode == 4) { // ColorModeRGB or ColorModeCustom - see domoticz ColorSwitch.h
+                    // m field contains information about color mode (enum ColorMode from domoticz ColorSwitch.h):
+                    unsigned int cmode = root["Color"]["m"];
+                    unsigned int cval;
                     
-                    // RED
-                    cval = root["Color"]["r"];
-                    DEBUG_MSG_P(PSTR("[DOMOTICZ] Received RED value %u for IDX %u\n"), cval, idx);
-                    lightChannel(0, cval);
-                    
-                    // GREEN
-                    cval = root["Color"]["g"];
-                    DEBUG_MSG_P(PSTR("[DOMOTICZ] Received GREEN value %u for IDX %u\n"), cval, idx);
-                    lightChannel(1, cval);
-                    
-                    // BLUE
-                    cval = root["Color"]["b"];
-                    DEBUG_MSG_P(PSTR("[DOMOTICZ] Received BLUE value %u for IDX %u\n"), cval, idx);
-                    lightChannel(2, cval);
-                    
-                    // WARM WHITE or MONOCHROME WHITE if supported
-                    if (lightChannels() > 3) {
-                        cval = root["Color"]["ww"];
-                        DEBUG_MSG_P(PSTR("[DOMOTICZ] Received WARM WHITE value %u for IDX %u\n"), cval, idx);
-                        lightChannel(3, cval);
+                    if (cmode == 3 || cmode == 4) { // ColorModeRGB or ColorModeCustom - see domoticz ColorSwitch.h
+                        
+                        // RED
+                        cval = root["Color"]["r"];
+                        DEBUG_MSG_P(PSTR("[DOMOTICZ] Received RED value %u for IDX %u\n"), cval, idx);
+                        lightChannel(0, cval);
+                        
+                        // GREEN
+                        cval = root["Color"]["g"];
+                        DEBUG_MSG_P(PSTR("[DOMOTICZ] Received GREEN value %u for IDX %u\n"), cval, idx);
+                        lightChannel(1, cval);
+                        
+                        // BLUE
+                        cval = root["Color"]["b"];
+                        DEBUG_MSG_P(PSTR("[DOMOTICZ] Received BLUE value %u for IDX %u\n"), cval, idx);
+                        lightChannel(2, cval);
+                        
+                        // WARM WHITE or MONOCHROME WHITE if supported
+                        if (lightChannels() > 3) {
+                            cval = root["Color"]["ww"];
+                            DEBUG_MSG_P(PSTR("[DOMOTICZ] Received WARM WHITE value %u for IDX %u\n"), cval, idx);
+                            lightChannel(3, cval);
+                        }
+                        
+                        // COLD WHITE if supported
+                        if (lightChannels() > 4) {
+                            cval = root["Color"]["cw"];
+                            DEBUG_MSG_P(PSTR("[DOMOTICZ] Received COLD WHITE value %u for IDX %u\n"), cval, idx);
+                            lightChannel(4, cval);
+                        }
+
+                        
+                        unsigned int brightness = root["Level"];
+                        DEBUG_MSG_P(PSTR("[DOMOTICZ] Received BRIGHTNESS value %u for IDX %u\n"), brightness, idx);
+                        unsigned int br = (brightness / 100.0) * LIGHT_MAX_BRIGHTNESS;
+                        DEBUG_MSG_P(PSTR("[DOMOTICZ] Calculated BRIGHTNESS value %u for IDX %u\n"), br, idx);
+                        lightBrightness(br); // domoticz uses 100 as maximum value while we're using LIGHT_MAX_BRIGHTNESS
+                        
+                        // update lights
+                        lightUpdate(true, mqttForward());
+
                     }
+
                     
-                    // COLD WHITE if supported
-                    if (lightChannels() > 4) {
-                        cval = root["Color"]["cw"];
-                        DEBUG_MSG_P(PSTR("[DOMOTICZ] Received COLD WHITE value %u for IDX %u\n"), cval, idx);
-                        lightChannel(4, cval);
+                    
+                    unsigned char relayID = _domoticzRelay(idx);
+                    if (relayID >= 0) {
+                        unsigned char value = root["nvalue"];
+                        DEBUG_MSG_P(PSTR("[DOMOTICZ] Received value %u for IDX %u\n"), value, idx);
+                        relayStatus(relayID, value > 0);
                     }
-
-                    
-                    unsigned int brightness = root["Level"];
-                    DEBUG_MSG_P(PSTR("[DOMOTICZ] Received BRIGHTNESS value %u for IDX %u\n"), brightness, idx);
-                    unsigned int br = (brightness / 100.0) * LIGHT_MAX_BRIGHTNESS;
-                    DEBUG_MSG_P(PSTR("[DOMOTICZ] Calculated BRIGHTNESS value %u for IDX %u\n"), br, idx);
-                    lightBrightness(br); // domoticz uses 100 as maximum value while we're using LIGHT_MAX_BRIGHTNESS
-                    
-                    // update lights
-                    lightUpdate(true, mqttForward());
-
                 }
-
-                
-                
-                unsigned char relayID = _domoticzRelay(idx);
-                if (relayID >= 0) {
-                    unsigned char value = root["nvalue"];
-                    DEBUG_MSG_P(PSTR("[DOMOTICZ] Received value %u for IDX %u\n"), value, idx);
-                    relayStatus(relayID, value > 0);
-                }
-                
+#else
+                DEBUG_MSG_P(PSTR("[DOMOTICZ] ESPurna compiled without LIGHT_PROVIDER"));
+#endif
             } else {
                 unsigned char relayID = _domoticzRelay(idx);
                 if (relayID >= 0) {

--- a/code/espurna/domoticz.ino
+++ b/code/espurna/domoticz.ino
@@ -78,7 +78,7 @@ void _domoticzMqtt(unsigned int type, const char * topic, const char * payload) 
                 unsigned int cmode = root["Color"]["m"];
                 unsigned int cval;
                 
-                if (cmode == 3 || cmode == 4) { // ColorModeRGB or ColorModeCustom - see 
+                if (cmode == 3 || cmode == 4) { // ColorModeRGB or ColorModeCustom - see domoticz ColorSwitch.h
                     
                     // RED
                     cval = root["Color"]["r"];


### PR DESCRIPTION
Support for control of RGB(WW) LED strips from Domoticz over MQTT.
Tested using AL-LC02 for the last ~3 weeks.
All comments highly appreciated.

References #291 