### PR TITLE
Fix lib wrappers

### DIFF
--- a/code/espurna/libs/SyncClientWrap.h
+++ b/code/espurna/libs/SyncClientWrap.h
@@ -9,13 +9,29 @@ Temporary wrap to fix https://github.com/me-no-dev/ESPAsyncTCP/issues/109
 
 #include <SyncClient.h>
 
+// ref Core 2.5.0: cores/esp8266/IPAddress.h
+#ifndef CONST
+#include <lwip/init.h>
+
+#if LWIP_VERSION_MAJOR == 1
+#define CONST
+#else
+#define CONST const
+#endif
+
+#endif
+
 class SyncClientWrap: public SyncClient {
 
     public:
+        SyncClientWrap() {}
+        ~SyncClientWrap() {}
 
-        int connect(const char *host, uint16_t port);
-        int connect(CONST IPAddress& ip, uint16_t port) { return connect(ip, port); }
-        bool flush(unsigned int maxWaitMs = 0) { flush(); return true; }
-        bool stop(unsigned int maxWaitMs = 0) { stop(); return true; }
+        // int connect(const char*, uint16_t);
+        using SyncClient::connect;
+
+        int connect(CONST IPAddress& ip, uint16_t port) { IPAddress _ip(ip); return SyncClient::connect(_ip, port); }
+        bool flush(unsigned int maxWaitMs = 0) { SyncClient::flush(); return true; }
+        bool stop(unsigned int maxWaitMs = 0) { SyncClient::stop(); return true; }
 
 };

--- a/code/espurna/ntp.ino
+++ b/code/espurna/ntp.ino
@@ -12,7 +12,7 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 #include <WiFiClient.h>
 #include <Ticker.h>
 
-#include <libs/NtpClientWrap.h>
+#include "libs/NtpClientWrap.h"
 
 Ticker _ntp_defer;
 


### PR DESCRIPTION
- fixes #1673 influxdb problem. should be compatible with all Core versions
- same issue. local include instead of global. pio allows such things, somehow ( also referenced in https://github.com/xoseperez/espurna/commit/e037dd15fbad66d961cf7f7a647ccb32d54839d4#commitcomment-32905447)