### PR TITLE
Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+FROM debian:buster-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get install -y python2-minimal \
+    python-pip \
+    nodejs \
+    npm \
+    git \
+    libc-bin \
+    bash \
+    && npm install -g npm \
+    && pip install platformio
+
+RUN groupadd --gid 1000 worker && \
+    useradd \
+    --uid 1000 \
+    --gid worker \
+    --shell /bin/bash \
+    --create-home worker
+
+RUN mkdir -p /espurna && \
+    mkdir -p /firmware && \
+    chown -R worker:worker /espurna && \
+    chown -R worker:worker /firmware
+
+USER worker
+
+RUN git clone -b dev https://github.com/xoseperez/espurna.git /espurna && \
+    cd /espurna/code && \
+    npm install --only=dev && \
+    platformio run --target clean
+
+VOLUME ["/espurna", "/firmware"]
+
+WORKDIR /espurna/code
+
+COPY docker-entrypoint.sh /
+ENTRYPOINT ["./build.sh", "-d", "/firmware"]
+CMD []

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,28 @@
+# Docker build image
+
+This directory contains a docker file for an ESPurna build environment.
+
+Two volumes can be used. 
+* `/espurna` with ESPurna source code.
+* `/firmware` target directory for complied firmware files.
+
+## Build
+
+```bash
+docker build -t espruna-build .
+```
+
+## Examples
+
+The simples example will build all firmware files from dev branch to /tmp/firmware.
+
+```bash
+docker run --rm -it -v /tmp/firmware/:/firmware espruna-build
+```
+
+
+This example will only build firmware for environment `intermittech-quinled` from local files in `/home/user/espurna`
+
+```bash
+docker run --rm -it -v /tmp/firmware/:/firmware -v /home/user/espurna/:/espurna espruna-build intermittech-quinled
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ Two volumes can be used.
 ## Build
 
 ```bash
-docker build -t espruna-build .
+docker build -t espurna-build .
 ```
 
 ## Examples
@@ -17,12 +17,12 @@ docker build -t espruna-build .
 The simples example will build all firmware files from dev branch to /tmp/firmware.
 
 ```bash
-docker run --rm -it -v /tmp/firmware/:/firmware espruna-build
+docker run --rm -it -v /tmp/firmware/:/firmware espurna-build
 ```
 
 
 This example will only build firmware for environment `intermittech-quinled` from local files in `/home/user/espurna`
 
 ```bash
-docker run --rm -it -v /tmp/firmware/:/firmware -v /home/user/espurna/:/espurna espruna-build intermittech-quinled
+docker run --rm -it -v /tmp/firmware/:/firmware -v /home/user/espurna/:/espurna espurna-build intermittech-quinled
 ```


### PR DESCRIPTION
# Docker build image

This PR contains a docker file for an ESPurna build environment.

Two volumes can be used. 
* `/espurna` with ESPurna source code.
* `/firmware` target directory for complied firmware files.

## Build

```bash
docker build -t espurna-build .
```

## Examples

The simples example will build all firmware files from dev branch to /tmp/firmware.

```bash
docker run --rm -it -v /tmp/firmware/:/firmware espurna-build
```


This example will only build firmware for environment `intermittech-quinled` from local files in `/home/user/espurna`

```bash
docker run --rm -it -v /tmp/firmware/:/firmware -v /home/user/espurna/:/espurna espurna-build intermittech-quinled
```