### PR TITLE
HomeAssistant: add back platform="mqtt" to the yaml output

### DIFF
--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -214,6 +214,7 @@ void _haSwitchYaml(unsigned char index, JsonObject& root) {
     output.reserve(HA_YAML_BUFFER_SIZE);
 
     JsonObject& config = root.createNestedObject("config");
+    config["platform"] = "mqtt";
     _haSendSwitch(index, config);
 
     if (index == 0) output += "\n\n" + switchType + ":";
@@ -250,6 +251,7 @@ void _haSensorYaml(unsigned char index, JsonObject& root) {
     output.reserve(HA_YAML_BUFFER_SIZE);
 
     JsonObject& config = root.createNestedObject("config");
+    config["platform"] = "mqtt";
     _haSendMagnitude(index, config);
 
     if (index == 0) output += "\n\nsensor:";


### PR DESCRIPTION
got lost in 13c1a193280652358e678ab92e13b20266ee00be
discovery does not need it, but yaml config does
fix #1940 