### PR TITLE
Fix SSL check callback function definition

### DIFF
--- a/code/espurna/libs/SecureClientHelpers.h
+++ b/code/espurna/libs/SecureClientHelpers.h
@@ -20,6 +20,15 @@ using fp_callback_f = std::function<String()>;
 using cert_callback_f = std::function<const char*()>;
 using mfln_callback_f = std::function<uint16_t()>;
 
+const char * _secureClientCheckAsString(int check) {
+    switch (check) {
+        case SECURE_CLIENT_CHECK_NONE: return "no validation";
+        case SECURE_CLIENT_CHECK_FINGERPRINT: return "fingerprint validation";
+        case SECURE_CLIENT_CHECK_CA: return "CA validation";
+        default: return "unknown";
+    }
+}
+
 #if SECURE_CLIENT == SECURE_CLIENT_AXTLS
 using SecureClientClass = axTLS::WiFiClientSecure;
 
@@ -61,7 +70,7 @@ struct SecureClientChecks {
         int check = getCheck();
 
         if(config.debug) {
-            DEBUG_MSG_P(PSTR("[%s] Using SSL check type: %d\n"), config.tag.c_str(), check);
+            DEBUG_MSG_P(PSTR("[%s] Using SSL check type: %s\n"), config.tag.c_str(), _secureClientCheckAsString(check));
         }
 
         if (check == SECURE_CLIENT_CHECK_NONE) {
@@ -157,7 +166,7 @@ struct SecureClientChecks {
         bool settime = (check == SECURE_CLIENT_CHECK_CA);
 
         if(config.debug) {
-            DEBUG_MSG_P(PSTR("[%s] Using SSL check type: %d\n"), config.tag.c_str(), check);
+            DEBUG_MSG_P(PSTR("[%s] Using SSL check type: %s\n"), config.tag.c_str(), _secureClientCheckAsString(check));
         }
 
         if (!ntpSynced() && settime) {

--- a/code/espurna/libs/SecureClientHelpers.h
+++ b/code/espurna/libs/SecureClientHelpers.h
@@ -15,7 +15,7 @@
 namespace SecureClientHelpers {
 
 using host_callback_f = std::function<String()>;
-using check_callback_f = std::function<bool()>;
+using check_callback_f = std::function<int()>;
 using fp_callback_f = std::function<String()>;
 using cert_callback_f = std::function<const char*()>;
 using mfln_callback_f = std::function<uint16_t()>;
@@ -59,6 +59,10 @@ struct SecureClientChecks {
         bool result = false;
 
         int check = getCheck();
+
+        if(config.debug) {
+            DEBUG_MSG_P(PSTR("[%s] Using SSL check type: %d\n"), config.tag.c_str(), check);
+        }
 
         if (check == SECURE_CLIENT_CHECK_NONE) {
             if (config.debug) DEBUG_MSG_P(PSTR("[%s] !!! Secure connection will not be validated !!!\n"), config.tag.c_str());
@@ -151,6 +155,10 @@ struct SecureClientChecks {
     bool beforeConnected(SecureClientClass& client) {
         int check = getCheck();
         bool settime = (check == SECURE_CLIENT_CHECK_CA);
+
+        if(config.debug) {
+            DEBUG_MSG_P(PSTR("[%s] Using SSL check type: %d\n"), config.tag.c_str(), check);
+        }
 
         if (!ntpSynced() && settime) {
             if (config.debug) DEBUG_MSG_P(PSTR("[%s] Time not synced! Cannot use CA validation\n"), config.tag.c_str());


### PR DESCRIPTION
Took me a loooong time to figure out why ``config.on_check()`` was returning 1 (fingerprint) instead of 2 (CA). This fixes the function definition, added some debug lines as well to indicate which check is being used.