### PR TITLE
yield() after handling OTA request

### DIFF
--- a/code/espurna/ota.ino
+++ b/code/espurna/ota.ino
@@ -118,6 +118,7 @@ void _otaFrom(const char * host, unsigned int port, const char * url) {
         _ota_size += len;
         DEBUG_MSG_P(PSTR("[OTA] Progress: %u bytes\r"), _ota_size);
 
+        delay(0);
 
     }, NULL);
 


### PR DESCRIPTION
avoid wdt reset when handling HTTP OTA
`debugSend()` actually saves the day here by doing`optimistic_yield()`, but it is possible to have DEBUG_SUPPORT=0