### PR TITLE
Use basic BearSSL ciphers on low memory boards

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -50,8 +50,8 @@ debug_flags = -DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP
 #    -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH = v2 Higher Bandwidth
 # ------------------------------------------------------------------------------
 build_flags = -g -w -DMQTT_MAX_PACKET_SIZE=400 -DNO_GLOBAL_EEPROM ${sysenv.ESPURNA_FLAGS} -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH 
-build_flags_512k = ${common.build_flags} -Wl,-Teagle.flash.512k0m1s.ld
-build_flags_1m0m = ${common.build_flags} -Wl,-Teagle.flash.1m0m1s.ld
+build_flags_512k = ${common.build_flags} -Wl,-Teagle.flash.512k0m1s.ld -DBEARSSL_SSL_BASIC
+build_flags_1m0m = ${common.build_flags} -Wl,-Teagle.flash.1m0m1s.ld -DBEARSSL_SSL_BASIC
 build_flags_2m1m = ${common.build_flags} -Wl,-Teagle.flash.2m1m4s.ld
 build_flags_4m1m = ${common.build_flags} -Wl,-Teagle.flash.4m1m4s.ld
 build_flags_4m3m = ${common.build_flags} -Wl,-Teagle.flash.4m3m4s.ld

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -48,10 +48,18 @@ debug_flags = -DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP
 #    -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH  = v1.4 Higher Bandwidth (default)
 #    -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY       = v2 Lower Memory
 #    -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH = v2 Higher Bandwidth
+#
+# BearSSL ciphers:
+#   When building on core >= 2.5, you can add the build flag -DBEARSSL_SSL_BASIC in order to build BearSSL with a limited set of ciphers:
+#     TLS_RSA_WITH_AES_128_CBC_SHA256 / AES128-SHA256
+#     TLS_RSA_WITH_AES_256_CBC_SHA256 / AES256-SHA256
+#     TLS_RSA_WITH_AES_128_CBC_SHA / AES128-SHA
+#     TLS_RSA_WITH_AES_256_CBC_SHA / AES256-SHA
+#  This reduces the OTA size with ~45KB, so it's especially useful on low memory boards (512k/1m).
 # ------------------------------------------------------------------------------
 build_flags = -g -w -DMQTT_MAX_PACKET_SIZE=400 -DNO_GLOBAL_EEPROM ${sysenv.ESPURNA_FLAGS} -DPIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH 
-build_flags_512k = ${common.build_flags} -Wl,-Teagle.flash.512k0m1s.ld -DBEARSSL_SSL_BASIC
-build_flags_1m0m = ${common.build_flags} -Wl,-Teagle.flash.1m0m1s.ld -DBEARSSL_SSL_BASIC
+build_flags_512k = ${common.build_flags} -Wl,-Teagle.flash.512k0m1s.ld
+build_flags_1m0m = ${common.build_flags} -Wl,-Teagle.flash.1m0m1s.ld
 build_flags_2m1m = ${common.build_flags} -Wl,-Teagle.flash.2m1m4s.ld
 build_flags_4m1m = ${common.build_flags} -Wl,-Teagle.flash.4m1m4s.ld
 build_flags_4m3m = ${common.build_flags} -Wl,-Teagle.flash.4m3m4s.ld


### PR DESCRIPTION
See: https://github.com/esp8266/Arduino/blob/8b1af68e3f996592c4b152e793cde81de4b8957d/libraries/ESP8266WiFi/src/WiFiClientSecureBearSSL.cpp#L725-L854

With this flag enabled, BearSSL is compiled with only these 4 ciphers:
```
TLS_RSA_WITH_AES_128_CBC_SHA256 / AES128-SHA256
TLS_RSA_WITH_AES_256_CBC_SHA256 / AES256-SHA256
TLS_RSA_WITH_AES_128_CBC_SHA / AES128-SHA
TLS_RSA_WITH_AES_256_CBC_SHA / AES256-SHA
```

Setting this build flag saves around 45.5KB in build size, which is very significant on low memory boards. I think it would be nice to enable this by default on the 512KB/1MB boards.

I did some quick checks and most (if not all) SSL server support these ciphers. To check a site, try: ``nmap --script ssl-enum-ciphers -p 443 google.com``