### PR TITLE
Check value range for PMSX005 and SenseAir CO2 sensor

### DIFF
--- a/code/espurna/sensors/PMSX003Sensor.h
+++ b/code/espurna/sensors/PMSX003Sensor.h
@@ -276,8 +276,6 @@ class PMSX003Sensor : public BaseSensor, PMSX003 {
                 return;
             }
 
-            _error = SENSOR_ERROR_OK;
-
             #if PMS_SMART_SLEEP
                 unsigned int readCycle;
                 if (_readCount++ > 30) {
@@ -304,22 +302,40 @@ class PMSX003Sensor : public BaseSensor, PMSX003 {
             uint16_t data[PMS_DATA_MAX];
             if (readData(data, pms_specs[_type].data_count)) {
                 if (_type == PMS_TYPE_5003ST) {
-                    _slot_values[0] = data[4];
-                    _slot_values[1] = (double)data[13] / 10;
-                    _slot_values[2] = (double)data[14] / 10;
-                    _slot_values[3] = (double)data[12] / 1000;
+                    if (data[14] > 10 && data[14] < 1000 && data[13] < 1000) {
+                        _slot_values[0] = data[4];
+                        _slot_values[1] = (double)data[13] / 10;
+                        _slot_values[2] = (double)data[14] / 10;
+                        _slot_values[3] = (double)data[12] / 1000;
+                        _error = SENSOR_ERROR_OK;
+                    } else {
+                        _error = SENSOR_ERROR_OUT_OF_RANGE;
+                        #if SENSOR_DEBUG
+                            DEBUG_MSG("[SENSOR] %s: Invalid temperature=%d humidity=%d.\n", pms_specs[_type].name, (int)data[13], (int)data[14]);
+                        #endif
+                    }
                 } else if (_type == PMS_TYPE_5003S) {
                     _slot_values[0] = data[4];
                     _slot_values[1] = data[5];
                     _slot_values[2] = (double)data[12] / 1000;
+                    _error = SENSOR_ERROR_OK;
                 } else if (_type == PMS_TYPE_5003T) {
-                    _slot_values[0] = data[4];
-                    _slot_values[1] = (double)data[10] / 10;
-                    _slot_values[2] = (double)data[11] / 10;
+                    if (data[11] > 10 && data[11] < 1000 && data[10] < 1000) {
+                        _slot_values[0] = data[4];
+                        _slot_values[1] = (double)data[10] / 10;
+                        _slot_values[2] = (double)data[11] / 10;
+                        _error = SENSOR_ERROR_OK;
+                    } else {
+                        _error = SENSOR_ERROR_OUT_OF_RANGE;
+                        #if SENSOR_DEBUG
+                            DEBUG_MSG("[SENSOR] %s: Invalid temperature=%d humidity=%d.\n", pms_specs[_type].name, (int)data[10], (int)data[11]);
+                        #endif
+                    }
                 } else {
                     _slot_values[0] = data[3];
                     _slot_values[1] = data[4];
                     _slot_values[2] = data[5];
+                    _error = SENSOR_ERROR_OK;
                 }
             }
 

--- a/code/espurna/sensors/SenseAirSensor.h
+++ b/code/espurna/sensors/SenseAirSensor.h
@@ -202,17 +202,17 @@ class SenseAirSensor : public BaseSensor, SenseAir {
                 return;
             }
 
-            _error = SENSOR_ERROR_OK;
-
             unsigned int co2 = readCo2();
             if (co2 >= 5000 || co2 < 100)
             {
                 _co2 = _lastCo2;
+                _error = SENSOR_ERROR_OUT_OF_RANGE;
             }
             else
             {
                 _co2 = (co2 > _lastCo2 + 2000) ? _lastCo2 : co2;
                 _lastCo2 = co2;
+                _error = SENSOR_ERROR_OK;
             }
         }
 


### PR DESCRIPTION
Check value range for PMSX005 and SenseAir CO2 sensor, and drop invalid value (temperature>=100°C or humidity<=1% or humidity>=100%) for MQTT reporting.