### PR TITLE
Amend #1843

### DIFF
--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -276,6 +276,7 @@ void webRequestRegister(web_request_callback_f);
 // -----------------------------------------------------------------------------
 // WebSockets
 // -----------------------------------------------------------------------------
+#include <queue>
 
 // TODO: pending configuration headers refactoring... here for now
 struct ws_counter_t;

--- a/code/espurna/sensors/HLW8012Sensor.h
+++ b/code/espurna/sensors/HLW8012Sensor.h
@@ -158,7 +158,7 @@ class HLW8012Sensor : public BaseSensor {
 
         // Descriptive name of the sensor
         String description() {
-            char buffer[25];
+            char buffer[28];
             snprintf(buffer, sizeof(buffer), "HLW8012 @ GPIO(%u,%u,%u)", _sel, _cf, _cf1);
             return String(buffer);
         }
@@ -170,7 +170,7 @@ class HLW8012Sensor : public BaseSensor {
 
         // Address of the sensor (it could be the GPIO or I2C address)
         String address(unsigned char index) {
-            char buffer[10];
+            char buffer[12];
             snprintf(buffer, sizeof(buffer), "%u:%u:%u", _sel, _cf, _cf1);
             return String(buffer);
         }

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -604,6 +604,7 @@ void _wsEvent(AsyncWebSocket * server, AsyncWebSocketClient * client, AwsEventTy
         _wsConnected(client->id());
         _wsResetUpdateTimer();
         wifiReconnectCheck();
+        client->_tempObject = new WebSocketIncommingBuffer(_wsParse, true);
 
     } else if(type == WS_EVT_DISCONNECT) {
         DEBUG_MSG_P(PSTR("[WEBSOCKET] #%u disconnected\n"), client->id());
@@ -670,9 +671,7 @@ void _wsHandleClientData(const bool connected) {
     yield();
 
     if (data.done()) {
-        // push the queue and finally allow incoming messages
         _ws_client_data.pop();
-        ws_client->_tempObject = new WebSocketIncommingBuffer(_wsParse, true);
     }
 }
 


### PR DESCRIPTION
Fix queue include when building without Home Assistant or Alexa (https://github.com/xoseperez/espurna/pull/1857#issuecomment-521735472)

Fix gcc warning about buffer size with unsigned char (which is kind of possible with GPIO_NONE, since Shelly 1PM should probably use it instead of real pins)

Change left over from the #1843 draft where a single loop handled all the queue elements at once. Since we are handling each thing separately, `new Buffer()` is called after each one finishes. That's not what we want, just create it on connection as it was before.