### PR TITLE
Light updates

### DIFF
--- a/code/espurna/light.ino
+++ b/code/espurna/light.ino
@@ -70,8 +70,7 @@ const char _light_channel_desc[5][5] PROGMEM = {
 };
 
 // Gamma Correction lookup table (8 bit)
-// TODO: move to PROGMEM
-const unsigned char _light_gamma_table[] = {
+const unsigned char _light_gamma_table[] PROGMEM = {
     0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
     1,   1,   1,   1,   1,   1,   1,   1,   1,   1,   2,   2,   2,   2,   2,   2,
     3,   3,   3,   3,   3,   3,   4,   4,   4,   4,   5,   5,   5,   5,   6,   6,
@@ -454,7 +453,7 @@ void _toCSV(char * buffer, size_t len, bool applyBrightness) {
 
 unsigned int _toPWM(unsigned long value, bool gamma, bool reverse) {
     value = constrain(value, 0, LIGHT_MAX_VALUE);
-    if (gamma) value = _light_gamma_table[value];
+    if (gamma) value = pgm_read_byte(_light_gamma_table + value);
     if (LIGHT_MAX_VALUE != LIGHT_LIMIT_PWM) value = map(value, 0, LIGHT_MAX_VALUE, 0, LIGHT_LIMIT_PWM);
     if (reverse) value = LIGHT_LIMIT_PWM - value;
     return value;

--- a/code/espurna/light.ino
+++ b/code/espurna/light.ino
@@ -68,6 +68,7 @@ const char _light_channel_desc[5][5] PROGMEM = {
     {'R', 'G', 'B', 'W',   0},
     {'R', 'G', 'B', 'W', 'C'}
 };
+static_assert((LIGHT_CHANNELS * LIGHT_CHANNELS) == (sizeof(_light_channel_desc)), "Out-of-bounds array access");
 
 // Gamma Correction lookup table (8 bit)
 const unsigned char _light_gamma_table[] PROGMEM = {
@@ -88,6 +89,7 @@ const unsigned char _light_gamma_table[] PROGMEM = {
     191, 193, 195, 197, 199, 201, 203, 205, 207, 209, 211, 213, 215, 217, 219, 221,
     223, 225, 227, 229, 231, 233, 235, 238, 240, 242, 244, 246, 248, 251, 253, 255
 };
+static_assert(LIGHT_MAX_VALUE <= sizeof(_light_gamma_table), "Out-of-bounds array access");
 
 // -----------------------------------------------------------------------------
 // UTILS
@@ -106,9 +108,12 @@ void _setCCTInputValue(unsigned char warm, unsigned char cold) {
 
 void _lightApplyBrightness(unsigned char channels = lightChannels()) {
 
-    double brightness = (double) _light_brightness / LIGHT_MAX_BRIGHTNESS;
+    double brightness = static_cast<double>(_light_brightness) / static_cast<double>(LIGHT_MAX_BRIGHTNESS);
 
-    for (unsigned char i=0; i < channels; i++) {
+    channels = std::min(channels, lightChannels());
+
+    for (unsigned char i=0; i < lightChannels(); i++) {
+        if (i >= channels) brightness = 1;
         _light_channel[i].value = _light_channel[i].inputValue * brightness;
     }
 

--- a/code/espurna/light.ino
+++ b/code/espurna/light.ino
@@ -68,7 +68,7 @@ const char _light_channel_desc[5][5] PROGMEM = {
     {'R', 'G', 'B', 'W',   0},
     {'R', 'G', 'B', 'W', 'C'}
 };
-static_assert((LIGHT_CHANNELS * LIGHT_CHANNELS) == (sizeof(_light_channel_desc)), "Out-of-bounds array access");
+static_assert((LIGHT_CHANNELS * LIGHT_CHANNELS) <= (sizeof(_light_channel_desc)), "Out-of-bounds array access");
 
 // Gamma Correction lookup table (8 bit)
 const unsigned char _light_gamma_table[] PROGMEM = {


### PR DESCRIPTION
Will likely rebase & merge this as-is, so adding all 3 commits
- fixes #1575: limit generic brightness function to only 3 channels when RGBWW color option is ON, but white channels are not used
- implement old TODO: move gamma to progmem
- test: print channel description in the terminal `channel <id>` (i'd also move this as webui description?)

@hyteoo https://github.com/xoseperez/espurna/commit/4702fcfb92726396542791a99300df0cadad8972 restores pre-1.13.3 behaviour when `useWhite` is off 
if `useColor` is also off, it will apply brightness to all the channels (as it does right now)