### PR TITLE
Allow empty fingerprints of MQTT SSL server

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -706,9 +706,11 @@
 // you will have to disable all the modules that use ESPAsyncTCP, that is:
 // ALEXA_SUPPORT=0, INFLUXDB_SUPPORT=0, TELNET_SUPPORT=0, THINGSPEAK_SUPPORT=0 and WEB_SUPPORT=0
 //
-// You will need the fingerprint for your MQTT server, example for CloudMQTT:
-// $ echo -n | openssl s_client -connect m11.cloudmqtt.com:24055 > cloudmqtt.pem
-// $ openssl x509 -noout -in cloudmqtt.pem -fingerprint -sha1
+// You will need the fingerprint of your MQTT server, in order to prevent MITS attacks.
+// To get a certificate fingerprint, run the following command:
+// $ echo -n | openssl s_client -connect mqtt.googleapis.com:8883 2>&1 | openssl x509 -noout -fingerprint -sha1 | cut -d\= -f2
+// Note that this fingerprint changes with e.g. LetsEncrypt renewals or when the CSR changes.
+// It's also possible to leave the fingerprint empty, the certificate is then always trusted.
 
 #ifndef MQTT_SSL_ENABLED
 #define MQTT_SSL_ENABLED            0               // By default MQTT over SSL will not be enabled

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -126,10 +126,12 @@ void _mqttConnect() {
             if (secure) {
                 DEBUG_MSG_P(PSTR("[MQTT] Using SSL\n"));
                 unsigned char fp[20] = {0};
-                if (sslFingerPrintArray(getSetting("mqttFP", MQTT_SSL_FINGERPRINT).c_str(), fp)) {
-                    _mqtt.addServerFingerprint(fp);
-                } else {
-                    DEBUG_MSG_P(PSTR("[MQTT] Wrong fingerprint\n"));
+                if (!getSetting("mqttFP", MQTT_SSL_FINGERPRINT).equals("")) {
+                    if (sslFingerPrintArray(getSetting("mqttFP", MQTT_SSL_FINGERPRINT).c_str(), fp)) {
+                        _mqtt.addServerFingerprint(fp);
+                    } else {
+                        DEBUG_MSG_P(PSTR("[MQTT] Wrong fingerprint\n"));
+                    }
                 }
             }
 
@@ -154,7 +156,11 @@ void _mqttConnect() {
                 DEBUG_MSG_P(PSTR("[MQTT] Using SSL\n"));
                 if (_mqtt_client_secure.connect(host, port)) {
                     char fp[60] = {0};
-                    if (sslFingerPrintChar(getSetting("mqttFP", MQTT_SSL_FINGERPRINT).c_str(), fp)) {
+                    if (getSetting("mqttFP", MQTT_SSL_FINGERPRINT).equals("")) {
+                        _mqtt.setClient(_mqtt_client_secure);
+                        _mqtt_client_secure.stop();
+                        yield();
+                    } else if (sslFingerPrintChar(getSetting("mqttFP", MQTT_SSL_FINGERPRINT).c_str(), fp)) {
                         if (_mqtt_client_secure.verify(fp, host)) {
                             _mqtt.setClient(_mqtt_client_secure);
                         } else {


### PR DESCRIPTION
This change allows empty fingerprints of MQTT SSL servers - so bypass key pinning.

Of course this is not really secure, as it allows MITM attacks with fake signatures. But in my opinion this is worth supporting, this way it's much easier to get started with a MQTT/SSL broker setup. In addition, LetsEncrypt certificates change signature every renewal (90 days), so it makes it possible to work with LE-issued certificated without changing the fingerprint at every renewal.