### PR TITLE
BUTTON_MQTT_MODE setting

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -322,9 +322,12 @@
 #define BUTTON_LNGLNGCLICK_DELAY    10000       // Time in ms holding the button down to get a long-long click
 #endif
 
-#ifndef BUTTON_MQTT_SEND_ALL_EVENTS
-#define BUTTON_MQTT_SEND_ALL_EVENTS 0           // 0 - to send only events the are bound to actions
-                                                // 1 - to send all button events to MQTT
+// BUTTON_MQTT_SEND_ACTION_EVENTS - to send only events the are bound to actions
+// BUTTON_MQTT_SEND_ALL_EVENTS    - to send all button events to MQTT
+// BUTTON_MQTT_SEND_PRESSED       - instead of event, send button status (pressed or not).
+// EVENTS modes do not set retain flag. PRESSED mode sets retain flag based on MQTT_RETAIN setting
+#ifndef BUTTON_MQTT_MODE
+#define BUTTON_MQTT_MODE BUTTON_MQTT_SEND_ACTION_EVENTS
 #endif
 
 //------------------------------------------------------------------------------

--- a/code/espurna/config/types.h
+++ b/code/espurna/config/types.h
@@ -51,6 +51,9 @@
 #define BUTTON_MODE_DIM_UP          10
 #define BUTTON_MODE_DIM_DOWN        11
 
+#define BUTTON_MQTT_SEND_ACTION_EVENTS   0
+#define BUTTON_MQTT_SEND_ALL_EVENTS      1
+#define BUTTON_MQTT_SEND_PRESSED         2
 
 // Needed for ESP8285 boards under Windows using PlatformIO (?)
 #ifndef BUTTON_PUSHBUTTON

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -755,6 +755,10 @@ bool mqttConnected() {
     return _mqtt.connected();
 }
 
+bool mqttRetain() {
+    return _mqtt_retain;
+}
+
 void mqttDisconnect() {
     if (_mqtt.connected()) {
         DEBUG_MSG_P(PSTR("[MQTT] Disconnecting\n"));


### PR DESCRIPTION
ref #1747
 
@skyynet I though a bit about eventsensor for this, but it might be a bad match due to hardware limitations and noise (i think you pretty much required to have hardware filtering for the digital pin signal)

Instead, what about an option to send button pressed state instead of event, bypassing event mapping and directly giving user the button state?