### PR TITLE
Build date nofuss

### DIFF
--- a/code/espurna/nofuss.ino
+++ b/code/espurna/nofuss.ino
@@ -54,7 +54,7 @@ void _nofussConfigure() {
 
     } else {
 
-        char buffer[20];
+        char buffer[32];
         snprintf_P(buffer, sizeof(buffer), PSTR("%s-%s"), APP_NAME, DEVICE);
 
         NoFUSSClient.setServer(nofussServer);

--- a/code/espurna/nofuss.ino
+++ b/code/espurna/nofuss.ino
@@ -58,12 +58,15 @@ void _nofussConfigure() {
         snprintf_P(buffer, sizeof(buffer), PSTR("%s-%s"), APP_NAME, DEVICE);
 
         NoFUSSClient.setServer(nofussServer);
-        NoFUSSClient.setDevice(buffer);
-        NoFUSSClient.setVersion(APP_VERSION);
-
         DEBUG_MSG_P(PSTR("[NOFUSS] Server : %s\n"), nofussServer.c_str());
+
+        NoFUSSClient.setDevice(buffer);
         DEBUG_MSG_P(PSTR("[NOFUSS] Dervice: %s\n"), buffer);
-        DEBUG_MSG_P(PSTR("[NOFUSS] Version: %s\n"), APP_VERSION);
+
+        snprintf_P(buffer, sizeof(buffer), PSTR("%s/%s"), APP_VERSION, buildTime().c_str());
+        NoFUSSClient.setVersion(buffer);
+        DEBUG_MSG_P(PSTR("[NOFUSS] Version: %s\n"), buffer);
+
         DEBUG_MSG_P(PSTR("[NOFUSS] Enabled\n"));
 
     }


### PR DESCRIPTION
I counldn't find a proper way to upgrade between different builds of the same version using NoFuss
(defining rules to upgrade from 1.13.6-dev to 1.13.6-dev caused infinite upgrade loop).
Therfore I decided to include build date in X-ESP8266-VERSION header to allow more gradual upgrades.
While it's probably not the most elegant solution, it does the job and preserves backwards compatibility (by simply ommiting build date str in versions.json).
And since i had to increase buffer length anyway, this PR also solves xoseperez/espurna#1721