### PR TITLE
Setup settings before using them in system module

### DIFF
--- a/code/espurna/espurna.ino
+++ b/code/espurna/espurna.ino
@@ -64,11 +64,11 @@ void setup() {
     // Init EEPROM
     eepromSetup();
 
-    // Init Serial, SPIFFS and system check
-    systemSetup();
-
     // Init persistance
     settingsSetup();
+
+    // Init Serial, SPIFFS and system check
+    systemSetup();
 
     // Init terminal features
     #if TERMINAL_SUPPORT


### PR DESCRIPTION
loopDelay, hbMode, hbInterval are always using defaults, because settings are empty