### PR TITLE
PZEM004T: settings & dev board

### DIFF
--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -354,7 +354,7 @@ void _sensorInitCommands() {
             DEBUG_MSG_P(PSTR("[SENSOR] PZEM004T\n"));
             for(unsigned char dev = init; dev < limit; dev++) {
                 float offset = pzem004t_sensor->resetEnergy(dev);
-                setSetting("pzEneTotal", dev, offset);
+                setSetting("pzemEneTotal", dev, offset);
                 DEBUG_MSG_P(PSTR("Device %d/%s - Offset: %s\n"), dev, pzem004t_sensor->getAddress(dev).c_str(), String(offset).c_str());
             }
             terminalOK();
@@ -737,7 +737,7 @@ void _sensorLoad() {
         // Read saved energy offset
         unsigned char dev_count = sensor->getAddressesCount();
         for(unsigned char dev = 0; dev < dev_count; dev++) {
-            float value = getSetting("pzEneTotal", dev, 0).toFloat();
+            float value = getSetting("pzemEneTotal", dev, 0).toFloat();
             if (value > 0) sensor->resetEnergy(dev, value);
         }
         _sensors.push_back(sensor);
@@ -1196,7 +1196,7 @@ void _sensorConfigure() {
                     unsigned char dev_count = sensor->getAddressesCount();
                     for(unsigned char dev = 0; dev < dev_count; dev++) {
                         sensor->resetEnergy(dev, 0);
-                        delSetting("pzEneTotal", dev);
+                        delSetting("pzemEneTotal", dev);
                     }
                     _sensorResetTS();
                 }
@@ -1373,6 +1373,9 @@ void sensorSetup() {
     // Backwards compatibility
     moveSetting("powerUnits", "pwrUnits");
     moveSetting("energyUnits", "eneUnits");
+
+	// Update PZEM004T energy total across multiple devices
+    moveSettings("pzEneTotal", "pzemEneTotal");
 
     // Load sensors
     _sensorLoad();

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -718,14 +718,22 @@ void _sensorLoad() {
 
     #if PZEM004T_SUPPORT
     {
+        String addresses = getSetting("pzemAddr", PZEM004T_ADDRESSES);
+        if (!addresses.length()) {
+            DEBUG_MSG_P(PSTR("[SENSOR] PZEM004T Error: no addresses are configured\n"));
+            return;
+        }
+
         PZEM004TSensor * sensor = pzem004t_sensor = new PZEM004TSensor();
-        #if PZEM004T_USE_SOFT
-            sensor->setRX(PZEM004T_RX_PIN);
-            sensor->setTX(PZEM004T_TX_PIN);
-        #else
+        sensor->setAddresses(addresses.c_str());
+
+        if (getSetting("pzemSoft", PZEM004T_USE_SOFT).toInt() == 1) {
+            sensor->setRX(getSetting("pzemRX", PZEM004T_RX_PIN).toInt());
+            sensor->setTX(getSetting("pzemTX", PZEM004T_TX_PIN).toInt());
+        } else {
             sensor->setSerial(& PZEM004T_HW_PORT);
-        #endif
-        sensor->setAddresses(PZEM004T_ADDRESSES);
+        }
+
         // Read saved energy offset
         unsigned char dev_count = sensor->getAddressesCount();
         for(unsigned char dev = 0; dev < dev_count; dev++) {

--- a/code/espurna/settings.ino
+++ b/code/espurna/settings.ino
@@ -103,6 +103,23 @@ void moveSetting(const char * from, const char * to) {
     delSetting(from);
 }
 
+void moveSetting(const char * from, const char * to, unsigned int index) {
+    String value = getSetting(from, index, "");
+    if (value.length() > 0) setSetting(to, index, value);
+    delSetting(from, index);
+}
+
+void moveSettings(const char * from, const char * to) {
+    unsigned int index = 0;
+    while (index < 100) {
+        String value = getSetting(from, index, "");
+        if (value.length() == 0) break;
+        setSetting(to, index, value);
+        delSetting(from, index);
+        index++;
+    }
+}
+
 template<typename T> String getSetting(const String& key, T defaultValue) {
     String value;
     if (!Embedis::get(key, value)) value = String(defaultValue);

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -400,6 +400,18 @@ build_flags = ${common.build_flags_4m1m} -DTINKERMAN_RFM69GW -DNOWSAUTH
 monitor_speed = 115200
 extra_scripts = ${common.extra_scripts}
 
+[env:nodemcu-pzem004t]
+platform = ${common.platform}
+framework = ${common.framework}
+board = ${common.board_4m}
+board_build.flash_mode = ${common.flash_mode}
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_flags = ${common.build_flags_4m1m} -DNODEMCU_BASIC -DEBUG_SERIAL_SUPPORT=0 -DPZEM004T_SUPPORT=1 -DDISABLE_POSTMORTEM_STACKDUMP
+upload_speed = ${common.upload_speed_fast}
+monitor_speed = ${common.monitor_speed}
+extra_scripts = ${common.extra_scripts}
+
 # ------------------------------------------------------------------------------
 
 [env:foxel-lightfox-dual]


### PR DESCRIPTION
resolve #1688 

- platformio `env:nodemcu-pzem004t`
- port settings setup from v2

No support for swapped `Serial`, just SoftwareSerial. PZEM library does `Serial.begin()` right in the constructor, so `Serial.swap()` call can go right after local sensor's `.begin()` if HW port is used.

SoftwareSerial support is always built in. PZEM library requires global define `PZEM004T_NO_SWSERIAL` an sensor here needs to conditionally depend on it, because it will strip tx+rx constructor.
545856 - 541896 = **3960** bytes of difference between SWS and no-SWS versions.
Not adding that here yet.