### PR TITLE
Added restore last schedule support

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1403,6 +1403,10 @@
 #define SCHEDULER_MAX_SCHEDULES     10          // Max schedules alowed
 #endif
 
+#ifndef SCHEDULER_RESTORE_LAST_SCHEDULE
+#define SCHEDULER_RESTORE_LAST_SCHEDULE      0  // Restore the last schedule state on the device boot
+#endif
+
 // -----------------------------------------------------------------------------
 // NTP
 // -----------------------------------------------------------------------------

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -733,7 +733,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
     JsonArray& pulse_time = relays.createNestedArray("pulse_time");
 
     #if SCHEDULER_SUPPORT
-        JsonArray& sch_last = relays.createNestedArray("relayLastSch");
+        JsonArray& sch_last = relays.createNestedArray("sch_last");
     #endif
 
     #if MQTT_SUPPORT

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -753,7 +753,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
         pulse_time.add(_relays[i].pulse_ms / 1000.0);
 
         #if SCHEDULER_SUPPORT
-            restore_last_schedule.add(getSetting("relayLastSchedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt() == 1);
+            relayLastschedule.add(getSetting("relayLastschedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt());
         #endif
 
         #if MQTT_SUPPORT

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -733,7 +733,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
     JsonArray& pulse_time = relays.createNestedArray("pulse_time");
 
     #if SCHEDULER_SUPPORT
-        JsonArray& restore_last_schedule = relays.createNestedArray("restore_last_schedule");
+        JsonArray& relayLastschedule = relays.createNestedArray("relayLastschedule");
     #endif
 
     #if MQTT_SUPPORT

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -34,7 +34,6 @@ typedef struct {
     unsigned long change_time;  // Scheduled time to change
     bool report;                // Whether to report to own topic
     bool group_report;          // Whether to report to group topic
-    unsigned char restore_last_schedule;  // Boolean, Restore to last schedule or not
 
     // Helping objects
 
@@ -657,7 +656,6 @@ void _relayConfigure() {
             //set to high to block short opening of relay
             digitalWrite(_relays[i].pin, HIGH);
         }
-        _relays[i].restore_last_schedule = getSetting("relayLastschedule", i, 1).toInt();
     }
 
     #if MQTT_SUPPORT
@@ -733,7 +731,10 @@ void _relayWebSocketSendRelays(JsonObject& root) {
     JsonArray& boot = relays.createNestedArray("boot");
     JsonArray& pulse = relays.createNestedArray("pulse");
     JsonArray& pulse_time = relays.createNestedArray("pulse_time");
-    JsonArray& restore_last_schedule = relays.createNestedArray("restore_last_schedule");
+
+    #if SCHEDULER_SUPPORT
+        JsonArray& restore_last_schedule = relays.createNestedArray("restore_last_schedule");
+    #endif
 
     #if MQTT_SUPPORT
         JsonArray& group = relays.createNestedArray("group");
@@ -750,7 +751,10 @@ void _relayWebSocketSendRelays(JsonObject& root) {
 
         pulse.add(_relays[i].pulse);
         pulse_time.add(_relays[i].pulse_ms / 1000.0);
-        restore_last_schedule.add(_relays[i].restore_last_schedule);
+
+        #if SCHEDULER_SUPPORT
+            restore_last_schedule.add(getSetting("relayLastSchedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt() == 1);
+        #endif
 
         #if MQTT_SUPPORT
             group.add(getSetting("mqttGroup", i, ""));

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -733,7 +733,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
     JsonArray& pulse_time = relays.createNestedArray("pulse_time");
 
     #if SCHEDULER_SUPPORT
-        JsonArray& relayLastschedule = relays.createNestedArray("relayLastschedule");
+        JsonArray& sch_last = relays.createNestedArray("relayLastSch");
     #endif
 
     #if MQTT_SUPPORT
@@ -753,7 +753,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
         pulse_time.add(_relays[i].pulse_ms / 1000.0);
 
         #if SCHEDULER_SUPPORT
-            relayLastschedule.add(getSetting("relayLastschedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt());
+            sch_last.add(getSetting("relayLastSch", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt());
         #endif
 
         #if MQTT_SUPPORT

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -34,6 +34,7 @@ typedef struct {
     unsigned long change_time;  // Scheduled time to change
     bool report;                // Whether to report to own topic
     bool group_report;          // Whether to report to group topic
+    unsigned char restore_last_schedule;  // Boolean, Restore to last schedule or not
 
     // Helping objects
 
@@ -656,6 +657,7 @@ void _relayConfigure() {
             //set to high to block short opening of relay
             digitalWrite(_relays[i].pin, HIGH);
         }
+        _relays[i].restore_last_schedule = getSetting("relayLastschedule", i, 1).toInt();
     }
 
     #if MQTT_SUPPORT
@@ -731,6 +733,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
     JsonArray& boot = relays.createNestedArray("boot");
     JsonArray& pulse = relays.createNestedArray("pulse");
     JsonArray& pulse_time = relays.createNestedArray("pulse_time");
+    JsonArray& restore_last_schedule = relays.createNestedArray("restore_last_schedule");
 
     #if MQTT_SUPPORT
         JsonArray& group = relays.createNestedArray("group");
@@ -747,6 +750,7 @@ void _relayWebSocketSendRelays(JsonObject& root) {
 
         pulse.add(_relays[i].pulse);
         pulse_time.add(_relays[i].pulse_ms / 1000.0);
+        restore_last_schedule.add(_relays[i].restore_last_schedule);
 
         #if MQTT_SUPPORT
             group.add(getSetting("mqttGroup", i, ""));

--- a/code/espurna/scheduler.ino
+++ b/code/espurna/scheduler.ino
@@ -257,7 +257,7 @@ void _schLoop() {
 
     if (_sch_restore == 0) {
         for (int i = 0; i < _relays.size(); i++){
-            if (getSetting("relayLastschedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt() == 1)
+            if (getSetting("relayLastSch", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt() == 1)
                 _schCheck(i, 0);
         }
         _sch_restore = 1;

--- a/code/espurna/scheduler.ino
+++ b/code/espurna/scheduler.ino
@@ -248,7 +248,7 @@ void _schLoop() {
 
     if (_sch_restore == 0) {
         for (int i = 0; i < _relays.size(); i++){
-            if (getSetting("relayLastSchedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt() == 1)
+            if (getSetting("relayLastschedule", i, SCHEDULER_RESTORE_LAST_SCHEDULE).toInt() == 1)
                 _schCheck(i, 0);
         }
         _sch_restore = 1;

--- a/code/espurna/scheduler.ino
+++ b/code/espurna/scheduler.ino
@@ -196,12 +196,21 @@ void _schCheck(int relay, int daybefore) {
             int sch_minute = getSetting("schMinute", i, 0).toInt();
             int minutes_to_trigger = _schMinutesLeft(t, sch_hour, sch_minute);
             int sch_action = getSetting("schAction", i, 0).toInt();
+            unsigned char sch_type = getSetting("schType", i, SCHEDULER_TYPE_SWITCH).toInt();
 
-            if (sch_switch == relay && sch_action != 2 && minutes_to_trigger < 0 && minutes_to_trigger > minimum_restore_time) {
+            if (sch_type == SCHEDULER_TYPE_SWITCH && sch_switch == relay && sch_action != 2 && minutes_to_trigger < 0 && minutes_to_trigger > minimum_restore_time) {
                 minimum_restore_time = minutes_to_trigger;
                 saved_action = sch_action;
                 saved_sch = i;
             }
+
+            #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
+                if (SCHEDULER_TYPE_DIM == sch_type && sch_switch == relay && minutes_to_trigger < 0 && minutes_to_trigger > minimum_restore_time) {
+                    minimum_restore_time = minutes_to_trigger;
+                    saved_action = sch_action;
+                    saved_sch = i;
+                }
+            #endif
 
             if (minutes_to_trigger == 0 && relay == -1) {
 

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -250,7 +250,7 @@ function addValue(data, name, value) {
     var is_group = [
         "ssid", "pass", "gw", "mask", "ip", "dns",
         "schEnabled", "schSwitch","schAction","schType","schHour","schMinute","schWDs","schUTC",
-        "relayBoot", "relayPulse", "relayTime", "relayLastschedule",
+        "relayBoot", "relayPulse", "relayTime", "relayLastSch",
         "mqttGroup", "mqttGroupSync", "relayOnDisc",
         "dczRelayIdx", "dczMagnitude",
         "tspkRelay", "tspkMagnitude",
@@ -265,9 +265,9 @@ function addValue(data, name, value) {
         name = "adminPass";
     }
 
-    // join both relayLastschedule values
-    if (name.startsWith("relayLastschedule")) {
-        name = "relayLastschedule";
+    // join all relayLastSch values
+    if (name.startsWith("relayLastSch")) {
+        name = "relayLastSch";
     }
 
     if (name in data) {
@@ -1030,10 +1030,10 @@ function initRelayConfig(data) {
         $("select[name='relayBoot']", line).val(data.boot[i]);
         $("select[name='relayPulse']", line).val(data.pulse[i]);
         $("input[name='relayTime']", line).val(data.pulse_time[i]);
-        $("input[name='relayLastschedule']", line).prop('checked', data.relayLastschedule[i]);
-        $("input[name='relayLastschedule']", line).attr("id", "relayLastschedule" + i);
-        $("input[name='relayLastschedule']", line).attr("name", "relayLastschedule" + i);
-        $("input[name='relayLastschedule" + i + "']", line).next().attr("for","relayLastschedule" + (i));
+        $("input[name='relayLastSch']", line).prop('checked', data.sch_last[i]);
+        $("input[name='relayLastSch']", line).attr("id", "relayLastSch" + i);
+        $("input[name='relayLastSch']", line).attr("name", "relayLastSch" + i);
+        $("input[name='relayLastSch" + i + "']", line).next().attr("for","relayLastSch" + (i));
 
         if ("group" in data) {
             $("input[name='mqttGroup']", line).val(data.group[i]);

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -1025,7 +1025,7 @@ function initRelayConfig(data) {
         $("select[name='relayBoot']", line).val(data.boot[i]);
         $("select[name='relayPulse']", line).val(data.pulse[i]);
         $("input[name='relayTime']", line).val(data.pulse_time[i]);
-        $("input[name='relayLastschedule']", line).prop('checked', data.restore_last_schedule[i]);
+        $("input[name='relayLastschedule']", line).prop('checked', data.relayLastschedule[i]);
         $("input[name='relayLastschedule']", line).attr("id", "relayLastschedule" + i);
         $("input[name='relayLastschedule']", line).attr("name", "relayLastschedule" + i);
         $("input[name='relayLastschedule" + i + "']", line).next().attr("for","relayLastschedule" + (i));

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -265,6 +265,11 @@ function addValue(data, name, value) {
         name = "adminPass";
     }
 
+    // join both relayLastschedule values
+    if (name.startsWith("relayLastschedule")) {
+        name = "relayLastschedule";
+    }
+
     if (name in data) {
         if (!Array.isArray(data[name])) {
             data[name] = [data[name]];

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -1709,6 +1709,11 @@ function processData(data) {
         var position = key.indexOf("Visible");
         if (position > 0 && position === key.length - 7) {
             var module = key.slice(0,-7);
+            if (module == "sch") {
+                $("li.module-" + module).css("display", "inherit");
+                $("div.module-" + module).css("display", "flex");
+                return;
+            }
             $(".module-" + module).css("display", "inherit");
             return;
         }

--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -250,7 +250,7 @@ function addValue(data, name, value) {
     var is_group = [
         "ssid", "pass", "gw", "mask", "ip", "dns",
         "schEnabled", "schSwitch","schAction","schType","schHour","schMinute","schWDs","schUTC",
-        "relayBoot", "relayPulse", "relayTime",
+        "relayBoot", "relayPulse", "relayTime", "relayLastschedule",
         "mqttGroup", "mqttGroupSync", "relayOnDisc",
         "dczRelayIdx", "dczMagnitude",
         "tspkRelay", "tspkMagnitude",
@@ -1025,6 +1025,10 @@ function initRelayConfig(data) {
         $("select[name='relayBoot']", line).val(data.boot[i]);
         $("select[name='relayPulse']", line).val(data.pulse[i]);
         $("input[name='relayTime']", line).val(data.pulse_time[i]);
+        $("input[name='relayLastschedule']", line).prop('checked', data.restore_last_schedule[i]);
+        $("input[name='relayLastschedule']", line).attr("id", "relayLastschedule" + i);
+        $("input[name='relayLastschedule']", line).attr("name", "relayLastschedule" + i);
+        $("input[name='relayLastschedule" + i + "']", line).next().attr("for","relayLastschedule" + (i));
 
         if ("group" in data) {
             $("input[name='mqttGroup']", line).val(data.group[i]);
@@ -1459,7 +1463,7 @@ function processData(data) {
 				});
 			}
 			return;
-		}
+        }
 
         <!-- endRemoveIf(!rfm69)-->
 

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1890,6 +1890,10 @@
                 <div class="pure-u-1 pure-u-lg-1-4"><label>Pulse time (s)</label></div>
                 <div class="pure-u-1 pure-u-lg-1-4"><input name="relayTime" class="pure-u-1" type="number" min="0" step="0.1" max="3600" /></div>
             </div>
+            <div class="p-g">
+                <div class="p-u-1 p-u-lg-1-4"><label>Restore last schedule</label></div>
+                <div><input name="relayLastschedule" type="checkbox" /></div>
+            </div>
             <div class="pure-g module module-mqtt">
                 <div class="pure-u-1 pure-u-lg-1-4"><label>MQTT group</label></div>
                 <div class="pure-u-1 pure-u-lg-3-4"><input name="mqttGroup" class="pure-u-1" tabindex="0" data="0" action="reconnect" /></div>

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1892,7 +1892,7 @@
             </div>
             <div class="p-g module module-sch">
                 <div class="p-u-1 p-u-lg-1-4"><label>Restore last schedule</label></div>
-                <div><input name="relayLastschedule" type="checkbox" /></div>
+                <div><input name="relayLastSch" type="checkbox" /></div>
             </div>
             <div class="pure-g module module-mqtt">
                 <div class="pure-u-1 pure-u-lg-1-4"><label>MQTT group</label></div>

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1890,7 +1890,7 @@
                 <div class="pure-u-1 pure-u-lg-1-4"><label>Pulse time (s)</label></div>
                 <div class="pure-u-1 pure-u-lg-1-4"><input name="relayTime" class="pure-u-1" type="number" min="0" step="0.1" max="3600" /></div>
             </div>
-            <div class="p-g">
+            <div class="p-g module module-sch">
                 <div class="p-u-1 p-u-lg-1-4"><label>Restore last schedule</label></div>
                 <div><input name="relayLastschedule" type="checkbox" /></div>
             </div>


### PR DESCRIPTION
I have added an option to restore the last schedule state on the device boot.

This option is useful in case of power loss or any kind of device reset that you still want your schedules to continue as usual.

At the moment if the device had a "down time" while a scheduled action should have happen, your action wont get applied, with this new feature the device will check for the closest schedule action that should have happened before boot, and restore its state to the desired schedule action state.

I have also added an option in the "SWITCHES" menu to choose on which relay you would like this feature to run on.

Disclaimer: it only counts "Turn ON" and "Turn OFF" actions and ignores toggle actions

![Capture](https://user-images.githubusercontent.com/52827101/66860183-5a8f0a00-ef95-11e9-8324-6d5f1d5eb180.PNG)

