### PR TITLE
Close connection in notFound callback

### DIFF
--- a/code/espurna/web.ino
+++ b/code/espurna/web.ino
@@ -344,8 +344,12 @@ void _onRequest(AsyncWebServerRequest *request){
         if (response) return;
     }
 
-    // No subscriber handled the request, return a 404
+    // No subscriber handled the request, return a 404 with implicit "Connection: close"
     request->send(404);
+
+    // And immediatly close the connection, ref: https://github.com/xoseperez/espurna/issues/1660
+    // Not doing so will cause memory exhaustion, because the connection will linger
+    request->client()->close();
 
 }
 
@@ -356,6 +360,10 @@ void _onBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t i
         bool response = (_web_body_callbacks[i])(request, data, len, index, total);
         if (response) return;
     }
+
+    // Same as _onRequest(...)
+    request->send(404);
+    request->client()->close();
 
 }
 

--- a/code/espurna/web.ino
+++ b/code/espurna/web.ino
@@ -336,7 +336,32 @@ void _onUpgradeData(AsyncWebServerRequest *request, String filename, size_t inde
     }
 }
 
+bool _onAPModeRequest(AsyncWebServerRequest *request) {
+
+    if ((WiFi.getMode() & WIFI_AP) > 0) {
+        const String domain = getSetting("hostname") + ".";
+        const String host = request->header("Host");
+        const String ip = WiFi.softAPIP().toString();
+
+        // Only allow requests that use our hostname or ip
+        if (host.equals(ip)) return true;
+        if (host.startsWith(domain)) return true;
+
+        // Immediatly close the connection, ref: https://github.com/xoseperez/espurna/issues/1660
+        // Not doing so will cause memory exhaustion, because the connection will linger
+        request->send(404);
+        request->client()->close();
+
+        return false;
+    }
+
+    return true;
+
+}
+
 void _onRequest(AsyncWebServerRequest *request){
+
+    if (!_onAPModeRequest(request)) return;
 
     // Send request to subscribers
     for (unsigned char i = 0; i < _web_request_callbacks.size(); i++) {
@@ -355,13 +380,15 @@ void _onRequest(AsyncWebServerRequest *request){
 
 void _onBody(AsyncWebServerRequest *request, uint8_t *data, size_t len, size_t index, size_t total) {
 
+    if (!_onAPModeRequest(request)) return;
+
     // Send request to subscribers
     for (unsigned char i = 0; i < _web_body_callbacks.size(); i++) {
         bool response = (_web_body_callbacks[i])(request, data, len, index, total);
         if (response) return;
     }
 
-    // Same as _onRequest(...)
+    // Same as _onAPModeRequest(...)
     request->send(404);
     request->client()->close();
 


### PR DESCRIPTION
resolve #1660 
also, see https://github.com/tzapu/WiFiManager/blob/740005b21e5f5e5c6092dbd4d3037e4edee19113/WiFiManager.cpp#L749

as described in the issue, device receives a lot of simultaneous requests in very short amount of time.
this solves the original test-case example with Android 9 connecting to the AP with captive portal on.
the connecting device continues to send requests, but heap is no longer exhausted by keeping track on old connections.
