### PR TITLE
Allow wildcard to enable discovery from browser using CORS

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -531,7 +531,7 @@
 // there are no special requirements. Any static web server will do (NGinx, Apache, Lighttpd,...).
 // The only requirement is that the resource must be available under this domain.
 #ifndef WEB_REMOTE_DOMAIN
-#define WEB_REMOTE_DOMAIN           "http://espurna.io"
+#define WEB_REMOTE_DOMAIN           "*"
 #endif
 
 // -----------------------------------------------------------------------------

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -557,7 +557,9 @@ void wsSetup() {
     // CORS
     #ifdef WEB_REMOTE_DOMAIN
         DefaultHeaders::Instance().addHeader("Access-Control-Allow-Origin", WEB_REMOTE_DOMAIN);
-        DefaultHeaders::Instance().addHeader("Access-Control-Allow-Credentials", "true");
+        if (strcmp(WEB_REMOTE_DOMAIN, "*")){
+            DefaultHeaders::Instance().addHeader("Access-Control-Allow-Credentials", "true");
+        }
     #endif
 
     webServer()->on("/auth", HTTP_GET, _onAuth);


### PR DESCRIPTION
I believe wildcard as origin is a more useful default for CORS, enabling to discover espurna devices from a browser, using the /discover endpoint. Wildcard works for this endpoint, since it does not require credentials.

In the future [Make WEB_REMOTE_DOMAIN configurable from admin console](https://github.com/xoseperez/espurna/issues/1289) could be used to override the default.

The issue has also been discussed in [WEB_REMOTE_DOMAIN How to use](https://github.com/xoseperez/espurna/issues/1027)

An example of a browser discory applikation is [ESPurna Device Locator](https://github.com/KimNyholm/espurna-device-locator/)