### PR TITLE
Fixes for platformio builds

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -121,15 +121,43 @@ lib_deps =
     https://github.com/ElderJoy/esp8266-oled-ssd1306#4.0.1
 lib_ignore =
 
+# ------------------------------------------------------------------------------
+# ESPURNA CORE BUILDS
+# ------------------------------------------------------------------------------
+
 [env:espurna-core-1MB]
 board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_WPS=1
+build_flags = ${common.build_flags_1m0m} -DESPURNA_CORE
 
 [env:espurna-core-2MB]
 board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_WPS=1
+build_flags = ${common.build_flags_2m1m} -DESPURNA_CORE
 
 [env:espurna-core-4MB]
+board = ${common.board_4m}
+build_flags = ${common.build_flags_4m1m} -DESPURNA_CORE
+
+[env:espurna-core-smartconfig-1MB]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+
+[env:espurna-core-smartconfig-2MB]
+board = ${common.board_2m}
+build_flags = ${common.build_flags_2m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+
+[env:espurna-core-smartconfig-4MB]
+board = ${common.board_4m}
+build_flags = ${common.build_flags_4m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+
+[env:espurna-core-wps-1MB]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_WPS=1
+
+[env:espurna-core-wps-2MB]
+board = ${common.board_2m}
+build_flags = ${common.build_flags_2m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_WPS=1
+
+[env:espurna-core-wps-4MB]
 board = ${common.board_4m}
 build_flags = ${common.build_flags_4m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_WPS=1
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -69,9 +69,9 @@ shared_libdeps_dir = libraries/
 # ------------------------------------------------------------------------------
 # OTA:
 # ------------------------------------------------------------------------------
-upload_port = "${sysenv.ESPURNA_IP}"
-upload_flags = --auth="${sysenv.ESPURNA_AUTH}"
-upload_protocol = espota
+ota_upload_port = "${sysenv.ESPURNA_IP}"
+ota_upload_flags = --auth="${sysenv.ESPURNA_AUTH}"
+ota_upload_protocol = espota
 
 # ------------------------------------------------------------------------------
 # COMMON SETTINGS:
@@ -651,28 +651,14 @@ upload_port = ${common.ota_upload_port}
 upload_flags = ${common.ota_upload_flags}
 
 [env:magichome-zj-espm-5ch-b-13]
-platform = ${common.platform}
-framework = ${common.framework}
 board = ${common.board_1m}
-board_build.flash_mode = ${common.flash_mode}
-lib_deps = ${common.lib_deps}
-lib_ignore = ${common.lib_ignore}
 build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_ESPM_5CH_B_13
-monitor_speed = ${common.monitor_speed}
-extra_scripts = ${common.extra_scripts}
 
 [env:magichome-zj-espm-5ch-b-13-ota]
-platform = ${common.platform}
-framework = ${common.framework}
 board = ${common.board_1m}
-board_build.flash_mode = ${common.flash_mode}
-lib_deps = ${common.lib_deps}
-lib_ignore = ${common.lib_ignore}
 build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_ESPM_5CH_B_13
-monitor_speed = ${common.monitor_speed}
-upload_port = ${common.upload_port}
-upload_flags = ${common.upload_flags}
-extra_scripts = ${common.extra_scripts}
+upload_port = ${common.ota_upload_port}
+upload_flags = ${common.ota_upload_flags}
 
 [env:huacanxing-h801]
 board = ${common.board_1m}


### PR DESCRIPTION
Couple of fixes for #1805
- consistent upload_... naming - upload_protocol -> ota_upload_protocol
- actually use ota_upload_port, ota_upload_flags (tnx @Niek)
- recover espurna-core comment

As a bonus, recover espurna-core without wps and add the build with smartconfig