### PR TITLE
Add config for push button of Arilux AL-LC06

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1681,6 +1681,11 @@
     #define LIGHT_PROVIDER      LIGHT_PROVIDER_DIMMER
     #define DUMMY_RELAY_COUNT   1
 
+    // Buttons
+    #define BUTTON1_PIN         0
+    #define BUTTON1_MODE        BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_RELAY       1
+
     // Light
     #define LIGHT_CHANNELS      5
     #define LIGHT_CH1_PIN       14      // RED


### PR DESCRIPTION
Button is not visible from the outside, but can be wired outside or made more accessible by using a thin object, so it feels more like a button than a hole. The configuration should not cause issues if the button is not used at all.