### PR TITLE
Restore WebUI builds in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,7 @@ cache:
   - "~/.npm"
   - "~/.platformio"
 install:
-- pip install -U platformio
-- pio platform update -p
-- npm install -g npm@latest
-- cd code && npm ci && cd ..
+- ./travis_install.sh
 env:
   global:
   - BUILDER_TOTAL_THREADS=4
@@ -23,10 +20,11 @@ stages:
   if: tag IS present AND tag =~ ^\d+\.\d+\.\d+$
 jobs:
   include:
-  - stage: Test
-    env: BUILDER_ENV=travis-2_3_0
-  - env: BUILDER_ENV=travis-latest
-  - env: BUILDER_ENV=travis-git BUILDER_EXTRA="-a test/build/extra/secure_client.h"
+  - stage: Test WebUI
+  - stage: Test PlatformIO Build
+    env: TEST_ENV=travis-2_3_0
+  - env: TEST_ENV=travis-latest
+  - env: TEST_ENV=travis-git TEST_EXTRA_ARGS="-a test/build/extra/secure_client.h"
   - stage: Release
     env: BUILDER_THREAD=0
   - env: BUILDER_THREAD=1

--- a/code/build.sh
+++ b/code/build.sh
@@ -21,6 +21,8 @@ stat_bytes() {
 destination=../firmware
 version_file=espurna/config/version.h
 version=$(grep -E '^#define APP_VERSION' $version_file | awk '{print $3}' | sed 's/"//g')
+script_build_environments=false
+script_build_webui=false
 
 if ${TRAVIS:-false}; then
     git_revision=${TRAVIS_COMMIT::7}
@@ -133,8 +135,14 @@ build_environments() {
 }
 
 # Parameters
-while getopts "lpd:" opt; do
+while getopts "wblpd:" opt; do
   case $opt in
+    w)
+        script_build_webui=true
+        ;;
+    b)
+        script_build_environments=true
+        ;;
     l)
         print_available
         exit
@@ -158,13 +166,18 @@ echo "Building for version ${version}" ${git_revision:+($git_revision)}
 # Environments to build
 environments=$@
 
-if [ $# -eq 0 ]; then
-    set_default_environments
+if $script_build_webui ; then
+    build_webui
 fi
 
-if ${CI:-false}; then
-    print_environments
-fi
+if $script_build_environments ; then
+    if [ $# -eq 0 ]; then
+        set_default_environments
+    fi
 
-build_webui
-build_environments
+    if ${CI:-false}; then
+        print_environments
+    fi
+
+    build_environments
+fi

--- a/travis_install.sh
+++ b/travis_install.sh
@@ -2,15 +2,25 @@
 
 set -x -e -v
 
+npm_install() {
+    npm install -g npm@latest
+    npm ci
+}
+
+pio_install() {
+    pip install -U platformio
+    pio platform update -p
+}
+
 cd code
 
 if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test webui" ]; then
-    ./build.sh -w
+    npm_install
 elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test platformio build" ]; then
-    # shellcheck disable=SC2086
-    scripts/test_build.py -e "$TEST_ENV" $TEST_EXTRA_ARGS
+    pio_install
 elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Release" ]; then
-    ./build.sh -w -b -p
+    npm_install
+    pio_install
 else
     echo -e "\e[1;33mUnknown stage name, exiting!\e[0m"
     exit 1

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -5,12 +5,12 @@ set -x -e -v
 cd code
 
 if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test webui" ]; then
-    ./build.sh -w
+    ./build.sh -f environments
 elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test platformio build" ]; then
     # shellcheck disable=SC2086
     scripts/test_build.py -e "$TEST_ENV" $TEST_EXTRA_ARGS
 elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Release" ]; then
-    ./build.sh -w -b -p
+    ./build.sh -p
 else
     echo -e "\e[1;33mUnknown stage name, exiting!\e[0m"
     exit 1


### PR DESCRIPTION
#1943 removed build.sh from test stage
- move install phase into a script, similar to travis_script move
- add `-w` (build WebUI) and `-b` (build binaries) to build.sh to separatly allow build one without the other. update travis_script to use `-w` when running webui test stage and both when running release stage

merge after #1951