### PR TITLE
Support for newer AL-LC02 boards with different pinout

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1637,6 +1637,26 @@
     #define LIGHT_CH3_INVERSE   0
     #define LIGHT_CH4_INVERSE   0
 
+#elif defined(ARILUX_AL_LC02V14)
+
+    // Info
+    #define MANUFACTURER        "ARILUX"
+    #define DEVICE              "AL_LC02V14"
+    #define RELAY_PROVIDER      RELAY_PROVIDER_LIGHT
+    #define LIGHT_PROVIDER      LIGHT_PROVIDER_DIMMER
+    #define DUMMY_RELAY_COUNT   1
+
+    // Light
+    #define LIGHT_CHANNELS      4
+    #define LIGHT_CH1_PIN       14      // RED
+    #define LIGHT_CH2_PIN       5       // GREEN
+    #define LIGHT_CH3_PIN       12      // BLUE
+    #define LIGHT_CH4_PIN       13      // WHITE1
+    #define LIGHT_CH1_INVERSE   0
+    #define LIGHT_CH2_INVERSE   0
+    #define LIGHT_CH3_INVERSE   0
+    #define LIGHT_CH4_INVERSE   0
+
 #elif defined(ARILUX_AL_LC06)
 
     // Info

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1404,6 +1404,31 @@ upload_flags = ${common.upload_flags}
 monitor_speed = ${common.monitor_speed}
 extra_scripts = ${common.extra_scripts}
 
+[env:arilux-al-lc02v14]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board_1m}
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m0m} -DARILUX_AL_LC02V14
+monitor_speed = ${common.monitor_speed}
+extra_scripts = ${common.extra_scripts}
+
+[env:arilux-al-lc02v14-ota]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board_1m}
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_1m0m} -DARILUX_AL_LC02V14
+upload_speed = ${common.upload_speed}
+upload_port = ${common.upload_port}
+upload_flags = ${common.upload_flags}
+monitor_speed = ${common.monitor_speed}
+extra_scripts = ${common.extra_scripts}
+
 [env:arilux-al-lc06]
 platform = ${common.platform}
 framework = ${common.framework}


### PR DESCRIPTION
Newer AL-LC02 boards (or at least devices sold as such) **have different LED pins used** than original LC02 boards. 
From outside the device looks almost exactly as AL-LC11 (including voltage rating on input side) with exception of LED strip connector (RGBW so only 5 pins and label with description of 5 pins). Unfortunately pinout of new board is different from existing LC11.
Above mentioned differences unfortunately are not bullet proof way to distinguish devices as I have few LC-02 units with "old" label and "new" boards.
So only sure way to distinguish device with new board from one with old board is to disassemble the device and see markings on the PCB which will read "ESP-IR-A V1.4".

This pull request contains changes that add new firmware for such devices (arilux-al-lc02v14) by adding new platform and new entries in hardware configuration.
Appropriate changes should also be made in Wiki mentioning existence of such boards and need to use alternative firmware is user experiences problems with mismatched colours (only problem I found).