### PR TITLE
Update EventsSensor

### DIFF
--- a/code/espurna/sensors/EventSensor.h
+++ b/code/espurna/sensors/EventSensor.h
@@ -130,6 +130,9 @@ class EventSensor : public BaseSensor {
                 _counter = 0;
                 return value;
             };
+            if (index == 1) {
+                return _value;
+            }
             return 0;
         }
 
@@ -155,7 +158,10 @@ class EventSensor : public BaseSensor {
                 _counter += 1;
 
                 // we are handling callbacks in tick()
-                if (_trigger) _events.push(digitalRead(gpio));
+                if (_trigger) {
+                    _value = digitalRead(gpio);
+                    _events.push(_value);
+                }
             }
         }
 
@@ -185,6 +191,7 @@ class EventSensor : public BaseSensor {
 
         volatile unsigned long _counter = 0;
         std::stack<unsigned char> _events;
+        unsigned char _value = 0;
         unsigned long _last = 0;
         unsigned long _debounce = microsecondsToClockCycles(EVENTS_DEBOUNCE * 1000);
         unsigned char _gpio = GPIO_NONE;

--- a/code/espurna/sensors/EventSensor.h
+++ b/code/espurna/sensors/EventSensor.h
@@ -155,7 +155,7 @@ class EventSensor : public BaseSensor {
                 _counter += 1;
 
                 // we are handling callbacks in tick()
-                _events.push(digitalRead(gpio));
+                if (_trigger) _events.push(digitalRead(gpio));
             }
         }
 

--- a/code/espurna/sensors/EventSensor.h
+++ b/code/espurna/sensors/EventSensor.h
@@ -10,7 +10,7 @@
 #include "Arduino.h"
 #include "BaseSensor.h"
 
-#include <stack>
+#include <queue>
 
 // we are bound by usable GPIOs
 #define EVENTS_SENSORS_MAX 10
@@ -94,7 +94,7 @@ class EventSensor : public BaseSensor {
             if (_events.empty()) return;
 
             if (_callback) {
-                _callback(MAGNITUDE_EVENT, _events.top());
+                _callback(MAGNITUDE_EVENT, _events.front());
                 _events.pop();
             }
         }
@@ -156,12 +156,10 @@ class EventSensor : public BaseSensor {
             if (cycles - _last > _debounce) {
                 _last = cycles;
                 _counter += 1;
+                _value = digitalRead(gpio);
 
                 // we are handling callbacks in tick()
-                if (_trigger) {
-                    _value = digitalRead(gpio);
-                    _events.push(_value);
-                }
+                if (_trigger) _events.push(_value);
             }
         }
 
@@ -190,7 +188,7 @@ class EventSensor : public BaseSensor {
         // ---------------------------------------------------------------------
 
         volatile unsigned long _counter = 0;
-        std::stack<unsigned char> _events;
+        std::queue<unsigned char> _events;
         unsigned char _value = 0;
         unsigned long _last = 0;
         unsigned long _debounce = microsecondsToClockCycles(EVENTS_DEBOUNCE * 1000);

--- a/code/espurna/sensors/EventSensor.h
+++ b/code/espurna/sensors/EventSensor.h
@@ -94,8 +94,10 @@ class EventSensor : public BaseSensor {
             if (_events.empty()) return;
 
             if (_callback) {
+                noInterrupts();
                 _callback(MAGNITUDE_EVENT, _events.front());
                 _events.pop();
+                interrupts();
             }
         }
 

--- a/code/espurna/sensors/EventSensor.h
+++ b/code/espurna/sensors/EventSensor.h
@@ -158,10 +158,12 @@ class EventSensor : public BaseSensor {
             if (cycles - _last > _debounce) {
                 _last = cycles;
                 _counter += 1;
-                _value = digitalRead(gpio);
 
                 // we are handling callbacks in tick()
-                if (_trigger) _events.push(_value);
+                if (_trigger) {
+                    _value = digitalRead(gpio);
+                    _events.push(_value);
+                }
             }
         }
 


### PR DESCRIPTION
- cache ms<->clockcycles conversions
- move callback invocation outside of ISR handler
- retain last event value

std::queue methods are still not technically in iram, but it might not matter for use-case with low interrupt count.