### PR TITLE
Thingspeak: async client fixes

### DIFF
--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -183,6 +183,9 @@ bool inline eraseSDKConfig();
 
 #define ARRAYINIT(type, name, ...) type name[] = {__VA_ARGS__};
 
+size_t strnlen(const char*, size_t);
+char* strnstr(const char*, const char*, size_t);
+
 // -----------------------------------------------------------------------------
 // WebServer
 // -----------------------------------------------------------------------------

--- a/code/espurna/thinkspeak.ino
+++ b/code/espurna/thinkspeak.ino
@@ -22,8 +22,7 @@ const char THINGSPEAK_REQUEST_TEMPLATE[] PROGMEM =
     "User-Agent: ESPurna\r\n"
     "Connection: close\r\n"
     "Content-Type: application/x-www-form-urlencoded\r\n"
-    "Content-Length: %d\r\n\r\n"
-    "%s\r\n";
+    "Content-Length: %d\r\n\r\n";
 
 bool _tspk_enabled = false;
 bool _tspk_clear = false;
@@ -124,12 +123,12 @@ void _tspkInitClient() {
 
         const char * p = strnstr(reinterpret_cast<const char *>(response), "\r\n\r\n", len);
         unsigned int code = (p) ? atoi(&p[4]) : 0;
-        DEBUG_MSG_P(PSTR("[THINGSPEAK] Response value: %d\n"), code);
+        DEBUG_MSG_P(PSTR("[THINGSPEAK] Response value: %u\n"), code);
 
         _tspk_last_flush = millis();
         if ((0 == code) && (--_tspk_tries > 0)) {
             _tspk_flush = true;
-            DEBUG_MSG_P(PSTR("[THINGSPEAK] Re-enqueuing\n"));
+            DEBUG_MSG_P(PSTR("[THINGSPEAK] Re-enqueuing %u more time(s)\n"), _tspk_tries);
         } else {
             _tspkClearQueue();
         }
@@ -143,7 +142,7 @@ void _tspkInitClient() {
         _tspk_connected = true;
         _tspk_connecting = false;
 
-        DEBUG_MSG_P(PSTR("[THINGSPEAK] Connected to %s:%d\n"), THINGSPEAK_HOST, THINGSPEAK_PORT);
+        DEBUG_MSG_P(PSTR("[THINGSPEAK] Connected to %s:%u\n"), THINGSPEAK_HOST, THINGSPEAK_PORT);
 
         #if THINGSPEAK_USE_SSL
             uint8_t fp[20] = {0};
@@ -201,7 +200,7 @@ void _tspkPost() {
 
     if (_tspk_client.connect(THINGSPEAK_HOST, THINGSPEAK_PORT)) {
 
-        DEBUG_MSG_P(PSTR("[THINGSPEAK] Connected to %s:%d\n"), THINGSPEAK_HOST, THINGSPEAK_PORT);
+        DEBUG_MSG_P(PSTR("[THINGSPEAK] Connected to %s:%u\n"), THINGSPEAK_HOST, THINGSPEAK_PORT);
 
         if (!_tspk_client.verify(THINGSPEAK_FINGERPRINT, THINGSPEAK_HOST)) {
             DEBUG_MSG_P(PSTR("[THINGSPEAK] Warning: certificate doesn't match\n"));
@@ -224,13 +223,13 @@ void _tspkPost() {
         String response = _tspk_client.readString();
         int pos = response.indexOf("\r\n\r\n");
         unsigned int code = (pos > 0) ? response.substring(pos + 4).toInt() : 0;
-        DEBUG_MSG_P(PSTR("[THINGSPEAK] Response value: %d\n"), code);
+        DEBUG_MSG_P(PSTR("[THINGSPEAK] Response value: %u\n"), code);
         _tspk_client.stop();
 
         _tspk_last_flush = millis();
         if ((0 == code) && (--_tspk_tries > 0)) {
             _tspk_flush = true;
-            DEBUG_MSG_P(PSTR("[THINGSPEAK] Re-enqueuing\n"));
+            DEBUG_MSG_P(PSTR("[THINGSPEAK] Re-enqueuing %u more time(s)\n"), _tspk_tries);
         } else {
             _tspkClearQueue();
         }
@@ -246,7 +245,7 @@ void _tspkPost() {
 #endif // THINGSPEAK_USE_ASYNC
 
 void _tspkEnqueue(unsigned char index, char * payload) {
-    DEBUG_MSG_P(PSTR("[THINGSPEAK] Enqueuing field #%d with value %s\n"), index, payload);
+    DEBUG_MSG_P(PSTR("[THINGSPEAK] Enqueuing field #%u with value %s\n"), index, payload);
     --index;
     if (_tspk_queue[index] != NULL) free(_tspk_queue[index]);
     _tspk_queue[index] = strdup(payload);

--- a/code/espurna/thinkspeak.ino
+++ b/code/espurna/thinkspeak.ino
@@ -121,6 +121,7 @@ void _tspkInitClient() {
     _tspk_client->onDisconnect([](void * s, AsyncClient * client) {
         DEBUG_MSG_P(PSTR("[THINGSPEAK] Disconnected\n"));
         _tspk_data = "";
+        _tspk_client_ts = millis();
         _tspk_connected = false;
         _tspk_connecting = false;
         _tspk_client_state = tspk_state_t::NONE;
@@ -190,7 +191,7 @@ void _tspkInitClient() {
 
         } while (_tspk_client_state != tspk_state_t::NONE);
 
-    }, NULL);
+    }, nullptr);
 
     _tspk_client->onConnect([](void * arg, AsyncClient * client) {
 
@@ -220,13 +221,15 @@ void _tspkInitClient() {
         client->write(headers);
         client->write(_tspk_data.c_str());
 
-    }, NULL);
+    }, nullptr);
 
 }
 
 void _tspkPost() {
 
     if (_tspk_connected || _tspk_connecting) return;
+
+    _tspk_client_ts = millis();
 
     #if ASYNC_TCP_SSL_ENABLED
         bool connected = _tspk_client->connect(THINGSPEAK_HOST, THINGSPEAK_PORT, THINGSPEAK_USE_SSL);

--- a/code/espurna/thinkspeak.ino
+++ b/code/espurna/thinkspeak.ino
@@ -32,7 +32,7 @@ String _tspk_data;
 
 bool _tspk_flush = false;
 unsigned long _tspk_last_flush = 0;
-unsigned char _tspk_tries = 0;
+unsigned char _tspk_tries = THINGSPEAK_TRIES;
 
 #if THINGSPEAK_USE_ASYNC
 AsyncClient * _tspk_client;
@@ -272,7 +272,7 @@ void _tspkFlush() {
         return;
     }
 
-    // Walk the fields
+    // Walk the fields, numbered 1...THINGSPEAK_FIELDS
     for (unsigned char id=0; id<THINGSPEAK_FIELDS; id++) {
         if (_tspk_queue[id] != NULL) {
             if (_tspk_data.length() > 0) _tspk_data.concat("&");

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -612,3 +612,19 @@ bool isNumber(const char * s) {
     }
     return digit;
 }
+
+// ref: lwip2 lwip_strnstr with strnlen
+char* strnstr(const char* buffer, const char* token, size_t n) {
+  size_t token_len = strnlen(token, n);
+  if (token_len == 0) {
+    return const_cast<char*>(buffer);
+  }
+
+  for (const char* p = buffer; *p && (p + token_len <= buffer + n); p++) {
+    if ((*p == *token) && (strncmp(p, token, token_len) == 0)) {
+      return const_cast<char*>(p);
+    }
+  }
+
+  return nullptr;
+}


### PR DESCRIPTION
- remove memory management in async client callbacks
- instead of global one, reference asyncclient from callback argument
- transfer temporary data-buffer to the global scope, avoid unintentional String copy
- implement strnstr to search onData payload

@JavierAder as discussed in #1752
Will try to leave it running with some sensor board.

There is another rough one, but *greatly* increasing firmware size:
https://github.com/xoseperez/espurna/compare/dev...mcspr:tspk/client-fixes
+1280bytes vs +<s>48</s>416bytes here
(supporting newest Core versions requires some tweaks to the networking part. I hope that can be reused somewhere to justify code size increase)