### PR TITLE
MQTT and HA brightness

### DIFF
--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -56,7 +56,7 @@ void _haSendMagnitudes(const JsonObject& deviceConfig) {
             _haSendMagnitude(i, config);
             config["uniq_id"] = getIdentifier() + "_" + magnitudeTopic(magnitudeType(i)) + "_" + String(i);
             config["device"] = deviceConfig;
-            
+
             config.printTo(output);
             jsonBuffer.clear();
         }
@@ -98,9 +98,10 @@ void _haSendSwitch(unsigned char i, JsonObject& config) {
 
         if (i == 0) {
 
+            config["brightness_state_topic"] = mqttTopic(MQTT_TOPIC_BRIGHTNESS, false);
+            config["brightness_command_topic"] = mqttTopic(MQTT_TOPIC_BRIGHTNESS, true);
+
             if (lightHasColor()) {
-                config["brightness_state_topic"] = mqttTopic(MQTT_TOPIC_BRIGHTNESS, false);
-                config["brightness_command_topic"] = mqttTopic(MQTT_TOPIC_BRIGHTNESS, true);
                 config["rgb_state_topic"] = mqttTopic(MQTT_TOPIC_COLOR_RGB, false);
                 config["rgb_command_topic"] = mqttTopic(MQTT_TOPIC_COLOR_RGB, true);
                 config["color_temp_command_topic"] = mqttTopic(MQTT_TOPIC_MIRED, true);
@@ -250,7 +251,7 @@ void _haDumpConfig(std::function<void(String&)> printer, bool wrapJson = false) 
 
 void _haGetDeviceConfig(JsonObject& config) {
     String identifier = getIdentifier();
-    
+
     config.createNestedArray("identifiers").add(identifier);
     config["name"] = getSetting("desc", getSetting("hostname"));
     config["manufacturer"] = String(MANUFACTURER);
@@ -278,7 +279,7 @@ void _haSend() {
     #if SENSOR_SUPPORT
         _haSendMagnitudes(deviceConfig);
     #endif
-    
+
     jsonBuffer.clear();
     _haSendFlag = false;
 

--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -56,7 +56,7 @@ void _haSendMagnitudes(const JsonObject& deviceConfig) {
             _haSendMagnitude(i, config);
             config["uniq_id"] = getIdentifier() + "_" + magnitudeTopic(magnitudeType(i)) + "_" + String(i);
             config["device"] = deviceConfig;
-
+            
             config.printTo(output);
             jsonBuffer.clear();
         }
@@ -251,7 +251,7 @@ void _haDumpConfig(std::function<void(String&)> printer, bool wrapJson = false) 
 
 void _haGetDeviceConfig(JsonObject& config) {
     String identifier = getIdentifier();
-
+    
     config.createNestedArray("identifiers").add(identifier);
     config["name"] = getSetting("desc", getSetting("hostname"));
     config["manufacturer"] = String(MANUFACTURER);
@@ -279,7 +279,7 @@ void _haSend() {
     #if SENSOR_SUPPORT
         _haSendMagnitudes(deviceConfig);
     #endif
-
+    
     jsonBuffer.clear();
     _haSendFlag = false;
 

--- a/code/espurna/light.ino
+++ b/code/espurna/light.ino
@@ -373,7 +373,7 @@ void _toHSV(char * hsv, size_t len) {
 }
 
 void _toLong(char * color, size_t len, bool target) {
-
+    
     if (!_light_has_color) return;
 
     snprintf_P(color, len, PSTR("%d,%d,%d"),

--- a/code/espurna/light.ino
+++ b/code/espurna/light.ino
@@ -373,7 +373,7 @@ void _toHSV(char * hsv, size_t len) {
 }
 
 void _toLong(char * color, size_t len, bool target) {
-    
+
     if (!_light_has_color) return;
 
     snprintf_P(color, len, PSTR("%d,%d,%d"),
@@ -539,8 +539,9 @@ void _lightMQTTCallback(unsigned int type, const char * topic, const char * payl
 
     if (type == MQTT_CONNECT_EVENT) {
 
+        mqttSubscribe(MQTT_TOPIC_BRIGHTNESS);
+
         if (_light_has_color) {
-            mqttSubscribe(MQTT_TOPIC_BRIGHTNESS);
             mqttSubscribe(MQTT_TOPIC_MIRED);
             mqttSubscribe(MQTT_TOPIC_KELVIN);
             mqttSubscribe(MQTT_TOPIC_COLOR_RGB);


### PR DESCRIPTION
MQTT and HA brightness shall only be depended on LIGHT_PROVIDER != LIGHT_PROVIDER_NONE

This should fix #1292. I did a quick test with MQTT and web interface on `intermittech-quinled` target without observations. The homeassistant part is untested.



