### PR TITLE
Bug fix: wrong representation of switch selection in schedules

### DIFF
--- a/code/html/custom.js
+++ b/code/html/custom.js
@@ -13,6 +13,7 @@ var numReboot = 0;
 var numReconnect = 0;
 var numReload = 0;
 var conf_saved = false;
+var relays_initialized = false;
 
 var useWhite = false;
 var useCCT = false;
@@ -1003,6 +1004,25 @@ function addSchedule(event) {
 
 }
 
+function initSchedules(key, value) {
+
+	while (relays_initialized == false) {
+		setTimeout(function() {initSchedules(key, value);}, 100);
+		return;
+	}
+	for (var i=0; i<value.size; ++i) {
+		var sch_line = addSchedule({ data: {schType: value.schType[i] }});
+
+		Object.keys(value).forEach(function(key) {
+			if ("size" == key) return;
+			var sch_value = value[key][i];
+			$("input[name='" + key + "']", sch_line).val(sch_value);
+			$("select[name='" + key + "']", sch_line).prop("value", sch_value);
+			$("input[type='checkbox'][name='" + key + "']", sch_line).prop("checked", sch_value);
+		});
+	}
+}
+
 // -----------------------------------------------------------------------------
 // Relays
 // -----------------------------------------------------------------------------
@@ -1686,17 +1706,7 @@ function processData(data) {
         }
 
         if ("schedules" === key) {
-            for (var i=0; i<value.size; ++i) {
-                var sch_line = addSchedule({ data: {schType: value.schType[i] }});
-
-                Object.keys(value).forEach(function(key) {
-                    if ("size" == key) return;
-                    var sch_value = value[key][i];
-                    $("input[name='" + key + "']", sch_line).val(sch_value);
-                    $("select[name='" + key + "']", sch_line).prop("value", sch_value);
-                    $("input[type='checkbox'][name='" + key + "']", sch_line).prop("checked", sch_value);
-                });
-            }
+            initSchedules(key, value);
             return;
         }
 
@@ -1707,6 +1717,7 @@ function processData(data) {
         if ("relayState" === key) {
             initRelays(value.status);
             updateRelays(value);
+            relays_initialized = true;
             return;
         }
 


### PR DESCRIPTION
Because of a synchronization problem (that started to happen during recent updates from some reason) the "schedules" key was sent before the "relayState" key in the processData function.
This caused the options in "schSwitch" selector not to be initialized before the value was set during the "schedules" key handling and therefor to show the wrong selection (always showing the first option available).

I was able to reproduce the bug in the last nightly build on my Sonoff CH4 PRO