### PR TITLE
WiFi SoftAP fixes

### DIFF
--- a/code/espurna/wifi.ino
+++ b/code/espurna/wifi.ino
@@ -431,6 +431,11 @@ void _wifiInitCommands() {
         terminalOK();
     });
 
+    terminalRegisterCommand(F("WIFI.STA"), [](Embedis* e) {
+        wifiStartSTA();
+        terminalOK();
+    });
+
     terminalRegisterCommand(F("WIFI.AP"), [](Embedis* e) {
         wifiStartAP();
         terminalOK();
@@ -586,6 +591,12 @@ bool wifiConnected() {
 
 void wifiDisconnect() {
     jw.disconnect();
+}
+
+void wifiStartSTA() {
+    jw.disconnect();
+    jw.enableSTA(true);
+    jw.enableAP(false);
 }
 
 void wifiStartAP(bool only) {

--- a/code/espurna/wifi.ino
+++ b/code/espurna/wifi.ino
@@ -508,7 +508,21 @@ void _wifiWebSocketOnAction(uint32_t client_id, const char * action, JsonObject&
 // INFO
 // -----------------------------------------------------------------------------
 
-String _wifiSTAGetPSK() {
+// backported WiFiAPClass methods
+
+String _wifiSoftAPSSID() {
+    struct softap_config config;
+    wifi_softap_get_config(&config);
+
+    char* name = reinterpret_cast<char*>(config.ssid);
+    char ssid[sizeof(config.ssid) + 1];
+    memcpy(ssid, name, sizeof(config.ssid));
+    ssid[sizeof(config.ssid)] = '\0';
+
+    return String(ssid);
+}
+
+String _wifiSoftAPPSK() {
     struct softap_config config;
     wifi_softap_get_config(&config);
 
@@ -544,8 +558,8 @@ void wifiDebug(WiFiMode_t modes) {
 
     if (((modes & WIFI_AP) > 0) && ((WiFi.getMode() & WIFI_AP) > 0)) {
         DEBUG_MSG_P(PSTR("[WIFI] -------------------------------------- MODE AP\n"));
-        DEBUG_MSG_P(PSTR("[WIFI] SSID  %s\n"), getSetting("hostname").c_str());
-        DEBUG_MSG_P(PSTR("[WIFI] PASS  %s\n"), _wifiSTAGetPSK().c_str());
+        DEBUG_MSG_P(PSTR("[WIFI] SSID  %s\n"), _wifiSoftAPSSID().c_str());
+        DEBUG_MSG_P(PSTR("[WIFI] PASS  %s\n"), _wifiSoftAPPSK().c_str());
         DEBUG_MSG_P(PSTR("[WIFI] IP    %s\n"), WiFi.softAPIP().toString().c_str());
         DEBUG_MSG_P(PSTR("[WIFI] MAC   %s\n"), WiFi.softAPmacAddress().c_str());
         footer = true;

--- a/code/espurna/wifi.ino
+++ b/code/espurna/wifi.ino
@@ -502,6 +502,18 @@ void _wifiWebSocketOnAction(uint32_t client_id, const char * action, JsonObject&
 // INFO
 // -----------------------------------------------------------------------------
 
+String _wifiSTAGetPSK() {
+    struct softap_config config;
+    wifi_softap_get_config(&config);
+
+    char* pass = reinterpret_cast<char*>(config.password);
+    char psk[sizeof(config.password) + 1];
+    memcpy(psk, pass, sizeof(config.password));
+    psk[sizeof(config.password)] = '\0';
+
+    return String(psk);
+}
+
 void wifiDebug(WiFiMode_t modes) {
 
     #if DEBUG_SUPPORT
@@ -527,7 +539,7 @@ void wifiDebug(WiFiMode_t modes) {
     if (((modes & WIFI_AP) > 0) && ((WiFi.getMode() & WIFI_AP) > 0)) {
         DEBUG_MSG_P(PSTR("[WIFI] -------------------------------------- MODE AP\n"));
         DEBUG_MSG_P(PSTR("[WIFI] SSID  %s\n"), getSetting("hostname").c_str());
-        DEBUG_MSG_P(PSTR("[WIFI] PASS  %s\n"), getAdminPass().c_str());
+        DEBUG_MSG_P(PSTR("[WIFI] PASS  %s\n"), _wifiSTAGetPSK().c_str());
         DEBUG_MSG_P(PSTR("[WIFI] IP    %s\n"), WiFi.softAPIP().toString().c_str());
         DEBUG_MSG_P(PSTR("[WIFI] MAC   %s\n"), WiFi.softAPmacAddress().c_str());
         footer = true;

--- a/code/espurna/wifi.ino
+++ b/code/espurna/wifi.ino
@@ -19,23 +19,30 @@ uint8_t _wifi_ap_mode = WIFI_AP_FALLBACK;
 // PRIVATE
 // -----------------------------------------------------------------------------
 
+bool _wifiCanDisableAP() {
+    return ((WIFI_AP_FALLBACK == _wifi_ap_mode) &&
+            (jw.connected()) &&
+            ((WiFi.getMode() & WIFI_AP) > 0) &&
+            (WiFi.softAPgetStationNum() == 0));
+}
+
 void _wifiCheckAP() {
+    if (_wifiCanDisableAP()) jw.enableAP(false);
+}
 
-    if ((WIFI_AP_FALLBACK == _wifi_ap_mode) &&
-        (jw.connected()) &&
-        ((WiFi.getMode() & WIFI_AP) > 0) &&
-        (WiFi.softAPgetStationNum() == 0)
-    ) {
-        jw.enableAP(false);
+String _wifiGetAdminPass() {
+    static String last = getAdminPass();
+    if (_wifiCanDisableAP()) {
+        last = getAdminPass();
     }
-
+    return last.c_str();
 }
 
 void _wifiConfigure() {
 
     jw.setHostname(getSetting("hostname").c_str());
     #if USE_PASSWORD
-        jw.setSoftAP(getSetting("hostname").c_str(), getAdminPass().c_str());
+        jw.setSoftAP(getSetting("hostname").c_str(), _wifiGetAdminPass().c_str());
     #else
         jw.setSoftAP(getSetting("hostname").c_str());
     #endif

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -243,6 +243,11 @@ upload_flags = ${common.ota_upload_flags}
 board = ${common.board_4m}
 build_flags = ${common.build_flags_4m1m} -DNODEMCU_LOLIN -DDEBUG_FAUXMO=Serial -DNOWSAUTH
 
+[env:nodemcu-lolin-252]
+platform = ${common.arduino_core_2_5_2}
+board = ${common.board_4m}
+build_flags = ${common.build_flags_4m1m} -DNODEMCU_LOLIN -DDEBUG_FAUXMO=Serial -DNOWSAUTH
+
 [env:nodemcu-lolin-ssl]
 platform = ${common.platform_latest}
 board = ${common.board_4m}


### PR DESCRIPTION
- Stop updating SoftAP hostname and password when changing hostname and password via WebUI / settings `reload`:
https://gitter.im/tinkerman-cat/espurna?at=5d65418f49ac051923be1f06
- show real ssid and psk values from current sdk configuration instead of using getSetting
- `WIFI.STA` command