### PR TITLE
Build date

### DIFF
--- a/code/espurna/mdns.ino
+++ b/code/espurna/mdns.ino
@@ -50,6 +50,7 @@ void mdnsServerSetup() {
     // Public ESPurna related txt for OTA discovery
     MDNS.addServiceTxt("arduino", "tcp", "app_name", APP_NAME);
     MDNS.addServiceTxt("arduino", "tcp", "app_version", APP_VERSION);
+    MDNS.addServiceTxt("arduino", "tcp", "build_date", buildTime());
     MDNS.addServiceTxt("arduino", "tcp", "mac", WiFi.macAddress());
     MDNS.addServiceTxt("arduino", "tcp", "target_board", getBoardName());
     {

--- a/code/ota.py
+++ b/code/ota.py
@@ -91,7 +91,7 @@ def list_devices():
             "SDK_SIZE",
             "FREE_SPACE"
     ))
-    print("-" * 139)
+    print("-" * 164)
 
     index = 0
     for device in devices:

--- a/code/ota.py
+++ b/code/ota.py
@@ -55,6 +55,7 @@ def on_service_state_change(zeroconf, service_type, name, state_change):
                 'mac': '',
                 'app_name': '',
                 'app_version': '',
+                'build_date': '',
                 'target_board': '',
                 'mem_size': 0,
                 'sdk_size': 0,
@@ -76,7 +77,7 @@ def list_devices():
     """
     Shows the list of discovered devices
     """
-    output_format = "{:>3}  {:<14}  {:<15}  {:<17}  {:<12}  {:<12}  {:<25}  {:<8}  {:<8}  {:<10}"
+    output_format = "{:>3}  {:<14}  {:<15}  {:<17}  {:<12}  {:<12}  {:<20}  {:<25}  {:<8}  {:<8}  {:<10}"
     print(output_format.format(
             "#",
             "HOSTNAME",
@@ -84,6 +85,7 @@ def list_devices():
             "MAC",
             "APP",
             "VERSION",
+            "BUILD_DATE",
             "DEVICE",
             "MEM_SIZE",
             "SDK_SIZE",
@@ -101,6 +103,7 @@ def list_devices():
                 device.get('mac', ''),
                 device.get('app_name', ''),
                 device.get('app_version', ''),
+                device.get('build_date', ''),
                 device.get('target_board', ''),
                 device.get('mem_size', 0),
                 device.get('sdk_size', 0),


### PR DESCRIPTION
This change makes managing ota updates of different builds of the same version (i.e. 1.13.6-dev) a little easier. Sample output is:
```
ESPurna OTA Manager v0.3

  #  HOSTNAME        IP               MAC                APP           VERSION       BUILD_DATE            DEVICE                     MEM_SIZE  SDK_SIZE  FREE_SPACE
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
  1  ALEXA-BRIDGE    10.1.5.151                                                                                                       0         0         0
  2  ESP-RS-01       10.1.22.201      84:F3:EB:83:9F:0F  ESPURNA       1.13.6-dev    2019-05-20 00:32:55   MPK_RS_4CH                 4096      4096      2654208
  3  ESP-WP-01       10.1.22.1        BC:DD:C2:23:2B:E3  ESPURNA       1.13.6-dev    2019-05-20 00:05:06   BLITZWOLF_BWSHPX           1024      1024      516096
  4  ESP-WP-02       10.1.22.2        BC:DD:C2:2A:D5:B3  ESPURNA       1.13.6-dev    2019-05-20 00:05:06   BLITZWOLF_BWSHPX           1024      1024      516096
```