### PR TITLE
Home Assistant updates

### DIFF
--- a/code/espurna/config/deprecated.h
+++ b/code/espurna/config/deprecated.h
@@ -25,3 +25,20 @@
 #warning EVENTS_PIN is deprecated! Please use EVENTS1_PIN instead
 #define EVENTS1_PIN EVENTS_PIN
 #endif
+
+// 1.13.6 unifies mqtt payload options
+#ifdef HOMEASSISTANT_PAYLOAD_ON
+#warning HOMEASSISTANT_PAYLOAD_ON is deprecated! Global RELAY_MQTT_ON is used instead
+#endif
+
+#ifdef HOMEASSISTANT_PAYLOAD_OFF
+#warning HOMEASSISTANT_PAYLOAD_OFF is deprecated! Global RELAY_MQTT_OFF is used instead
+#endif
+
+#ifdef HOMEASSISTANT_PAYLOAD_AVAILABLE
+#warning HOMEASSISTANT_PAYLOAD_AVAILABLE is deprecated! Global MQTT_STATUS_ONLINE is used instead
+#endif
+
+#ifdef HOMEASSISTANT_PAYLOAD_NOT_AVAILABLE
+#warning HOMEASSISTANT_PAYLOAD_NOT_AVAILABLE is deprecated! Global MQTT_STATUS_OFFLINE is used instead
+#endif

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -408,6 +408,7 @@
 #ifndef RELAY_MQTT_ON
 #define RELAY_MQTT_ON               "1"
 #endif
+
 #ifndef RELAY_MQTT_OFF
 #define RELAY_MQTT_OFF              "0"
 #endif
@@ -1048,14 +1049,15 @@
 #define MQTT_TOPIC_NOTIFY_TEMP_RANGE_MAX "notify_temp_range_max"
 
 
+#ifndef MQTT_STATUS_ONLINE
 #define MQTT_STATUS_ONLINE          "1"         // Value for the device ON message
+#endif
+
 #ifndef MQTT_STATUS_OFFLINE
 #define MQTT_STATUS_OFFLINE         "0"         // Value for the device OFF message (will)
 #endif
 
 #define MQTT_ACTION_RESET           "reboot"    // RESET MQTT topic particle
-
-#define MQTT_MESSAGE_ID_SHIFT       1000        // Store MQTT message id into EEPROM every these many
 
 // Custom get and set postfixes
 // Use something like "/status" or "/set", with leading slash
@@ -1240,22 +1242,6 @@
 
 #ifndef HOMEASSISTANT_PREFIX
 #define HOMEASSISTANT_PREFIX    "homeassistant" // Default MQTT prefix
-#endif
-
-#ifndef HOMEASSISTANT_PAYLOAD_ON
-#define HOMEASSISTANT_PAYLOAD_ON    "1"         // Payload for ON and available messages
-#endif
-
-#ifndef HOMEASSISTANT_PAYLOAD_OFF
-#define HOMEASSISTANT_PAYLOAD_OFF   "0"         // Payload for OFF and unavailable messages
-#endif
-
-#ifndef HOMEASSISTANT_PAYLOAD_AVAILABLE
-#define HOMEASSISTANT_PAYLOAD_AVAILABLE     "1" // Payload for available messages
-#endif
-
-#ifndef HOMEASSISTANT_PAYLOAD_NOT_AVAILABLE
-#define HOMEASSISTANT_PAYLOAD_NOT_AVAILABLE "0" // Payload for available messages
 #endif
 
 // -----------------------------------------------------------------------------

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -167,10 +167,28 @@ void i2c_read_buffer(uint8_t address, uint8_t * buffer, size_t len);
 
 using mqtt_callback_f = std::function<void(unsigned int, const char *, char *)>;
 
-#if MQTT_SUPPORT
-    void mqttRegister(mqtt_callback_f callback);
-    String mqttMagnitude(char * topic);
-#endif
+void mqttRegister(mqtt_callback_f callback);
+
+String mqttTopic(const char * magnitude, bool is_set);
+String mqttTopic(const char * magnitude, unsigned int index, bool is_set);
+
+String mqttMagnitude(char * topic);
+
+void mqttSendRaw(const char * topic, const char * message, bool retain);
+void mqttSendRaw(const char * topic, const char * message);
+
+void mqttSend(const char * topic, const char * message, bool force, bool retain);
+void mqttSend(const char * topic, const char * message, bool force);
+void mqttSend(const char * topic, const char * message);
+
+void mqttSend(const char * topic, unsigned int index, const char * message, bool force);
+void mqttSend(const char * topic, unsigned int index, const char * message);
+
+const String& mqttPayloadOnline();
+const String& mqttPayloadOffline();
+const char* mqttPayloadStatus(bool status);
+
+void mqttSendStatus();
 
 #if MQTT_SECURE_CLIENT_INCLUDE_CA
 #include "../static/mqtt_secure_client_ca.h" // Assumes this header file defines a _mqtt_client_ca[] PROGMEM = "...PEM data..."
@@ -225,16 +243,42 @@ typedef struct {
 // -----------------------------------------------------------------------------
 #include <bitset>
 
+bool relayStatus(unsigned char id, bool status, bool report, bool group_report);
+bool relayStatus(unsigned char id, bool status);
+bool relayStatus(unsigned char id);
+
+void relayToggle(unsigned char id, bool report, bool group_report);
+void relayToggle(unsigned char id);
+
+unsigned char relayCount();
+unsigned char relayParsePayload(const char * payload);
+
+const String& relayPayloadOn();
+const String& relayPayloadOff();
+const char* relayPayload(bool status);
+
 // -----------------------------------------------------------------------------
 // Settings
 // -----------------------------------------------------------------------------
 #include <Embedis.h>
+
 template<typename T> bool setSetting(const String& key, T value);
 template<typename T> bool setSetting(const String& key, unsigned int index, T value);
 template<typename T> String getSetting(const String& key, T defaultValue);
 template<typename T> String getSetting(const String& key, unsigned int index, T defaultValue);
 void settingsGetJson(JsonObject& data);
 bool settingsRestoreJson(JsonObject& data);
+
+struct settings_cfg_t {
+    String& setting;
+    const char* key;
+    const char* default_value;
+};
+
+using settings_filter_t = std::function<String(String& value)>;
+using settings_cfg_list_t = std::vector<settings_cfg_t>;
+
+void settingsProcessConfig(const settings_cfg_list_t& config, settings_filter_t filter = nullptr);
 
 // -----------------------------------------------------------------------------
 // Terminal

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -334,6 +334,7 @@ using ws_on_keycheck_callback_list_t = std::vector<ws_on_keycheck_callback_f>;
     void wsPostAll(const ws_on_send_callback_list_t& callbacks);
 
     void wsPostSequence(uint32_t client_id, const ws_on_send_callback_list_t& callbacks);
+    void wsPostSequence(uint32_t client_id, ws_on_send_callback_list_t&& callbacks);
     void wsPostSequence(const ws_on_send_callback_list_t& callbacks);
 
     bool wsConnected();

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -291,9 +291,9 @@ struct ws_data_t;
 struct ws_debug_t;
 struct ws_callbacks_t;
 
-using ws_on_send_callback_f = std::function<void(JsonObject&)>;
-using ws_on_action_callback_f = std::function<void(uint32_t, const char *, JsonObject&)>;
-using ws_on_keycheck_callback_f = std::function<bool(const char *, JsonVariant&)>;
+using ws_on_send_callback_f = std::function<void(JsonObject& root)>;
+using ws_on_action_callback_f = std::function<void(uint32_t client_id, const char * action, JsonObject& data)>;
+using ws_on_keycheck_callback_f = std::function<bool(const char * key, JsonVariant& value)>;
 
 using ws_on_send_callback_list_t = std::vector<ws_on_send_callback_f>;
 using ws_on_action_callback_list_t = std::vector<ws_on_action_callback_f>;
@@ -318,27 +318,27 @@ using ws_on_keycheck_callback_list_t = std::vector<ws_on_keycheck_callback_f>;
     ws_callbacks_t& wsRegister();
 
     void wsSetup();
-    void wsSend(uint32_t, const char*);
-    void wsSend(uint32_t, JsonObject&);
-    void wsSend(JsonObject&);
-    void wsSend(ws_on_send_callback_f);
+    void wsSend(uint32_t client_id, const char* data);
+    void wsSend(uint32_t client_id, JsonObject& root);
+    void wsSend(JsonObject& root);
+    void wsSend(ws_on_send_callback_f callback);
 
-    void wsSend_P(PGM_P);
-    void wsSend_P(uint32_t, PGM_P);
+    void wsSend_P(PGM_P data);
+    void wsSend_P(uint32_t client_id, PGM_P data);
 
-    void wsPost(const ws_on_send_callback_f&);
-    void wsPost(const ws_on_send_callback_list_t&);
-    void wsPost(uint32_t, const ws_on_send_callback_list_t&);
+    void wsPost(const ws_on_send_callback_f& callback);
+    void wsPost(const ws_on_send_callback_list_t& callbacks);
+    void wsPost(uint32_t client_id, const ws_on_send_callback_list_t& callbacks);
 
-    void wsPostAll(uint32_t, const ws_on_send_callback_list_t&);
-    void wsPostAll(const ws_on_send_callback_list_t&);
+    void wsPostAll(uint32_t client_id, const ws_on_send_callback_list_t& callbacks);
+    void wsPostAll(const ws_on_send_callback_list_t& callbacks);
 
-    void wsPostSequence(uint32_t, const ws_on_send_callback_list_t&);
-    void wsPostSequence(const ws_on_send_callback_list_t&);
+    void wsPostSequence(uint32_t client_id, const ws_on_send_callback_list_t& callbacks);
+    void wsPostSequence(const ws_on_send_callback_list_t& callbacks);
 
     bool wsConnected();
-    bool wsConnected(uint32_t);
-    bool wsDebugSend(const char*, const char*);
+    bool wsConnected(uint32_t client_id);
+    bool wsDebugSend(const char* prefix, const char* message);
 #endif
 
 // -----------------------------------------------------------------------------

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -276,7 +276,7 @@ struct settings_cfg_t {
 };
 
 using settings_filter_t = std::function<String(String& value)>;
-using settings_cfg_list_t = std::vector<settings_cfg_t>;
+using settings_cfg_list_t = std::initializer_list<settings_cfg_t>;
 
 void settingsProcessConfig(const settings_cfg_list_t& config, settings_filter_t filter = nullptr);
 

--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -95,7 +95,6 @@ void _haSendMagnitude(unsigned char i, JsonObject& config) {
 
     unsigned char type = magnitudeType(i);
     config["name"] = _haFixName(getSetting("hostname") + String(" ") + magnitudeTopic(type));
-    config.set("platform", "mqtt");
     config["state_topic"] = mqttTopic(magnitudeTopicIndex(i).c_str(), false);
     config["unit_of_measurement"] = magnitudeUnits(type);
 }
@@ -141,7 +140,6 @@ void _haSendSwitch(unsigned char i, JsonObject& config) {
     }
 
     config.set("name", _haFixName(name));
-    config.set("platform", "mqtt");
 
     if (relayCount()) {
         config["state_topic"] = mqttTopic(MQTT_TOPIC_RELAY, i, false);

--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -17,7 +17,7 @@ bool _haSendFlag = false;
 // UTILS
 // -----------------------------------------------------------------------------
 
-String _haFixName(String name) {
+String& _haFixName(String& name) {
     for (unsigned char i=0; i<name.length(); i++) {
         if (!isalnum(name.charAt(i))) name.setCharAt(i, '_');
     }

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -68,6 +68,9 @@ String _mqtt_server;
 uint16_t _mqtt_port;
 String _mqtt_clientid;
 
+String _mqtt_payload_online;
+String _mqtt_payload_offline;
+
 std::vector<mqtt_callback_f> _mqtt_callbacks;
 
 struct mqtt_message_t {
@@ -119,7 +122,7 @@ void _mqttConnect() {
         _mqtt.setClientId(_mqtt_clientid.c_str());
         _mqtt.setKeepAlive(_mqtt_keepalive);
         _mqtt.setCleanSession(false);
-        _mqtt.setWill(_mqtt_will.c_str(), _mqtt_qos, _mqtt_retain, MQTT_STATUS_OFFLINE);
+        _mqtt.setWill(_mqtt_will.c_str(), _mqtt_qos, _mqtt_retain, _mqtt_payload_offline.c_str());
         if (_mqtt_user.length() && _mqtt_pass.length()) {
             DEBUG_MSG_P(PSTR("[MQTT] Connecting as user %s\n"), _mqtt_user.c_str());
             _mqtt.setCredentials(_mqtt_user.c_str(), _mqtt_pass.c_str());
@@ -252,7 +255,7 @@ void _mqttConnect() {
         if (verified) {
             #if MQTT_LIBRARY == MQTT_ARDUINO // Arduino-MQTT
                 _mqtt.begin(_mqtt_server.c_str(), _mqtt_port, (secure ? _mqtt_client_secure : _mqtt_client));
-                _mqtt.setWill(_mqtt_will.c_str(), MQTT_STATUS_OFFLINE, _mqtt_qos, _mqtt_retain);
+                _mqtt.setWill(_mqtt_will.c_str(), _mqtt_payload_offline.c_str(), _mqtt_qos, _mqtt_retain);
                 verified = _mqtt.connect(_mqtt_clientid.c_str(), _mqtt_user.c_str(), _mqtt_pass.c_str());
             #else // PubSubClient
                 _mqtt.setClient(secure ? _mqtt_client_secure : _mqtt_client);
@@ -260,9 +263,9 @@ void _mqttConnect() {
 
                 if (_mqtt_user.length() && _mqtt_pass.length()) {
                     DEBUG_MSG_P(PSTR("[MQTT] Connecting as user %s\n"), _mqtt_user.c_str());
-                    verified = _mqtt.connect(_mqtt_clientid.c_str(), _mqtt_user.c_str(), _mqtt_pass.c_str(), _mqtt_will.c_str(), _mqtt_qos, _mqtt_retain, MQTT_STATUS_OFFLINE);
+                    verified = _mqtt.connect(_mqtt_clientid.c_str(), _mqtt_user.c_str(), _mqtt_pass.c_str(), _mqtt_will.c_str(), _mqtt_qos, _mqtt_retain, _mqtt_payload_offline.c_str());
                 } else {
-                    verified = _mqtt.connect(_mqtt_clientid.c_str(), _mqtt_will.c_str(), _mqtt_qos, _mqtt_retain, MQTT_STATUS_OFFLINE);
+                    verified = _mqtt.connect(_mqtt_clientid.c_str(), _mqtt_will.c_str(), _mqtt_qos, _mqtt_retain, _mqtt_payload_offline.c_str());
                 }
             #endif
         }
@@ -386,6 +389,13 @@ void _mqttConfigure() {
         _mqttApplyTopic(_mqtt_topic_json, MQTT_TOPIC_JSON);
     }
 
+    // Custom payload strings
+    settingsProcessConfig({
+        {_mqtt_payload_online,  "mqttPayloadOnline",  MQTT_STATUS_ONLINE},
+        {_mqtt_payload_offline, "mqttPayloadOffline", MQTT_STATUS_OFFLINE}
+    });
+
+    // Reset reconnect delay to reconnect sooner
     _mqtt_reconnect_delay = MQTT_RECONNECT_DELAY_MIN;
 
 }
@@ -878,6 +888,22 @@ void mqttSetBroker(IPAddress ip, unsigned int port) {
 
 void mqttSetBrokerIfNone(IPAddress ip, unsigned int port) {
     if (getSetting("mqttServer", MQTT_SERVER).length() == 0) mqttSetBroker(ip, port);
+}
+
+const String& mqttPayloadOnline() {
+    return _mqtt_payload_online;
+}
+
+const String& mqttPayloadOffline() {
+    return _mqtt_payload_offline;
+}
+
+const char* mqttPayloadStatus(bool status) {
+    return status ? _mqtt_payload_online.c_str() : _mqtt_payload_offline.c_str();
+}
+
+void mqttSendStatus() {
+    mqttSend(MQTT_TOPIC_STATUS, _mqtt_payload_online.c_str(), true);
 }
 
 // -----------------------------------------------------------------------------

--- a/code/espurna/settings.ino
+++ b/code/espurna/settings.ino
@@ -245,6 +245,17 @@ void settingsGetJson(JsonObject& root) {
 
 }
 
+void settingsProcessConfig(const settings_cfg_list_t& config, settings_filter_t filter) {
+    for (auto& entry : config) {
+        String value = getSetting(entry.key, entry.default_value);
+        if (filter) {
+            value = filter(value);
+        }
+        if (value.equals(entry.setting)) continue;
+        entry.setting = std::move(value);
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Initialization
 // -----------------------------------------------------------------------------

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -272,7 +272,7 @@ void heartbeat() {
                 mqttSend(MQTT_TOPIC_VCC, String(ESP.getVcc()).c_str());
 
             if (hb_cfg & Heartbeat::Status)
-                mqttSend(MQTT_TOPIC_STATUS, MQTT_STATUS_ONLINE, true);
+                mqttSendStatus();
 
             if (hb_cfg & Heartbeat::Loadavg)
                 mqttSend(MQTT_TOPIC_LOADAVG, String(systemLoadAverage()).c_str());
@@ -291,7 +291,7 @@ void heartbeat() {
             #endif
 
         } else if (!serial && _heartbeat_mode == HEARTBEAT_REPEAT_STATUS) {
-            mqttSend(MQTT_TOPIC_STATUS, MQTT_STATUS_ONLINE, true);
+            mqttSendStatus();
         }
 
     #endif

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -91,6 +91,14 @@ struct ws_data_t {
         counter(0, 1)
     {}
 
+    ws_data_t(const uint32_t client_id, ws_on_send_callback_list_t&& callbacks, mode_t mode = SEQUENCE) :
+        storage(new ws_on_send_callback_list_t(std::forward<ws_on_send_callback_list_t>(callbacks))),
+        client_id(client_id),
+        mode(mode),
+        callbacks(*storage.get()),
+        counter(0, callbacks.size())
+    {}
+
     ws_data_t(const uint32_t client_id, const ws_on_send_callback_list_t& callbacks, mode_t mode = SEQUENCE) :
         client_id(client_id),
         mode(mode),
@@ -758,6 +766,10 @@ void wsPostAll(const ws_on_send_callback_list_t& cbs) {
 
 void wsPostSequence(uint32_t client_id, const ws_on_send_callback_list_t& cbs) {
     _ws_client_data.emplace(client_id, cbs, ws_data_t::SEQUENCE);
+}
+
+void wsPostSequence(uint32_t client_id, ws_on_send_callback_list_t&& cbs) {
+    _ws_client_data.emplace(client_id, std::forward<ws_on_send_callback_list_t>(cbs), ws_data_t::SEQUENCE);
 }
 
 void wsPostSequence(const ws_on_send_callback_list_t& cbs) {

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -92,11 +92,11 @@ struct ws_data_t {
     {}
 
     ws_data_t(const uint32_t client_id, ws_on_send_callback_list_t&& callbacks, mode_t mode = SEQUENCE) :
-        storage(new ws_on_send_callback_list_t(std::forward<ws_on_send_callback_list_t>(callbacks))),
+        storage(new ws_on_send_callback_list_t(std::move(callbacks))),
         client_id(client_id),
         mode(mode),
         callbacks(*storage.get()),
-        counter(0, callbacks.size())
+        counter(0, (storage.get())->size())
     {}
 
     ws_data_t(const uint32_t client_id, const ws_on_send_callback_list_t& callbacks, mode_t mode = SEQUENCE) :


### PR DESCRIPTION
- remove "platform" key, see #1440. this implicitly sets schema to "basic". pending some other clean-up regarding json and mqtt queueing, other schema can be added down the line 
- updated ws module queue elem to capture callbacks list, allows to pass more than one callback (for example, when they are generated on the fly as lambdas, see ha wsPost usage)
- modified method to send ha config to use global ws queue, fix #1762 problem with empty topics and ensure json allocation is consistent.
- use existing defines to set mqtt payload options. amend https://github.com/xoseperez/espurna/issues/1085, https://github.com/xoseperez/espurna/pull/1188 to use the set payload value. drop HOMEASSISTANT_PAYLOAD... defines. fixes #1883 
- update MQTT_STATUS_ONLINE/OFFLINE and RELAY_MQTT_ON/OFF with runtime configuration
- filter payload strings so that resulting yaml value is not interpreted as bool
- helper method for settings to streamline string values manipulation