### PR TITLE
Fix ESP.eraseConfig() when using Core 2.3.0

### DIFF
--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -157,6 +157,7 @@ bool settingsRestoreJson(JsonObject& data);
 // -----------------------------------------------------------------------------
 char * ltrim(char * s);
 void nice_delay(unsigned long ms);
+bool inline eraseSDKConfig();
 
 #define ARRAYINIT(type, name, ...) type name[] = {__VA_ARGS__};
 

--- a/code/espurna/terminal.ino
+++ b/code/espurna/terminal.ino
@@ -96,7 +96,7 @@ void _terminalInitCommand() {
         terminalOK();
         resetReason(CUSTOM_RESET_TERMINAL);
         _eepromCommit();
-        ESP.eraseConfig();
+        eraseSDKConfig();
         *((int*) 0) = 0; // see https://github.com/esp8266/Arduino/issues/1494
     });
 

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -578,6 +578,25 @@ bool checkNeedsReset() {
     return _reset_reason > 0;
 }
 
+// Use fixed method for Core 2.3.0, because it erases only 2 out of 4 SDK-reserved sectors
+// Fixed since 2.4.0, see: esp8266/core/esp8266/Esp.cpp: ESP::eraseConfig()
+bool eraseSDKConfig() {
+    #if defined(ARDUINO_ESP8266_RELEASE_2_3_0)
+        const size_t cfgsize = 0x4000;
+        size_t cfgaddr = ESP.getFlashChipSize() - cfgsize;
+
+        for (size_t offset = 0; offset < cfgsize; offset += SPI_FLASH_SEC_SIZE) {
+            if (!ESP.flashEraseSector((cfgaddr + offset) / SPI_FLASH_SEC_SIZE)) {
+                return false;
+            }
+        }
+
+        return true;
+    #else
+        return ESP.eraseConfig();
+    #endif
+}
+
 // -----------------------------------------------------------------------------
 
 char * ltrim(char * s) {


### PR DESCRIPTION
Erase all 4 SDK sectors, as mentioned in https://github.com/xoseperez/espurna/issues/1595#issuecomment-469724250

@xoseperez looking at `flash.dump 1023` (last sector on 4M board) after running erase:
```
         00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
------------------------------------------------------
0x0000:  00 FF FF FF AA 55 AA 55 02 00 00 00 1C 00 00 00      U U

...reset...

         00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
------------------------------------------------------
0x0000:  00 FF FF FF AA 55 AA 55 03 00 00 00 1C 00 00 00      U U
```
Any idea what it is counting at 08? Flash writes? Resets?