### PR TITLE
Fix WEB_SUPPORT=0 and missing definitions

### DIFF
--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -309,10 +309,16 @@ using ws_on_keycheck_callback_list_t = std::vector<ws_on_keycheck_callback_f>;
 
     ws_callbacks_t& wsRegister();
 
-    void wsSend(uint32_t, JsonObject& root);
-    void wsSend(JsonObject& root);
-    void wsSend(ws_on_send_callback_f sender);
+    void wsSetup();
+    void wsSend(uint32_t, const char*);
+    void wsSend(uint32_t, JsonObject&);
+    void wsSend(JsonObject&);
+    void wsSend(ws_on_send_callback_f);
 
+    void wsSend_P(PGM_P);
+    void wsSend_P(uint32_t, PGM_P);
+
+    void wsPost(const ws_on_send_callback_f&);
     void wsPost(const ws_on_send_callback_list_t&);
     void wsPost(uint32_t, const ws_on_send_callback_list_t&);
 

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -58,13 +58,12 @@ void systemStabilityCounter(uint8_t);
 // -----------------------------------------------------------------------------
 // API
 // -----------------------------------------------------------------------------
+
+using api_get_callback_f = std::function<void(char *, size_t)>;
+using api_put_callback_f = std::function<void(const char *)> ;
+
 #if WEB_SUPPORT
-    typedef std::function<void(char *, size_t)> api_get_callback_f;
-    typedef std::function<void(const char *)> api_put_callback_f;
     void apiRegister(const char * key, api_get_callback_f getFn, api_put_callback_f putFn = NULL);
-#else
-    #define api_get_callback_f void *
-    #define api_put_callback_f void *
 #endif
 
 // -----------------------------------------------------------------------------
@@ -135,6 +134,7 @@ bool gpioReleaseLock(unsigned char gpio);
 // Homeassistant
 // -----------------------------------------------------------------------------
 struct ha_config_t;
+void haSetup();
 
 // -----------------------------------------------------------------------------
 // I2C
@@ -164,12 +164,12 @@ void i2c_read_buffer(uint8_t address, uint8_t * buffer, size_t len);
 // -----------------------------------------------------------------------------
 // MQTT
 // -----------------------------------------------------------------------------
+
+using mqtt_callback_f = std::function<void(unsigned int, const char *, char *)>;
+
 #if MQTT_SUPPORT
-    typedef std::function<void(unsigned int, const char *, char *)> mqtt_callback_f;
     void mqttRegister(mqtt_callback_f callback);
     String mqttMagnitude(char * topic);
-#else
-    #define mqtt_callback_f void *
 #endif
 
 // -----------------------------------------------------------------------------
@@ -330,18 +330,17 @@ using ws_on_keycheck_callback_list_t = std::vector<ws_on_keycheck_callback_f>;
 // -----------------------------------------------------------------------------
 // WIFI
 // -----------------------------------------------------------------------------
-#include "JustWifi.h"
-typedef std::function<void(justwifi_messages_t code, char * parameter)> wifi_callback_f;
+#include <JustWifi.h>
+using wifi_callback_f = std::function<void(justwifi_messages_t code, char * parameter)>;
 void wifiRegister(wifi_callback_f callback);
 bool wifiConnected();
 
+// -----------------------------------------------------------------------------
 // THERMOSTAT
 // -----------------------------------------------------------------------------
+using thermostat_callback_f = std::function<void(bool)>;
 #if THERMOSTAT_SUPPORT
-    typedef std::function<void(bool)> thermostat_callback_f;
     void thermostatRegister(thermostat_callback_f callback);
-#else
-    #define thermostat_callback_f void *
 #endif
 
 // -----------------------------------------------------------------------------

--- a/code/espurna/ntp.ino
+++ b/code/espurna/ntp.ino
@@ -239,7 +239,9 @@ void ntpSetup() {
             } else if (error == invalidAddress) {
                 DEBUG_MSG_P(PSTR("[NTP] Error: Invalid NTP server address\n"));
             }
-            wsPost(_ntpWebSocketOnData);
+            #if WEB_SUPPORT
+                wsPost(_ntpWebSocketOnData);
+            #endif
         } else {
             _ntp_report = true;
             setTime(NTPw.getLastNTPSync());

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -22,6 +22,31 @@ Ticker _web_defer;
 // WS callbacks
 // -----------------------------------------------------------------------------
 
+ws_callbacks_t& ws_callbacks_t::onVisible(ws_on_send_callback_f cb) {
+    on_visible.push_back(cb);
+    return *this;
+}
+
+ws_callbacks_t& ws_callbacks_t::onConnected(ws_on_send_callback_f cb) {
+    on_connected.push_back(cb);
+    return *this;
+}
+
+ws_callbacks_t& ws_callbacks_t::onData(ws_on_send_callback_f cb) {
+    on_data.push_back(cb);
+    return *this;
+}
+
+ws_callbacks_t& ws_callbacks_t::onAction(ws_on_action_callback_f cb) {
+    on_action.push_back(cb);
+    return *this;
+}
+
+ws_callbacks_t& ws_callbacks_t::onKeyCheck(ws_on_keycheck_callback_f cb) {
+    on_keycheck.push_back(cb);
+    return *this;
+}
+
 ws_callbacks_t _ws_callbacks;
 
 struct ws_counter_t {


### PR DESCRIPTION
https://github.com/xoseperez/espurna/commit/21423431ceab1a6d792d3f6ba746b3166ec6cb5b#r34669282
https://github.com/xoseperez/espurna/commit/21423431ceab1a6d792d3f6ba746b3166ec6cb5b#r34669593
https://travis-ci.org/mcspr/espurna-nightly-builder/jobs/571178137#L454-L462
```
* espurna-1.13.6-dev-espurna-core-4MB.bin --- using global library storage

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:737:1: error: 'ws_callbacks_t' does not name a type

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:745:42: error: 'ws_on_send_callback_list_t' does not name a type

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:745:70: error: ISO C++ forbids declaration of 'cbs' with no type [-fpermissive]

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:746:22: error: 'ws_on_send_callback_list_t' does not name a type

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:746:50: error: ISO C++ forbids declaration of 'cbs' with no type [-fpermissive]

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:747:47: error: 'ws_on_send_callback_list_t' does not name a type

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:747:75: error: ISO C++ forbids declaration of 'cbs' with no type [-fpermissive]

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:748:27: error: 'ws_on_send_callback_list_t' does not name a type

/home/travis/build/mcspr/espurna-nightly-builder/espurna/code/espurna/espurna.ino:748:55: error: ISO C++ forbids declaration of 'cbs' with no type [-fpermissive]
```
- add WEB_SUPPORT check for NTP ws callback
- forward declare AsyncClient, ws_... etc.
- always typedef callback types that happen to be in function signatures, remove redefinition to void