### PR TITLE
Fixed a bug, any unauthenticated user could reset the device

### DIFF
--- a/code/espurna/web.ino
+++ b/code/espurna/web.ino
@@ -59,6 +59,12 @@ constexpr const size_t WEB_CONFIG_BUFFER_MAX = 4096;
 // -----------------------------------------------------------------------------
 
 void _onReset(AsyncWebServerRequest *request) {
+
+    webLog(request);
+    if (!webAuthenticate(request)) {
+        return request->requestAuthentication(getSetting("hostname").c_str());
+    }
+
     deferredReset(100, CUSTOM_RESET_HTTP);
     request->send(200);
 }


### PR DESCRIPTION
If you just access /reset the device reboots without any warning or need to authenticate