### PR TITLE
Fix warning about unused variable if DEBUG support is disabled

### DIFF
--- a/code/espurna/ntp.ino
+++ b/code/espurna/ntp.ino
@@ -122,11 +122,13 @@ void _ntpReport() {
 
     _ntp_report = false;
 
+    #if DEBUG_SUPPORT
     if (ntpSynced()) {
         time_t t = now();
         DEBUG_MSG_P(PSTR("[NTP] UTC Time  : %s\n"), ntpDateTime(ntpLocal2UTC(t)).c_str());
         DEBUG_MSG_P(PSTR("[NTP] Local Time: %s\n"), ntpDateTime(t).c_str());
     }
+    #endif
 
 }
 


### PR DESCRIPTION
There's a compiler warning  in the NTP module when DEBUG support is disabled, this fixes it.