### PR TITLE
Update mqtt packet size to fit JSON payloads

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -65,7 +65,7 @@ board_1m = esp01_1m
 board_2m = esp_wroom_02
 board_4m = esp12e
 
-build_flags = -g -w -DMQTT_MAX_PACKET_SIZE=400 -DNO_GLOBAL_EEPROM ${sysenv.ESPURNA_FLAGS} -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+build_flags = -g -w -DMQTT_MAX_PACKET_SIZE=1024 -DNO_GLOBAL_EEPROM ${sysenv.ESPURNA_FLAGS} -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
 build_flags_512k = ${common.build_flags} -Wl,-Teagle.flash.512k0m1s.ld
 build_flags_1m0m = ${common.build_flags} -Wl,-Teagle.flash.1m0m1s.ld
 build_flags_2m1m = ${common.build_flags} -Wl,-Teagle.flash.2m1m4s.ld

--- a/dist/arduino_ide/2.3.0/boards.local.txt
+++ b/dist/arduino_ide/2.3.0/boards.local.txt
@@ -36,4 +36,4 @@ generic.menu.float_support.disabled.build.float=
 generic.menu.float_support.enabled=Enabled
 generic.menu.float_support.enabled.build.float=-u _printf_float -u _scanf_float
 
-generic.compiler.cpp.extra_flags=-DNO_GLOBAL_EEPROM -DMQTT_MAX_PACKET_SIZE=400
+generic.compiler.cpp.extra_flags=-DNO_GLOBAL_EEPROM -DMQTT_MAX_PACKET_SIZE=1024

--- a/dist/arduino_ide/latest/boards.local.txt
+++ b/dist/arduino_ide/latest/boards.local.txt
@@ -36,4 +36,4 @@ generic.menu.float_support.disabled.build.float=
 generic.menu.float_support.enabled=Enabled
 generic.menu.float_support.enabled.build.float=-u _printf_float -u _scanf_float
 
-generic.compiler.cpp.extra_flags=-DNO_GLOBAL_EEPROM -DMQTT_MAX_PACKET_SIZE=400
+generic.compiler.cpp.extra_flags=-DNO_GLOBAL_EEPROM -DMQTT_MAX_PACKET_SIZE=1024

--- a/dist/boards_local_txt.py
+++ b/dist/boards_local_txt.py
@@ -110,7 +110,7 @@ MENUS = ["flash_size", "float_support"]
 CORE_VERSIONS = ["2.3.0", "latest"]
 
 EXTRA_FLAGS = [
-    (".compiler.cpp.extra_flags", "-DNO_GLOBAL_EEPROM -DMQTT_MAX_PACKET_SIZE=400")
+    (".compiler.cpp.extra_flags", "-DNO_GLOBAL_EEPROM -DMQTT_MAX_PACKET_SIZE=1024")
 ]
 
 
@@ -167,7 +167,13 @@ def print_versions(args):
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--directory", default="arduino_ide")
+    parser.add_argument(
+        "-d",
+        "--directory",
+        default=os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), "arduino_ide"
+        ),
+    )
 
     subparsers = parser.add_subparsers(title="commands")
     parser_versions = subparsers.add_parser("versions", help="list supported versions")


### PR DESCRIPTION
As noticed in #1873 
PubSubClient & Arduino MQTT use internal buffer, but the default value of 128 is pretty small
PubSubClient needs this value known at build-tme
ArduinoMQTT accepts constructor argument, but right now mqtt module depends on global object