### PR TITLE
Web OTA: check authentication result before accepting payload

### DIFF
--- a/code/espurna/web.ino
+++ b/code/espurna/web.ino
@@ -125,6 +125,10 @@ void _onPostConfig(AsyncWebServerRequest *request) {
 
 void _onPostConfigData(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
 
+    if (!webAuthenticate(request)) {
+        return request->requestAuthentication(getSetting("hostname").c_str());
+    }
+
     // No buffer
     if (final && (index == 0)) {
         DynamicJsonBuffer jsonBuffer;
@@ -297,7 +301,11 @@ void _onUpgrade(AsyncWebServerRequest *request) {
 
 }
 
-void _onUpgradeData(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
+void _onUpgradeFile(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final) {
+
+    if (!webAuthenticate(request)) {
+        return request->requestAuthentication(getSetting("hostname").c_str());
+    }
 
     if (!index) {
 
@@ -455,7 +463,7 @@ void webSetup() {
     _server->on("/reset", HTTP_GET, _onReset);
     _server->on("/config", HTTP_GET, _onGetConfig);
     _server->on("/config", HTTP_POST | HTTP_PUT, _onPostConfig, _onPostConfigData);
-    _server->on("/upgrade", HTTP_POST, _onUpgrade, _onUpgradeData);
+    _server->on("/upgrade", HTTP_POST, _onUpgrade, _onUpgradeFile);
     _server->on("/discover", HTTP_GET, _onDiscover);
 
     // Serve static files


### PR DESCRIPTION
Using HTTP upgrade method described in the wiki and omitting auth headers:
https://github.com/xoseperez/espurna/wiki/OTA

```
curl -XPOST  \
  -H "Content-Type: multipart/form-data" \
  -F "filename=@.pioenvs/esp8266-1m-ota/firmware.bin" \
  http://192.168.4.1/upgrade
```

Causes file handler to process OTA file and **write it to flash** and only then to go into the request handler, where it will issue auth error.