### PR TITLE
Sensors can determine precision of their magnitudes

### DIFF
--- a/code/espurna/sensors/BMX280Sensor.h
+++ b/code/espurna/sensors/BMX280Sensor.h
@@ -98,6 +98,16 @@ class BMX280Sensor : public I2CSensor {
             #endif
             return MAGNITUDE_NONE;
         }
+	// Number of decimals for a magnitude (or -1 for default)
+	signed char decimals(unsigned char type) { 
+	    // These numbers of decimals correspond to maximum sensor resolution settings
+	    switch (type) {  
+	    case MAGNITUDE_TEMPERATURE: return 3;
+	    case MAGNITUDE_PRESSURE:    return 4;
+	    case MAGNITUDE_HUMIDITY:    return 2;
+	    }
+	    return -1;
+	}
 
         // Pre-read hook (usually to populate registers with up-to-date data)
         virtual void pre() {

--- a/code/espurna/sensors/BaseSensor.h
+++ b/code/espurna/sensors/BaseSensor.h
@@ -57,6 +57,9 @@ class BaseSensor {
         // Type for slot # index
         virtual unsigned char type(unsigned char index) = 0;
 
+	// Number of decimals for a magnitude (or -1 for default)
+	virtual signed char decimals(unsigned char type) { return -1; }
+
         // Current value for slot # index
         virtual double value(unsigned char index) = 0;
 

--- a/code/espurna/sensors/DallasSensor.h
+++ b/code/espurna/sensors/DallasSensor.h
@@ -192,6 +192,11 @@ class DallasSensor : public BaseSensor {
             return MAGNITUDE_NONE;
         }
 
+	// Number of decimals for a magnitude (or -1 for default)
+	signed char decimals(unsigned char type) { 
+	  return 2; // smallest increment is 0.0625 C, so 2 decimals
+	}
+
         // Pre-read hook (usually to populate registers with up-to-date data)
         void pre() {
             _error = SENSOR_ERROR_OK;


### PR DESCRIPTION
Currently espurna magnitude precisions are hard-coded in sensor.ino. For example the default temperature precision is whole integer degrees Celsius.  This causes sensors such as the Dallas DS18B20 to miss 3 digits of extra precision.

This change modifies BaseSensor so that each sensor class can specify the number of decimals to represent its magnitude types. If the sensor does not override this virtual method, the default is to use the sensors.ino hard-coded values (i.e. fall back on previous method).

I also updated sensors BMX280 and Dallas OneWire are with the specified precision knowledge; tested with BME280 and Dallas DS18B20 sensors