### PR TITLE
Allow to set relative brightness and relative color in mireds through…

### DIFF
--- a/code/espurna/light.ino
+++ b/code/espurna/light.ino
@@ -989,8 +989,15 @@ void _lightInitCommands() {
 
     terminalRegisterCommand(F("BRIGHTNESS"), [](Embedis* e) {
         if (e->argc > 1) {
-            lightBrightness(String(e->argv[1]).toInt());
-            lightUpdate(true, true);
+            const String value(e->argv[1]);
+            if( value.length() > 0 ) {
+                if( value[0] == '+' || value[0] == '-' ) {
+                    lightBrightness(lightBrightness()+String(e->argv[1]).toInt());
+                } else {
+                    lightBrightness(String(e->argv[1]).toInt());
+                }
+                lightUpdate(true, true);
+            }
         }
         DEBUG_MSG_P(PSTR("Brightness: %d\n"), lightBrightness());
         terminalOK();
@@ -1032,9 +1039,17 @@ void _lightInitCommands() {
 
     terminalRegisterCommand(F("MIRED"), [](Embedis* e) {
         if (e->argc > 1) {
-            String color = String("M") + String(e->argv[1]);
-            lightColor(color.c_str());
-            lightUpdate(true, true);
+            const String value(e->argv[1]);
+            String color = String("M");
+            if( value.length() > 0 ) {
+                if( value[0] == '+' || value[0] == '-' ) {
+                    color += String(_light_mireds + String(e->argv[1]).toInt());
+                } else {
+                    color += String(e->argv[1]);
+                }
+                lightColor(color.c_str());
+                lightUpdate(true, true);
+            }
         }
         DEBUG_MSG_P(PSTR("Color: %s\n"), lightColor().c_str());
         terminalOK();


### PR DESCRIPTION
… command using +N and -N notation

It allows not to ask for current value of brightness and color temperature, but increase/decrease it relatively. So controller like arduino board with buttons and infinite knobs might be more dummy and more efficient (since communication is not bidirectional).

Backward compatibility is almost untouched (except rare cases when people used commands like "brightness +50" instead of "brightness 50").

Example of commands:
brightness +50 // increase brightness for 50 points
mired -10 // decrease color temperature for 10 mireds
mired 100 // set color temperature to 100 mireds