### PR TITLE
Update BMX280Sensor

### DIFF
--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -159,7 +159,7 @@
 #endif
 
 #ifndef BMX280_NUMBER
-#define BMX280_NUMBER                   2       // Number of sensors present. Either 1 or 2 allowed
+#define BMX280_NUMBER                   1       // Number of sensors present. Either 1 or 2 allowed
 #endif
 #ifndef BMX280_ADDRESS
 #define BMX280_ADDRESS                  0x00    // 0x00 means auto (0x76 or 0x77 allowed) for sensor #0

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -481,18 +481,21 @@ void _sensorLoad() {
 
     #if BMX280_SUPPORT
     {
-        BMX280Sensor * sensor = new BMX280Sensor();
-        sensor->setAddress(BMX280_ADDRESS);
-        _sensors.push_back(sensor);
+        // Support up to two sensors with full auto-discovery.
+        const unsigned char number = constrain(getSetting("bmx280Number", BMX280_NUMBER).toInt(), 1, 2);
 
-        #if (BMX280_NUMBER == 2)
-        // Up to two BME sensors allowed on one I2C bus
-        BMX280Sensor * sensor2 = new BMX280Sensor();
-	// For second sensor, if BMX280_ADDRESS is 0x00 then auto-discover
-	//   otherwise choose the other unnamed sensor address
-        sensor->setAddress( (BMX280_ADDRESS == 0x00) ? 0x00 : (0x76 + 0x77 - BMX280_ADDRESS));
-        _sensors.push_back(sensor2);
-        #endif
+        // For second sensor, if BMX280_ADDRESS is 0x00 then auto-discover
+        // otherwise choose the other unnamed sensor address
+        const unsigned char first = getSetting("bmx280Address", BMX280_ADDRESS).toInt();
+        const unsigned char second = (first == 0x00) ? 0x00 : (0x76 + 0x77 - first);
+
+        const unsigned char address_map[2] = { first, second };
+
+        for (unsigned char n=0; n < number; ++n) {
+            BMX280Sensor * sensor = new BMX280Sensor();
+            sensor->setAddress(address_map[n]);
+            _sensors.push_back(sensor);
+        }
     }
     #endif
 

--- a/code/espurna/sensors/BMX280Sensor.h
+++ b/code/espurna/sensors/BMX280Sensor.h
@@ -322,7 +322,7 @@ class BMX280Sensor : public I2CSensor {
 
             #if BMX280_TEMPERATURE > 0
                 int32_t adc_T = i2c_read_uint16(_address, BMX280_REGISTER_TEMPDATA);
-                if (0xFFFF == adc_T) return SENSOR_ERROR_I2C;
+                if (0xFFFF == adc_T) return SENSOR_ERROR_OUT_OF_RANGE;
                 adc_T <<= 8;
                 adc_T |= i2c_read_uint8(_address, BMX280_REGISTER_TEMPDATA+2);
                 adc_T >>= 4;
@@ -350,7 +350,7 @@ class BMX280Sensor : public I2CSensor {
                 int64_t var1, var2, p;
 
                 int32_t adc_P = i2c_read_uint16(_address, BMX280_REGISTER_PRESSUREDATA);
-                if (0xFFFF == adc_P) return SENSOR_ERROR_I2C;
+                if (0xFFFF == adc_P) return SENSOR_ERROR_OUT_OF_RANGE;
                 adc_P <<= 8;
                 adc_P |= i2c_read_uint8(_address, BMX280_REGISTER_PRESSUREDATA+2);
                 adc_P >>= 4;
@@ -362,7 +362,7 @@ class BMX280Sensor : public I2CSensor {
                 var1 = ((var1 * var1 * (int64_t)_bmx280_calib.dig_P3)>>8) +
                     ((var1 * (int64_t)_bmx280_calib.dig_P2)<<12);
                 var1 = (((((int64_t)1)<<47)+var1))*((int64_t)_bmx280_calib.dig_P1)>>33;
-                if (var1 == 0) return SENSOR_ERROR_I2C;  // avoid exception caused by division by zero
+                if (var1 == 0) return SENSOR_ERROR_OUT_OF_RANGE;  // avoid exception caused by division by zero
 
                 p = 1048576 - adc_P;
                 p = (((p<<31) - var2)*3125) / var1;
@@ -379,7 +379,7 @@ class BMX280Sensor : public I2CSensor {
             if (_chip == BMX280_CHIP_BME280) {
 
                 int32_t adc_H = i2c_read_uint16(_address, BMX280_REGISTER_HUMIDDATA);
-                if (0xFFFF == adc_H) return SENSOR_ERROR_I2C;
+                if (0xFFFF == adc_H) return SENSOR_ERROR_OUT_OF_RANGE;
 
                 int32_t v_x1_u32r;
 


### PR DESCRIPTION
resolves #1672
- default to one sensor
- dynamic number and address setting
- do not return i2c-specific error for wrong values
(unless it is some value returned by Wire.read() and not sensor?)