### PR TITLE
Added support for reverse telnet

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -130,6 +130,13 @@
 #define TELNET_SERVER           TELNET_SERVER_ASYNC // Can be either TELNET_SERVER_ASYNC (using ESPAsyncTCP) or TELNET_SERVER_WIFISERVER (using WiFiServer)
 #endif
 
+// Enable this flag to add support for reverse telnet (+800 bytes)
+// This is useful to telnet to a device behind a NAT or firewall
+// To use this feature, start a listen server on a publicly reachable host with e.g. "ncat -vlp <port>" and use the MQTT reverse telnet command to connect
+#ifndef TELNET_REVERSE_SUPPORT
+#define TELNET_REVERSE_SUPPORT  0
+#endif
+
 //------------------------------------------------------------------------------
 // TERMINAL
 //------------------------------------------------------------------------------
@@ -1068,6 +1075,7 @@
 #define MQTT_TOPIC_IRIN             "irin"
 #define MQTT_TOPIC_IROUT            "irout"
 #define MQTT_TOPIC_OTA              "ota"
+#define MQTT_TOPIC_TELNET_REVERSE   "telnet_reverse"
 
 // Light module
 #define MQTT_TOPIC_CHANNEL          "channel"

--- a/code/espurna/telnet.ino
+++ b/code/espurna/telnet.ino
@@ -20,7 +20,7 @@ Parts of the code have been borrowed from Thomas Sarlandie's NetServer
     std::unique_ptr<AsyncClient> _telnetClients[TELNET_MAX_CLIENTS];
 #endif
 
-bool _telnetFirst = true;
+bool _telnetFirst = false;
 
 bool _telnetAuth = TELNET_AUTHENTICATION;
 bool _telnetClientsAuth[TELNET_MAX_CLIENTS];
@@ -227,7 +227,6 @@ void _telnetNotifyConnected(unsigned char i) {
         }
     #endif
 
-    _telnetFirst = true;
     wifiReconnectCheck();
 
 }
@@ -258,6 +257,7 @@ void _telnetLoop() {
                     }
                 }
 
+                _telnetFirst = true;
                 _telnetNotifyConnected(i);
 
                 break;
@@ -317,6 +317,8 @@ void _telnetNewClient(AsyncClient* client) {
         if (!_telnetClients[i] || !_telnetClients[i]->connected()) {
 
             _telnetClients[i] = std::unique_ptr<AsyncClient>(client);
+
+            _telnetFirst = true;
 
             _telnetNotifyConnected(i);
             return;

--- a/code/espurna/telnet.ino
+++ b/code/espurna/telnet.ino
@@ -10,6 +10,9 @@ Parts of the code have been borrowed from Thomas Sarlandie's NetServer
 
 #if TELNET_SUPPORT
 
+#define TELNET_IAC  0xFF
+#define TELNET_XEOF 0xEC
+
 #if TELNET_SERVER == TELNET_SERVER_WIFISERVER
     #include <ESP8266WiFi.h>
     WiFiServer _telnetServer = WiFiServer(TELNET_PORT);
@@ -19,8 +22,6 @@ Parts of the code have been borrowed from Thomas Sarlandie's NetServer
     AsyncServer _telnetServer = AsyncServer(TELNET_PORT);
     std::unique_ptr<AsyncClient> _telnetClients[TELNET_MAX_CLIENTS];
 #endif
-
-bool _telnetFirst = false;
 
 bool _telnetAuth = TELNET_AUTHENTICATION;
 bool _telnetClientsAuth[TELNET_MAX_CLIENTS];
@@ -133,21 +134,15 @@ bool _telnetWrite(unsigned char clientId, const char * message) {
 }
 
 void _telnetData(unsigned char clientId, void *data, size_t len) {
-    // Skip first message since it's always garbage
-    if (_telnetFirst) {
-        _telnetFirst = false;
-        return;
-    }
-
     // Capture close connection
     char * p = (char *) data;
 
-    // C-d is sent as two bytes (sometimes repeating)
-    if (len >= 2) {
-        if ((p[0] == 0xFF) && (p[1] == 0xEC)) {
+    if ((len >= 2) && (p[0] == TELNET_IAC)) {
+        // C-d is sent as two bytes (sometimes repeating)
+        if (p[1] == TELNET_XEOF) {
             _telnetDisconnect(clientId);
-            return;
         }
+        return; // Ignore telnet negotiation
     }
 
     if ((strncmp(p, "close", 5) == 0) || (strncmp(p, "quit", 4) == 0)) {
@@ -257,7 +252,6 @@ void _telnetLoop() {
                     }
                 }
 
-                _telnetFirst = true;
                 _telnetNotifyConnected(i);
 
                 break;
@@ -317,8 +311,6 @@ void _telnetNewClient(AsyncClient* client) {
         if (!_telnetClients[i] || !_telnetClients[i]->connected()) {
 
             _telnetClients[i] = std::unique_ptr<AsyncClient>(client);
-
-            _telnetFirst = true;
 
             _telnetNotifyConnected(i);
             return;

--- a/code/espurna/telnet.ino
+++ b/code/espurna/telnet.ino
@@ -50,9 +50,9 @@ void _telnetWebSocketOnConnected(JsonObject& root) {
         for (i = 0; i < TELNET_MAX_CLIENTS; i++) {
             if (!_telnetClients[i] || !_telnetClients[i]->connected()) {
                 #if TELNET_SERVER == TELNET_SERVER_WIFISERVER
-                    _telnetClients[i] = std::unique_ptr<WiFiClient>(new WiFiClient());
+                    _telnetClients[i] = std::make_unique<WiFiClient>();
                 #else // TELNET_SERVER_ASYNC
-                    _telnetClients[i] = std::unique_ptr<AsyncClient>(client);
+                    _telnetClients[i] = std::make_unique<AsyncClient>();
                 #endif
 
                 if (_telnetClients[i]->connect(host, port)) {


### PR DESCRIPTION
Not sure if this is a useful feature to add, but I could see it being useful for some people. This basically adds the ability to telnet to an Espurna device that is NATed/firewalled. After sending the ``host:ip`` of a publicly reachable ncat listener to the MQTT topic ``telnet_reverse``, the device opens a telnet connection.

Note: untested on Async telnet server, but should work. There's one more issue that the first command is ignored, probably easiest is to move ``_telnetFirst = true`` to ``_telnetLoop`` / ``_telnetNewClient`` and set it to false in ``_telnetReverse``?