### PR TITLE
Fix HA sensor discovery with MQTT

### DIFF
--- a/code/espurna/homeassistant.ino
+++ b/code/espurna/homeassistant.ino
@@ -99,8 +99,10 @@ void _haSendMagnitude(unsigned char i, JsonObject& config) {
     config["unit_of_measurement"] = magnitudeUnits(type);
 }
 
-void _haSendMagnitudes(ha_config_t& config) {
+void _haSendMagnitudes() {
 
+    ha_config_t config;
+    
     for (unsigned char i=0; i<magnitudeCount(); i++) {
 
         String topic = getSetting("haPrefix", HOMEASSISTANT_PREFIX) +
@@ -178,7 +180,9 @@ void _haSendSwitch(unsigned char i, JsonObject& config) {
 
 }
 
-void _haSendSwitches(ha_config_t& config) {
+void _haSendSwitches() {
+
+    ha_config_t config;
 
     for (unsigned char i=0; i<relayCount(); i++) {
 
@@ -300,12 +304,11 @@ void _haSend() {
     DEBUG_MSG_P(PSTR("[HA] Sending autodiscovery MQTT message\n"));
 
     // Get common device config
-    ha_config_t config;
 
     // Send messages
-    _haSendSwitches(config);
+    _haSendSwitches();
     #if SENSOR_SUPPORT
-        _haSendMagnitudes(config);
+        _haSendMagnitudes();
     #endif
     
     _haSendFlag = false;


### PR DESCRIPTION
Before this patch, the config object (and its JSON) was reused across the `sendSwitch` and `sendMagnitude`. This led to a situation that advertising for the sensors includes some old keys (state_command, payload_on, ...) to be sent. Which leads to HA ignoring the sensor advertisement with 

```
Exception in async_discover_sensor when dispatching 'mqtt_discovery_new_sensor_mqtt': ({'name': 'switch_fridge_reactive', 'state_topic': 'switch-fridge/reactive', 'payload_on': '1', 'payload_off': '0', 'availability_topic': 'switch-fridge/status', 'payload_available': '1', 'payload_not_available': '0', 'unique_id': 'ESPURNA-XXXXX_reactive_3', 'device': {'identifiers': ['ESPURNA-XXXXX'], 'name': 'Switch that monitors the fridge', 'sw_version': 'ESPURNA 1.13.6-dev (2.3.0)', 'manufacturer': 'TECKIN', 'model': 'SP22_V14'}, 'unit_of_measurement': 'W', 'platform': 'mqtt'},)
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/homeassistant/components/mqtt/sensor.py", line 81, in async_discover_sensor
    config = PLATFORM_SCHEMA(discovery_payload)
  File "/usr/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/usr/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/usr/lib/python3.6/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: extra keys not allowed @ data['payload_on']
```


This patch is intended to clean that. Since no data has be shared between `sendSwitch` and `sendMagnitude` except the common info, each function now uses it own config object (at the price of 2 inits when advertising in mqtt).


Impact: RAM and CPU.

Rational of this patch: I could have removed the Json keys that we didn't need, but I found this kind of manipulation rather dirty and unwelcoming for new developers that will have to understand the logic.

