### PR TITLE
test: dns probing and netstat for terminal

### DIFF
--- a/code/espurna/config/dependencies.h
+++ b/code/espurna/config/dependencies.h
@@ -81,3 +81,8 @@
 #undef OTA_CLIENT_HTTPUPDATE_2_3_0_COMPATIBLE
 #define OTA_CLIENT_HTTPUPDATE_2_3_0_COMPATIBLE 0   // Use new HTTPUpdate API with BearSSL
 #endif
+
+#if LWIP_VERSION_MAJOR != 1
+#undef MDNS_CLIENT_SUPPORT
+#define MDNS_CLIENT_SUPPORT         0          // default resolver already handles this
+#endif

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -16,6 +16,21 @@ extern "C" {
 // System
 // -----------------------------------------------------------------------------
 
+#define LWIP_INTERNAL
+#include <ESP8266WiFi.h>
+#undef LWIP_INTERNAL
+
+extern "C" {
+  #include <lwip/opt.h>
+  #include <lwip/ip.h>
+  #include <lwip/tcp.h>
+  #include <lwip/inet.h> // ip_addr_t
+  #include <lwip/err.h> // ERR_x
+  #include <lwip/dns.h> // dns_gethostbyname
+  #include <lwip/ip_addr.h> // ip4/ip6 helpers
+  #include <lwip/init.h> // LWIP_VERSION_MAJOR
+}
+
 uint32_t systemResetReason();
 uint8_t systemStabilityCounter();
 void systemStabilityCounter(uint8_t);

--- a/code/espurna/terminal.ino
+++ b/code/espurna/terminal.ino
@@ -79,6 +79,91 @@ void _terminalKeysCommand() {
 
 }
 
+#if LWIP_VERSION_MAJOR != 1
+
+// not yet CONNECTING or LISTENING
+extern struct tcp_pcb *tcp_bound_pcbs;
+// accepting or sending data
+extern struct tcp_pcb *tcp_active_pcbs;
+// // TIME-WAIT status
+extern struct tcp_pcb *tcp_tw_pcbs;
+
+String _terminalPcbStateToString(const unsigned char state) {
+    switch (state) {
+        case 0: return F("CLOSED");
+        case 1: return F("LISTEN");
+        case 2: return F("SYN_SENT");
+        case 3: return F("SYN_RCVD");
+        case 4: return F("ESTABLISHED");
+        case 5: return F("FIN_WAIT_1");
+        case 6: return F("FIN_WAIT_2");
+        case 7: return F("CLOSE_WAIT");
+        case 8: return F("CLOSING");
+        case 9: return F("LAST_ACK");
+        case 10: return F("TIME_WAIT");
+        default: return String(int(state));
+    };
+}
+
+void _terminalPrintTcpPcb(tcp_pcb* pcb) {
+
+    char remote_ip[32] = {0};
+    char local_ip[32] = {0};
+
+    inet_ntoa_r((pcb->local_ip), local_ip, sizeof(local_ip));
+    inet_ntoa_r((pcb->remote_ip), remote_ip, sizeof(remote_ip));
+
+    DEBUG_MSG_P(PSTR("state=%s local=%s:%u remote=%s:%u snd_queuelen=%u lastack=%u send_wnd=%u rto=%u\n"),
+            _terminalPcbStateToString(pcb->state).c_str(),
+            local_ip, pcb->local_port,
+            remote_ip, pcb->remote_port,
+            pcb->snd_queuelen, pcb->lastack,
+            pcb->snd_wnd, pcb->rto
+    );
+
+}
+
+void _terminalPrintTcpPcbs() {
+
+    tcp_pcb *pcb;
+    //DEBUG_MSG_P(PSTR("Active PCB states:\n"));
+    for (pcb = tcp_active_pcbs; pcb != NULL; pcb = pcb->next) {
+        _terminalPrintTcpPcb(pcb);
+    }
+    //DEBUG_MSG_P(PSTR("TIME-WAIT PCB states:\n"));
+    for (pcb = tcp_tw_pcbs; pcb != NULL; pcb = pcb->next) {
+        _terminalPrintTcpPcb(pcb);
+    }
+    //DEBUG_MSG_P(PSTR("BOUND PCB states:\n"));
+    for (pcb = tcp_bound_pcbs; pcb != NULL; pcb = pcb->next) {
+        _terminalPrintTcpPcb(pcb);
+    }
+
+}
+
+void _terminalPrintDnsResult(const char* name, const ip_addr_t* address) {
+    // TODO fix asynctcp building with lwip-ipv6
+    /*
+    #if LWIP_IPV6
+        if (IP_IS_V6(address)) {
+            DEBUG_MSG_P(PSTR("[DNS] %s has IPV6 address %s\n"), name, ip6addr_ntoa(ip_2_ip6(address)));
+        }
+    #endif
+    */
+    DEBUG_MSG_P(PSTR("[DNS] %s has address %s\n"), name, ipaddr_ntoa(address));
+}
+
+void _terminalDnsFound(const char* name, const ip_addr_t* result, void*) {
+    if (!result) {
+        DEBUG_MSG_P(PSTR("[DNS] %s not found\n"), name);
+        return;
+    }
+
+    _terminalPrintDnsResult(name, result);
+}
+
+#endif // LWIP_VERSION_MAJOR != 1
+
 void _terminalInitCommand() {
 
     terminalRegisterCommand(F("COMMANDS"), [](Embedis* e) {
@@ -229,6 +314,32 @@ void _terminalInitCommand() {
             }
         });
     #endif
+
+    #if LWIP_VERSION_MAJOR != 1
+        terminalRegisterCommand(F("HOST"), [](Embedis* e) {
+            if (e->argc != 2) {
+                terminalError(F("HOST [hostname]"));
+                return;
+            }
+
+            ip_addr_t result;
+            auto error = dns_gethostbyname(e->argv[1], &result, _terminalDnsFound, nullptr);
+            if (error == ERR_OK) {
+                _terminalPrintDnsResult(e->argv[1], &result);
+                terminalOK();
+                return;
+            } else if (error != ERR_INPROGRESS) {
+                DEBUG_MSG_P(PSTR("[DNS] dns_gethostbyname error: %s\n"), lwip_strerr(error));
+                return;
+            }
+
+        });
+
+        terminalRegisterCommand(F("NETSTAT"), [](Embedis*) {
+            _terminalPrintTcpPcbs();
+        });
+
+    #endif // LWIP_VERSION_MAJOR != 1
     
 }
 

--- a/code/espurna/terminal.ino
+++ b/code/espurna/terminal.ino
@@ -408,6 +408,11 @@ void terminalSetup() {
         #endif
     });
 
+    #if WEB_SUPPORT
+        wsRegister()
+            .onVisible([](JsonObject& root) { root["cmdVisible"] = 1; });
+    #endif
+
     _terminalInitCommand();
 
     #if SERIAL_RX_ENABLED

--- a/code/espurna/ws.ino
+++ b/code/espurna/ws.ino
@@ -540,9 +540,6 @@ void _wsOnConnected(JsonObject& root) {
     root["btnDelay"] = getSetting("btnDelay", BUTTON_DBLCLICK_DELAY).toInt();
     root["webPort"] = getSetting("webPort", WEB_PORT).toInt();
     root["wsAuth"] = getSetting("wsAuth", WS_AUTHENTICATION).toInt() == 1;
-    #if TERMINAL_SUPPORT
-        root["cmdVisible"] = 1;
-    #endif
     root["hbMode"] = getSetting("hbMode", HEARTBEAT_MODE).toInt();
     root["hbInterval"] = getSetting("hbInterval", HEARTBEAT_INTERVAL).toInt();
 }


### PR DESCRIPTION
https://gitter.im/tinkerman-cat/espurna?at=5d761a6e74c23124a2e2662f, @Niek 
Do we even need MDNS_CLIENT_SUPPORT then? I can resolve .local hostnames with built-in resolver, no need to use the external library. Only applies to lwip2 builds:
https://github.com/d-a-v/esp82xx-nonos-linklayer/blob/e23a07e5f9ccb43d36777c497fc34d044e3ecf3b/glue-lwip/arduino/lwipopts.h#L1164-L1168