### PR TITLE
Fix HTTPS support with OTA_CLIENT_HTTPUPDATE

### DIFF
--- a/code/espurna/ota_httpupdate.ino
+++ b/code/espurna/ota_httpupdate.ino
@@ -186,7 +186,7 @@ void _otaClientFrom(const String& url) {
         return;
     }
 
-    #if SECURE_CLIENT_SUPPORT
+    #if SECURE_CLIENT != SECURE_CLIENT_NONE
         if (url.startsWith("https://")) {
             _otaClientFromHttps(url);
             return;


### PR DESCRIPTION
There is a wrong #if check in the HttpUpdate OTA implementation, causing HTTPS URLs not to work. This fixes the check.