### PR TITLE
Rtcmem update

### DIFF
--- a/code/espurna/rtcmem.ino
+++ b/code/espurna/rtcmem.ino
@@ -46,18 +46,38 @@ void _rtcmemInitCommands() {
         _rtcmemInit();
     });
 
-    terminalRegisterCommand(F("RTCMEM.ERASE"), [](Embedis* e) {
-        _rtcmemErase();
-    });
-
     terminalRegisterCommand(F("RTCMEM.DUMP"), [](Embedis* e) {
-        DEBUG_MSG_P(PSTR("[RTCMEM] status:%u blocks:%u addr:0x%p\n"),
-            _rtcmemStatus(), RtcmemSize, Rtcmem);
 
-        for (uint8_t block=0; block<RtcmemSize; ++block) {
-            DEBUG_MSG_P(PSTR("[RTCMEM] %02u: %u\n"),
-                block, reinterpret_cast<volatile uint32_t*>(RTCMEM_ADDR)[block]);
-        }
+        DEBUG_MSG_P(PSTR("[RTCMEM] boot_status=%u status=%u blocks_used=%u\n"),
+            _rtcmem_status, _rtcmemStatus(), RtcmemSize);
+
+        String line;
+        line.reserve(96);
+        char buffer[16] = {0};
+
+        auto addr = reinterpret_cast<volatile uint32_t*>(RTCMEM_ADDR);
+
+        uint8_t block = 1;
+        uint8_t offset = 0;
+        uint8_t start = 0;
+
+        do {
+
+            offset = block - 1;
+
+            snprintf(buffer, sizeof(buffer), "%08x ", *(addr + offset));
+            line += buffer;
+
+            if ((block % 8) == 0) {
+                DEBUG_MSG_P(PSTR("%02u %p: %s\n"), start, addr+start, line.c_str());
+                start = block;
+                line = "";
+            }
+
+            ++block;
+
+        } while (block<(RTCMEM_BLOCKS+1));
+
     });
 }
 

--- a/code/espurna/rtcmem.ino
+++ b/code/espurna/rtcmem.ino
@@ -1,7 +1,22 @@
+/*
+
+RTMEM MODULE
+
+*/
+
 bool _rtcmem_status = false;
 
+void _rtcmemErase() {
+    auto ptr = reinterpret_cast<volatile uint32_t*>(RTCMEM_ADDR);
+    const auto end = ptr + RTCMEM_BLOCKS;
+    DEBUG_MSG_P(PSTR("[RTCMEM] Erasing start=%p end=%p\n"), ptr, end);
+    do {
+        *ptr = 0;
+    } while (++ptr != end);
+}
+
 void _rtcmemInit() {
-    memset((uint32_t*)RTCMEM_ADDR, 0, sizeof(uint32_t) * RTCMEM_BLOCKS);
+    _rtcmemErase();
     Rtcmem->magic = RTCMEM_MAGIC;
 }
 
@@ -31,7 +46,8 @@ void _rtcmemInitCommands() {
         _rtcmemInit();
     });
 
-    terminalRegisterCommand(F("RTCMEM.TEST"), [](Embedis* e) {
+    terminalRegisterCommand(F("RTCMEM.ERASE"), [](Embedis* e) {
+        _rtcmemErase();
     });
 
     terminalRegisterCommand(F("RTCMEM.DUMP"), [](Embedis* e) {


### PR DESCRIPTION
- remove `rtcmem.test` command that was doing nothing
- replace memset with direct address writes. adds a debug with start/end address
- nicer `rtcmem.dump`. prints all usable block instead of just the ones used. still show the number of continuous blocks used in the status string at the top:
```
[080089] [RTCMEM] boot_status=0 status=0 blocks_used=8
[080090] 00 60001280: 00000000 00000001 00000002 00000003 00000004 00000005 00000006 00000007
[080091] 08 600012a0: 00000008 00000009 0000000a 0000000b 0000000c 0000000d 0000000e 0000000f
[080100] 16 600012c0: 00000010 00000011 00000012 00000013 00000014 00000015 00000016 00000017
[080109] 24 600012e0: 00000018 00000019 0000001a 0000001b 0000001c 0000001d 0000001e 0000001f
[080118] 32 60001300: 00000020 00000021 00000022 00000023 00000024 00000025 00000026 00000027
[080127] 40 60001320: 00000028 00000029 0000002a 0000002b 0000002c 0000002d 0000002e 0000002f
[080136] 48 60001340: 00000030 00000031 00000032 00000033 00000034 00000035 00000036 00000037
[080145] 56 60001360: 00000038 00000039 0000003a 0000003b 0000003c 0000003d 0000003e 0000003f
[080154] 64 60001380: 00000040 00000041 00000042 00000043 00000044 00000045 00000046 00000047
[080163] 72 600013a0: 00000048 00000049 0000004a 0000004b 0000004c 0000004d 0000004e 0000004f
[080172] 80 600013c0: 00000050 00000051 00000052 00000053 00000054 00000055 00000056 00000057
[080181] 88 600013e0: 00000058 00000059 0000005a 0000005b 0000005c 0000005d 0000005e 0000005f
```