### PR TITLE
ONLY processes Domoticz RGB MQTT Messages for the current idx

### DIFF
--- a/code/espurna/domoticz.ino
+++ b/code/espurna/domoticz.ino
@@ -70,6 +70,7 @@ void _domoticzMqtt(unsigned int type, const char * topic, const char * payload) 
             String stype = root["stype"];
             if (
                 (stype.equals("RGB") || stype.equals("RGBW") || stype.equals("RGBWW"))
+				&& domoticzIdx(0) == idx
             ) {
 #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
                 if (lightHasColor()) {

--- a/code/espurna/domoticz.ino
+++ b/code/espurna/domoticz.ino
@@ -70,7 +70,7 @@ void _domoticzMqtt(unsigned int type, const char * topic, const char * payload) 
             String stype = root["stype"];
             if (
                 (stype.equals("RGB") || stype.equals("RGBW") || stype.equals("RGBWW"))
-				&& domoticzIdx(0) == idx
+                && domoticzIdx(0) == idx
             ) {
 #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
                 if (lightHasColor()) {


### PR DESCRIPTION
Fix for #1459

MQTT messages were processed regardless of the current idx.

Now it  only decodes messages with the right domoticz idx.
