### PR TITLE
Safer loop delay default

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -21,7 +21,11 @@
 #endif
 
 #ifndef LOOP_DELAY_TIME
-#define LOOP_DELAY_TIME         1               // Delay for this millis in the main loop [0-250] (see https://github.com/xoseperez/espurna/issues/1541)
+#define LOOP_DELAY_TIME         10              // Delay for the main loop, in millis [0-250]
+                                                // Recommended minimum is 10, see:
+                                                // https://github.com/xoseperez/espurna/issues/1541
+                                                // https://github.com/xoseperez/espurna/issues/1631
+                                                // https://github.com/esp8266/Arduino/issues/5825
 #endif
 
 //------------------------------------------------------------------------------

--- a/code/espurna/espurna.ino
+++ b/code/espurna/espurna.ino
@@ -25,6 +25,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 std::vector<void (*)()> _loop_callbacks;
 std::vector<void (*)()> _reload_callbacks;
 
+unsigned long _loop_delay = 0;
+
 // -----------------------------------------------------------------------------
 // GENERAL CALLBACKS
 // -----------------------------------------------------------------------------
@@ -41,6 +43,10 @@ void espurnaReload() {
     for (unsigned char i = 0; i < _reload_callbacks.size(); i++) {
         (_reload_callbacks[i])();
     }
+}
+
+unsigned long espurnaLoopDelay() {
+    return _loop_delay;
 }
 
 // -----------------------------------------------------------------------------
@@ -208,6 +214,11 @@ void setup() {
     // Prepare configuration for version 2.0
     migrate();
 
+    // Set up delay() after loop callbacks are finished
+    // Note: should be after settingsSetup()
+    _loop_delay = atol(getSetting("loopDelay", LOOP_DELAY_TIME).c_str());
+    _loop_delay = constrain(_loop_delay, 0, 300);
+
     saveSettings();
 
 }
@@ -218,5 +229,8 @@ void loop() {
     for (unsigned char i = 0; i < _loop_callbacks.size(); i++) {
         (_loop_callbacks[i])();
     }
+
+    // Power saving delay
+    if (_loop_delay) delay(_loop_delay);
 
 }

--- a/code/espurna/system.ino
+++ b/code/espurna/system.ino
@@ -10,8 +10,6 @@ Copyright (C) 2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 // -----------------------------------------------------------------------------
 
-unsigned long _loop_delay = 0;
-
 bool _system_send_heartbeat = false;
 unsigned char _heartbeat_mode = HEARTBEAT_MODE;
 unsigned long _heartbeat_interval = HEARTBEAT_INTERVAL;
@@ -71,10 +69,6 @@ void systemSendHeartbeat() {
 
 bool systemGetHeartbeat() {
     return _system_send_heartbeat;
-}
-
-unsigned long systemLoopDelay() {
-    return _loop_delay;
 }
 
 unsigned long systemLoadAverage() {
@@ -153,11 +147,6 @@ void systemLoop() {
 
     }
 
-    // -------------------------------------------------------------------------
-    // Power saving delay
-    // -------------------------------------------------------------------------
-    if (_loop_delay) delay(_loop_delay);
-
 }
 
 void _systemSetupSpecificHardware() {
@@ -193,10 +182,6 @@ void systemSetup() {
 
     // Init device-specific hardware
     _systemSetupSpecificHardware();
-
-    // Cache loop delay value to speed things (recommended max 250ms)
-    _loop_delay = atol(getSetting("loopDelay", LOOP_DELAY_TIME).c_str());
-    _loop_delay = constrain(_loop_delay, 0, 300);
 
     // Register Loop
     espurnaRegisterLoop(systemLoop);

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -500,8 +500,8 @@ void info() {
     #if ADC_MODE_VALUE == ADC_VCC
         DEBUG_MSG_P(PSTR("[MAIN] Power: %u mV\n"), ESP.getVcc());
     #endif
-    if (systemLoopDelay()) {
-        DEBUG_MSG_P(PSTR("[MAIN] Power saving delay value: %lu ms\n"), systemLoopDelay());
+    if (espurnaLoopDelay()) {
+        DEBUG_MSG_P(PSTR("[MAIN] Power saving delay value: %lu ms\n"), espurnaLoopDelay());
     }
 
     const WiFiSleepType_t sleep_mode = WiFi.getSleepMode();


### PR DESCRIPTION
- revert to 10 as default loop delay (#1574, https://github.com/xoseperez/espurna/issues/1631#issuecomment-480434926)
- call delay after callbacks are done, instead of calling it at the beginning (systemLoop is inside callbacks list)