### PR TITLE
Fix path creation for firmware in build.sh

### DIFF
--- a/code/build.sh
+++ b/code/build.sh
@@ -117,7 +117,7 @@ build_webui() {
 build_environments() {
     echo "--------------------------------------------------------------"
     echo "Building firmware images..."
-    mkdir -p ../firmware/espurna-$version
+    mkdir -p $destination/espurna-$version
 
     for environment in $environments; do
         echo -n "* espurna-$version-$environment.bin --- "


### PR DESCRIPTION
When using `build.sh` with `-d` option to relocate firmware storage location the script will fail with e.g.:
`mv: cannot move '.pioenvs/intermittech-quinled/firmware.bin' to '/firmware/espurna-1.13.6-dev/espurna-1.13.6-dev-intermittech-quinled.bin': No such file or directory`

This is cause by `mkdir` not using `$destination` variable.