### PR TITLE
#1519 Esp-01 + 2ch 5v relay LC tech Exclusive relay on

### DIFF
--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -83,6 +83,11 @@ void _relayProviderStatus(unsigned char id, bool status) {
         Serial.write(id + 1);
         Serial.write(status);
         Serial.write(0xA1 + status + id);
+
+        // The serial init are not full recognized by relais board.
+        // References: https://github.com/xoseperez/espurna/issues/1519 , https://github.com/xoseperez/espurna/issues/1130
+        delay(100);
+
         Serial.flush();
     #endif
 


### PR DESCRIPTION
When using the switches configuration "Zero or one switches active" the serial init are not full recognized by this relay board. The result is two relays on ON status.

When I click Switch#0 ON, and then Switch#1 ON, I need FIRST the relay 0 to OFF, and THEN relay 1 to ON, and viceversa.