### PR TITLE
Add option to disable relay reporting to MQTT

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -356,6 +356,10 @@
 #define RELAY_SAVE_DELAY            1000
 #endif
 
+#ifndef RELAY_REPORT_STATUS
+#define RELAY_REPORT_STATUS         1
+#endif
+
 // Configure the MQTT payload for ON/OFF
 #ifndef RELAY_MQTT_ON
 #define RELAY_MQTT_ON               "1"

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -237,7 +237,7 @@ void _mqttConfigure() {
     // Getters and setters
     _mqtt_setter = getSetting("mqttSetter", MQTT_SETTER);
     _mqtt_getter = getSetting("mqttGetter", MQTT_GETTER);
-    _mqtt_forward = !_mqtt_getter.equals(_mqtt_setter);
+    _mqtt_forward = !_mqtt_getter.equals(_mqtt_setter)  && RELAY_REPORT_STATUS;
 
     // MQTT options
     _mqtt_qos = getSetting("mqttQoS", MQTT_QOS).toInt();

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -339,7 +339,7 @@ bool relayStatus(unsigned char id, bool status, bool report, bool group_report) 
 }
 
 bool relayStatus(unsigned char id, bool status) {
-    return relayStatus(id, status, RELAY_REPORT_STATUS, true);
+    return relayStatus(id, status, mqttForward(), true);
 }
 
 bool relayStatus(unsigned char id) {
@@ -436,7 +436,7 @@ void relayToggle(unsigned char id, bool report, bool group_report) {
 }
 
 void relayToggle(unsigned char id) {
-    relayToggle(id, RELAY_REPORT_STATUS, true);
+    relayToggle(id, mqttForward(), true);
 }
 
 unsigned char relayCount() {

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -436,7 +436,7 @@ void relayToggle(unsigned char id, bool report, bool group_report) {
 }
 
 void relayToggle(unsigned char id) {
-    relayToggle(id, true, true);
+    relayToggle(id, RELAY_REPORT_STATUS, true);
 }
 
 unsigned char relayCount() {

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -339,7 +339,7 @@ bool relayStatus(unsigned char id, bool status, bool report, bool group_report) 
 }
 
 bool relayStatus(unsigned char id, bool status) {
-    return relayStatus(id, status, true, true);
+    return relayStatus(id, status, RELAY_REPORT_STATUS, true);
 }
 
 bool relayStatus(unsigned char id) {


### PR DESCRIPTION
This feature is especially useful when using custom MQTT groups for relays. This adds the option to disable the reporting of relay statuses to MQTT, and report only to the custom MQTT groups (if defined).