### PR TITLE
pio: patch lwip1 MTU bug in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
 env:
   global:
   - BUILDER_TOTAL_THREADS=4
+  - ESPURNA_PIO_PATCH_ISSUE_1610=y
 script:
 - cd code && ./build.sh -p &&  cd ..
 stages:

--- a/code/extra_scripts.py
+++ b/code/extra_scripts.py
@@ -92,6 +92,36 @@ def dummy_ets_printf(target, source, env):
     env.Execute(env.VerboseAction(" ".join(cmd), "Removing ets_printf / ets_printf_P"))
     env.Depends(postmortem_obj_file,"$BUILD_DIR/src/dummy_ets_printf.c.o")
 
+def patch_lwip():
+    # ignore when building with lwip2
+    if "lwip_gcc" not in env["LIBS"]:
+        return
+
+    framework_dir = env["FRAMEWORK_ARDUINOESP8266_DIR"]
+
+    platform = env.PioPlatform()
+    toolchain_prefix = os.path.join(platform.get_package_dir("toolchain-xtensa"), "bin", "xtensa-lx106-elf-")
+
+    patch_action = env.VerboseAction(" ".join([
+        "-patch", "-u", "-N", "-d",
+        os.path.join(framework_dir, "tools", "sdk", "lwip"),
+        os.path.join("src", "core", "tcp_out.c"),
+        env.subst(os.path.join("$PROJECT_DIR", "..", "dist", "patches", "lwip_mtu_issue_1610.patch"))
+    ]), "Patching lwip source")
+    build_action = env.VerboseAction(" ".join([
+        "make", "-C", os.path.join(framework_dir, "tools", "sdk", "lwip", "src"),
+        "install",
+        "TOOLS_PATH={}".format(toolchain_prefix),
+        "LWIP_LIB=liblwip_gcc.a"
+    ]), "Rebuilding lwip")
+
+    patcher = env.Alias("patch-lwip", None, patch_action)
+    builder = env.Alias("build-lwip", patcher, build_action)
+    if os.environ.get("ESPURNA_PIO_PATCH_ISSUE_1610"):
+        env.Depends("$BUILD_DIR/${PROGNAME}.elf", builder)
+    env.AlwaysBuild(patcher)
+    env.AlwaysBuild(builder)
+
 # ------------------------------------------------------------------------------
 # Hooks
 # ------------------------------------------------------------------------------
@@ -109,3 +139,7 @@ env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", check_size)
 if "DISABLE_POSTMORTEM_STACKDUMP" in env["CPPFLAGS"]:
     env.AddPostAction("$BUILD_DIR/FrameworkArduino/core_esp8266_postmortem.c.o", dummy_ets_printf)
     env.AddPostAction("$BUILD_DIR/FrameworkArduino/core_esp8266_postmortem.cpp.o", dummy_ets_printf)
+
+# patch lwip1 sources conditionally:
+# https://github.com/xoseperez/espurna/issues/1610
+patch_lwip()

--- a/dist/patches/lwip_mtu_issue_1610.patch
+++ b/dist/patches/lwip_mtu_issue_1610.patch
@@ -1,0 +1,13 @@
+diff --git a/src/core/tcp_out.c b/src/core/tcp_out.c
+index fa8d77f..a7b0595 100644
+--- a/src/core/tcp_out.c
++++ b/src/core/tcp_out.c
+@@ -469,7 +469,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u16_t len, u8_t apiflags)
+     if (oversize > 0) {
+       LWIP_ASSERT("inconsistent oversize vs. space", oversize_used <= space);
+       seg = last_unsent;
+-      oversize_used = oversize < len ? oversize : len;
++      oversize_used = LWIP_MIN(space, LWIP_MIN(oversize, len));
+       pos += oversize_used;
+       oversize -= oversize_used;
+       space -= oversize_used;


### PR DESCRIPTION
fix #1610 

- triggers only when `ESPURNA_PIO_PATCH_ISSUE_1610=something` is specified
- conditionally patch & build lwip1 sources whenever build environment depends on it
- `build-lwip` and `patch-lwip` pio targets (use `pio run -e <env> -t <target>`) to trigger respective actions

make itself will track dependencies, and will not rebuild things. only overhead is extra `patch` and `cp` call.
platformio --silent flag suppresses all output, so no additional logging either