### PR TITLE
Fix js sync bug that can cause brick

### DIFF
--- a/code/espurna/config/types.h
+++ b/code/espurna/config/types.h
@@ -227,6 +227,8 @@
 #define CUSTOM_RESET_NOFUSS         8       // Reset after successful NOFUSS update
 #define CUSTOM_RESET_UPGRADE        9       // Reset after update from web interface
 #define CUSTOM_RESET_FACTORY        10      // Factory reset from terminal
+#define CUSTOM_RESET_CONFIG_UPDATE  11      // Reset after configuration update
+
 
 #define CUSTOM_RESET_MAX            10
 

--- a/code/espurna/web.ino
+++ b/code/espurna/web.ino
@@ -131,6 +131,7 @@ void _onPostConfig(AsyncWebServerRequest *request) {
     if (!webAuthenticate(request)) {
         return request->requestAuthentication(getSetting("hostname").c_str());
     }
+    if (_webConfigSuccess) deferredReset(100, CUSTOM_RESET_CONFIG_UPDATE);
     request->send(_webConfigSuccess ? 200 : 400);
 }
 
@@ -143,6 +144,7 @@ void _onPostConfigData(AsyncWebServerRequest *request, String filename, size_t i
     // No buffer
     if (final && (index == 0)) {
         _webConfigSuccess = settingsRestoreJson((char*) data);
+        if (_webConfigSuccess) deferredReset(100, CUSTOM_RESET_CONFIG_UPDATE);
         return;
     }
 
@@ -175,6 +177,7 @@ void _onPostConfigData(AsyncWebServerRequest *request, String filename, size_t i
         delete _webConfigBuffer;
 
     }
+    if (_webConfigSuccess) deferredReset(100, CUSTOM_RESET_CONFIG_UPDATE);
 
 }
 

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -383,6 +383,7 @@ void _wsParse(AsyncWebSocketClient *client, uint8_t * payload, size_t length) {
             if (strcmp(action, "restore") == 0) {
                 if (settingsRestoreJson(data)) {
                     wsSend_P(client_id, PSTR("{\"message\": 5}"));
+                    deferredReset(100, CUSTOM_RESET_CONFIG_UPDATE);
                 } else {
                     wsSend_P(client_id, PSTR("{\"message\": 4}"));
                 }

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -36,7 +36,7 @@ function initMessages() {
     messages[2]  = "OTA update started";
     messages[3]  = "Error parsing data!";
     messages[4]  = "The file does not look like a valid configuration backup or is corrupted";
-    messages[5]  = "Changes saved. You should reboot your board now";
+    messages[5]  = "Changes saved. Device will now reboot";
     messages[7]  = "Passwords do not match!";
     messages[8]  = "Changes saved";
     messages[9]  = "No changes detected";


### PR DESCRIPTION
if you restore configuration (not rebooting the device) and change more settings it makes the device freak out and sometimes even bricks it (wont boot anymore).
making sure to restart after configuration restore fixes it.

Tested on Sonoff 4CH PRO R2