### PR TITLE
Fix LED Invert for YJZK Switches

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -975,7 +975,7 @@
 
     // LEDs
     #define LED1_PIN            13
-    #define LED1_PIN_INVERSE    0
+    #define LED1_PIN_INVERSE    1
 
 #elif defined(YJZK_SWITCH_2CH)
 
@@ -1013,7 +1013,7 @@
 
     // LEDs
     #define LED1_PIN            13
-    #define LED1_PIN_INVERSE    0
+    #define LED1_PIN_INVERSE    1
 
 // YJZK 3CH switch
 // Also Lixin Touch Wifi 3M
@@ -1065,7 +1065,7 @@
 
     // LEDs
     #define LED1_PIN            13
-    #define LED1_PIN_INVERSE    0
+    #define LED1_PIN_INVERSE    1
 
 // -----------------------------------------------------------------------------
 // Electrodragon boards


### PR DESCRIPTION
I noticed that the hardware profiles for the YJZK switches have `LED1_PIN_INVERSE` set to `0`, but these devices actually have inverted LED logic. I have corrected all 3 profiles in `hardware.h`.