### PR TITLE
Fix WS status message on boot

### DIFF
--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -311,9 +311,9 @@ void _wsUpdate(JsonObject& root) {
 }
 
 void _wsDoUpdate(bool reset = false) {
-    static unsigned long last = 0;
+    static unsigned long last = millis();
     if (reset) {
-        last = 0;
+        last = millis() + WS_UPDATE_INTERVAL;
         return;
     }
 


### PR DESCRIPTION
Fix for when `millis()` is less than wanted interval and last=0 (i.e. right after reboot or on millis overflow)