### PR TITLE
Fix compile error when RF_SUPPORT is enabled

### DIFF
--- a/code/espurna/rfbridge.ino
+++ b/code/espurna/rfbridge.ino
@@ -152,9 +152,6 @@ void _rfbLearn() {
 
 }
 
-
-#if not RF_SUPPORT
-
 /*
  From an hexa char array ("A220EE...") to a byte array (half the size)
  */
@@ -169,6 +166,8 @@ static int _rfbToArray(const char * in, byte * out, int length = RF_MESSAGE_SIZE
     }
     return n;
 }
+
+#if not RF_SUPPORT
 
 void _rfbSendRaw(const byte *message, const unsigned char n = RF_MESSAGE_SIZE) {
     for (unsigned char j=0; j<n; j++) {


### PR DESCRIPTION
Since the function ``_rfbToArray`` is also called in RF_SUPPORT code, move the #if block.