### PR TITLE
Fix SSL builds on cores < 2.4.2

### DIFF
--- a/code/espurna/libs/SecureClientHelpers.h
+++ b/code/espurna/libs/SecureClientHelpers.h
@@ -9,7 +9,12 @@
 #if SECURE_CLIENT == SECURE_CLIENT_BEARSSL
 #include <WiFiClientSecureBearSSL.h>
 #elif SECURE_CLIENT == SECURE_CLIENT_AXTLS
-#include <WiFiClientSecureAxTLS.h>
+    // No support for axTLS namespace in core < 2.4.2
+    #if defined(ARDUINO_ESP8266_RELEASE_2_3_0) || defined(ARDUINO_ESP8266_RELEASE_2_4_0) || defined(ARDUINO_ESP8266_RELEASE_2_4_1)
+        #include <WiFiClientSecure.h>
+    #else
+        #include <WiFiClientSecureAxTLS.h>
+    #endif
 #endif
 
 namespace SecureClientHelpers {
@@ -30,7 +35,12 @@ const char * _secureClientCheckAsString(int check) {
 }
 
 #if SECURE_CLIENT == SECURE_CLIENT_AXTLS
-using SecureClientClass = axTLS::WiFiClientSecure;
+    // No support for axTLS namespace in core < 2.4.2
+    #if defined(ARDUINO_ESP8266_RELEASE_2_3_0) || defined(ARDUINO_ESP8266_RELEASE_2_4_0) || defined(ARDUINO_ESP8266_RELEASE_2_4_1)
+        using SecureClientClass = WiFiClientSecure;
+    #else
+        using SecureClientClass = axTLS::WiFiClientSecure;
+    #endif
 
 struct SecureClientConfig {
     SecureClientConfig(const char* tag, host_callback_f host_cb, check_callback_f check_cb, fp_callback_f fp_cb, bool debug = false) :


### PR DESCRIPTION
On core 2.3.0/2.4.0/2.4.1 the WiFiClientSecureAxTLS.h header doesn't exist. The best would be to dynamically check for the header with ``__has_include("WiFiClientSecureAxTLS.h")``, but that doesn't have good compiler support. Hence the series of checks for old cores - on < 2.4.2 include the WiFiClientSecure.h header instead and do not use the ``axTLS`` namespace.