### PR TITLE
Configure Heartbeat from WebUI & option HEARTBEAT_REPEAT_STATUS

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -169,6 +169,7 @@
 #define HEARTBEAT_NONE              0           // Never send heartbeat
 #define HEARTBEAT_ONCE              1           // Send it only once upon MQTT connection
 #define HEARTBEAT_REPEAT            2           // Send it upon MQTT connection and every HEARTBEAT_INTERVAL
+#define HEARTBEAT_REPEAT_STATUS     3           // Send it upon MQTT connection and every HEARTBEAT_INTERVAL only STATUS report
 
 // Backwards compatibility check
 #if defined(HEARTBEAT_ENABLED) && (HEARTBEAT_ENABLED == 0)

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -181,7 +181,7 @@
 #endif
 
 #ifndef HEARTBEAT_INTERVAL
-#define HEARTBEAT_INTERVAL          300000      // Interval between heartbeat messages (in ms)
+#define HEARTBEAT_INTERVAL          300         // Interval between heartbeat messages (in sec)
 #endif
 
 #define UPTIME_OVERFLOW             4294967295  // Uptime overflow value

--- a/code/espurna/system.ino
+++ b/code/espurna/system.ino
@@ -82,8 +82,6 @@ unsigned long systemLoadAverage() {
 }
 
 void _systemSetupHeartbeat() {
-    if (getSetting("hbMode").length() == 0)  setSetting("hbMode", HEARTBEAT_MODE);
-    if (getSetting("hbInterval").length() == 0)  setSetting("hbInterval", HEARTBEAT_INTERVAL);
     _heartbeat_mode = getSetting("hbMode", HEARTBEAT_MODE).toInt();
     _heartbeat_interval = getSetting("hbInterval", HEARTBEAT_INTERVAL).toInt();
 }
@@ -116,9 +114,9 @@ void systemLoop() {
     } else if (_heartbeat_mode == HEARTBEAT_REPEAT || _heartbeat_mode == HEARTBEAT_REPEAT_STATUS) {
         static unsigned long last_hbeat = 0;
         #if NTP_SUPPORT
-            if ((_system_send_heartbeat && ntpSynced()) || (millis() - last_hbeat > _heartbeat_interval)) {
+            if ((_system_send_heartbeat && ntpSynced()) || (millis() - last_hbeat > _heartbeat_interval * 1000)) {
         #else
-            if (_system_send_heartbeat || (millis() - last_hbeat > _heartbeat_interval)) {
+            if (_system_send_heartbeat || (millis() - last_hbeat > _heartbeat_interval * 1000)) {
         #endif
             last_hbeat = millis();
             heartbeat();

--- a/code/espurna/system.ino
+++ b/code/espurna/system.ino
@@ -12,6 +12,8 @@ Copyright (C) 2018 by Xose Pérez <xose dot perez at gmail dot com>
 
 unsigned long _loop_delay = 0;
 bool _system_send_heartbeat = false;
+unsigned char _heartbeat_mode = HEARTBEAT_MODE;
+unsigned long _heartbeat_interval = HEARTBEAT_INTERVAL;
 
 // Calculated load average 0 to 100;
 unsigned short int _load_average = 100;
@@ -66,6 +68,10 @@ void systemSendHeartbeat() {
     _system_send_heartbeat = true;
 }
 
+bool systemGetHeartbeat() {
+    return _system_send_heartbeat;
+}
+
 unsigned long systemLoopDelay() {
     return _loop_delay;
 }
@@ -73,6 +79,13 @@ unsigned long systemLoopDelay() {
 
 unsigned long systemLoadAverage() {
     return _load_average;
+}
+
+void _systemSetupHeartbeat() {
+    if (getSetting("hbMode").length() == 0)  setSetting("hbMode", HEARTBEAT_MODE);
+    if (getSetting("hbInterval").length() == 0)  setSetting("hbInterval", HEARTBEAT_INTERVAL);
+    _heartbeat_mode = getSetting("hbMode", HEARTBEAT_MODE).toInt();
+    _heartbeat_interval = getSetting("hbInterval", HEARTBEAT_INTERVAL).toInt();
 }
 
 void systemLoop() {
@@ -97,19 +110,21 @@ void systemLoop() {
     // Heartbeat
     // -------------------------------------------------------------------------
 
-    #if HEARTBEAT_MODE == HEARTBEAT_ONCE
-        if (_system_send_heartbeat) {
-            _system_send_heartbeat = false;
-            heartbeat();
-        }
-    #elif HEARTBEAT_MODE == HEARTBEAT_REPEAT
+    if (_system_send_heartbeat && _heartbeat_mode == HEARTBEAT_ONCE) {
+        heartbeat();
+        _system_send_heartbeat = false;
+    } else if (_heartbeat_mode == HEARTBEAT_REPEAT || _heartbeat_mode == HEARTBEAT_REPEAT_STATUS) {
         static unsigned long last_hbeat = 0;
-        if (_system_send_heartbeat || (last_hbeat == 0) || (millis() - last_hbeat > HEARTBEAT_INTERVAL)) {
-            _system_send_heartbeat = false;
+        #if NTP_SUPPORT
+            if ((_system_send_heartbeat && ntpSynced()) || (millis() - last_hbeat > _heartbeat_interval)) {
+        #else
+            if (_system_send_heartbeat || (millis() - last_hbeat > _heartbeat_interval)) {
+        #endif
             last_hbeat = millis();
             heartbeat();
+           _system_send_heartbeat = false;
         }
-    #endif // HEARTBEAT_MODE == HEARTBEAT_REPEAT
+    }
 
     // -------------------------------------------------------------------------
     // Load Average calculation
@@ -178,5 +193,8 @@ void systemSetup() {
 
     // Register Loop
     espurnaRegisterLoop(systemLoop);
+
+    // Cache Heartbeat values
+    _systemSetupHeartbeat();
 
 }

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -350,6 +350,8 @@ void _wsOnStart(JsonObject& root) {
         #if TERMINAL_SUPPORT
             root["cmdVisible"] = 1;
         #endif
+        root["hbMode"] = getSetting("hbMode", HEARTBEAT_MODE).toInt();
+        root["hbInterval"] = getSetting("hbInterval", HEARTBEAT_INTERVAL).toInt();
 
     }
 

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -621,6 +621,34 @@
                                 </div>
 
                                 <div class="pure-g">
+                                    <label class="pure-u-1 pure-u-lg-1-4">Heartbeat mode</label>
+                                    <select class="pure-u-1 pure-u-lg-1-4" name="hbMode" tabindex="15" >
+                                        <option value="0">HEARTBEAT_NONE</option>
+                                        <option value="1">HEARTBEAT_ONCE</option>
+                                        <option value="2">HEARTBEAT_REPEAT</option>
+                                        <option value="3">HEARTBEAT_REPEAT_STATUS</option>
+                                    </select>
+                                    <div class="pure-u-0 pure-u-lg-1-2"></div>
+                                    <div class="pure-u-0 pure-u-lg-1-4"></div>
+                                    <div class="pure-u-1 pure-u-lg-3-4 hint">
+                                        <strong>HEARTBEAT_NONE:</strong> no heartbeat at all, never.<br />
+                                        <strong>HEARTBEAT_ONCE:</strong> only on device startup.<br />
+                                        <strong>HEARTBEAT_REPEAT:</strong> on device startup and after HEARTBEAT_INTERVAL.<br />
+                                        <strong>HEARTBEAT_REPEAT_STATUS:</strong> on device startup full heartbeat information and after HEARTBEAT_INTERVAL only STATUS report.
+                                    </div>
+                                </div>
+
+                                <div class="pure-g">
+                                    <label class="pure-u-1 pure-u-lg-1-4">Heartbeat interval</label>
+                                    <input name="hbInterval" class="pure-u-1 pure-u-lg-1-4" type="text" tabindex="16" />
+                                    <div class="pure-u-0 pure-u-lg-1-2"></div>
+                                    <div class="pure-u-0 pure-u-lg-1-4"></div>
+                                    <div class="pure-u-1 pure-u-lg-3-4 hint">
+                                        This is the interval in <strong>ms</strong> how often to send the heartbeat message.
+                                    </div>
+                                </div>
+
+                                <div class="pure-g">
                                     <label class="pure-u-1 pure-u-lg-1-4">Upgrade</label>
                                     <input class="pure-u-1-2 pure-u-lg-1-2" name="filename" type="text" readonly />
                                     <div class="pure-u-1-4 pure-u-lg-1-8"><button type="button" class="pure-button button-upgrade-browse pure-u-23-24">Browse</button></div>
@@ -629,7 +657,7 @@
                                     <div class="pure-u-1 pure-u-lg-3-4 hint">The device has <span name="free_size"></span> bytes available for OTA updates. If your image is larger than this consider doing a <a href="https://github.com/xoseperez/espurna/wiki/TwoStepUpdates" target="_blank"><strong>two-step update</strong></a>.</div>
                                     <div class="pure-u-0 pure-u-lg-1-4"></div>
                                     <div class="pure-u-1 pure-u-lg-3-4"><progress id="upgrade-progress"></progress></div>
-                                    <input name="upgrade" type="file" tabindex="16" />
+                                    <input name="upgrade" type="file" tabindex="17" />
                                 </div>
 
                             </fieldset>

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -621,30 +621,27 @@
                                 </div>
 
                                 <div class="pure-g">
-                                    <label class="pure-u-1 pure-u-lg-1-4">Heartbeat mode</label>
+                                    <label class="pure-u-1 pure-u-lg-1-4">Heartbeat message</label>
                                     <select class="pure-u-1 pure-u-lg-1-4" name="hbMode" tabindex="15" >
-                                        <option value="0">HEARTBEAT_NONE</option>
-                                        <option value="1">HEARTBEAT_ONCE</option>
-                                        <option value="2">HEARTBEAT_REPEAT</option>
-                                        <option value="3">HEARTBEAT_REPEAT_STATUS</option>
+                                        <option value="0">Disabled</option>
+                                        <option value="1">On device startup</option>
+                                        <option value="2">Repeat after defined interval</option>
+                                        <option value="3">Repeat only device status</option>
                                     </select>
                                     <div class="pure-u-0 pure-u-lg-1-2"></div>
                                     <div class="pure-u-0 pure-u-lg-1-4"></div>
                                     <div class="pure-u-1 pure-u-lg-3-4 hint">
-                                        <strong>HEARTBEAT_NONE:</strong> no heartbeat at all, never.<br />
-                                        <strong>HEARTBEAT_ONCE:</strong> only on device startup.<br />
-                                        <strong>HEARTBEAT_REPEAT:</strong> on device startup and after HEARTBEAT_INTERVAL.<br />
-                                        <strong>HEARTBEAT_REPEAT_STATUS:</strong> on device startup full heartbeat information and after HEARTBEAT_INTERVAL only STATUS report.
+                                        Define when heartbeat message will be sent.
                                     </div>
                                 </div>
 
                                 <div class="pure-g">
                                     <label class="pure-u-1 pure-u-lg-1-4">Heartbeat interval</label>
-                                    <input name="hbInterval" class="pure-u-1 pure-u-lg-1-4" type="text" tabindex="16" />
+                                    <input name="hbInterval" class="pure-u-1 pure-u-lg-1-4" type="number" tabindex="16" />
                                     <div class="pure-u-0 pure-u-lg-1-2"></div>
                                     <div class="pure-u-0 pure-u-lg-1-4"></div>
                                     <div class="pure-u-1 pure-u-lg-3-4 hint">
-                                        This is the interval in <strong>ms</strong> how often to send the heartbeat message.
+                                        This is the interval in <strong>seconds</strong> how often to send the heartbeat message.
                                     </div>
                                 </div>
 


### PR DESCRIPTION
- Heartbeat mode and interval configuration added to WebUI ADMIN page
- New option HEARTBEAT_REPEAT_STATUS: on device startup full heartbeat information and after HEARTBEAT_INTERVAL only STATUS report.
- Enhanced first heartbeat message - on device startup it will send heartbeat after ntpSynced will be true to get device time.

P.S. Code is tested. Web part is not compiled,and not tested, but I hope it will work :)