### PR TITLE
Relay: update setup code, rework masking

### DIFF
--- a/code/espurna/alexa.ino
+++ b/code/espurna/alexa.ino
@@ -8,6 +8,7 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if ALEXA_SUPPORT
 
+#include "relay.h"
 #include "broker.h"
 
 #include <fauxmoESP.h>

--- a/code/espurna/button.ino
+++ b/code/espurna/button.ino
@@ -15,6 +15,7 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 #include <DebounceEvent.h>
 #include <vector>
 
+#include "relay.h"
 #include "light.h"
 
 typedef struct {

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -429,11 +429,6 @@
 #define RELAY_MQTT_TOGGLE           "2"
 #endif
 
-// TODO Only single EEPROM address is used to store state, which is 1 byte
-// Relay status is stored using bitfield.
-// This means that, atm, we are only storing the status of the first 8 relays.
-#define RELAY_SAVE_MASK_MAX         8
-
 // -----------------------------------------------------------------------------
 // WIFI
 // -----------------------------------------------------------------------------

--- a/code/espurna/config/prototypes.h
+++ b/code/espurna/config/prototypes.h
@@ -251,36 +251,6 @@ typedef struct {
 } packet_t;
 
 // -----------------------------------------------------------------------------
-// Relay
-// -----------------------------------------------------------------------------
-#include <bitset>
-
-enum class RelayStatus : unsigned char {
-    OFF = 0,
-    ON = 1,
-    TOGGLE = 2,
-    UNKNOWN = 0xFF
-};
-
-RelayStatus relayParsePayload(const char * payload);
-
-bool relayStatus(unsigned char id, bool status, bool report, bool group_report);
-bool relayStatus(unsigned char id, bool status);
-bool relayStatus(unsigned char id);
-
-void relayToggle(unsigned char id, bool report, bool group_report);
-void relayToggle(unsigned char id);
-
-unsigned char relayCount();
-
-const String& relayPayloadOn();
-const String& relayPayloadOff();
-const String& relayPayloadToggle();
-const char* relayPayload(RelayStatus status);
-
-void relaySetupDummy(unsigned char size, bool reconfigure = false);
-
-// -----------------------------------------------------------------------------
 // Settings
 // -----------------------------------------------------------------------------
 #include <Embedis.h>

--- a/code/espurna/domoticz.ino
+++ b/code/espurna/domoticz.ino
@@ -8,7 +8,9 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if DOMOTICZ_SUPPORT
 
+#include "relay.h"
 #include "broker.h"
+
 #include <ArduinoJson.h>
 
 bool _dcz_enabled = false;

--- a/code/espurna/espurna.ino
+++ b/code/espurna/espurna.ino
@@ -22,6 +22,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "config/all.h"
 #include <vector>
 
+#include "utils.h"
+#include "relay.h"
 #include "broker.h"
 #include "tuya.h"
 #include "libs/HeapStats.h"

--- a/code/espurna/ir.ino
+++ b/code/espurna/ir.ino
@@ -48,6 +48,8 @@ Raw messages:
 
 #if IR_SUPPORT
 
+#include "relay.h"
+
 #include <IRremoteESP8266.h>
 
 #if defined(IR_RX_PIN)

--- a/code/espurna/led.ino
+++ b/code/espurna/led.ino
@@ -12,6 +12,7 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if LED_SUPPORT
 
+#include "relay.h"
 #include "broker.h"
 
 typedef struct {

--- a/code/espurna/relay.h
+++ b/code/espurna/relay.h
@@ -1,0 +1,38 @@
+/*
+
+RELAY MODULE
+
+Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
+
+*/
+
+#pragma once
+
+constexpr size_t RELAYS_MAX = 32; 
+
+enum class RelayStatus : unsigned char {
+    OFF = 0,
+    ON = 1,
+    TOGGLE = 2,
+    UNKNOWN = 0xFF
+};
+
+RelayStatus relayParsePayload(const char * payload);
+
+bool relayStatus(unsigned char id, bool status, bool report, bool group_report);
+bool relayStatus(unsigned char id, bool status);
+bool relayStatus(unsigned char id);
+
+void relayToggle(unsigned char id, bool report, bool group_report);
+void relayToggle(unsigned char id);
+
+unsigned char relayCount();
+
+const String& relayPayloadOn();
+const String& relayPayloadOff();
+const String& relayPayloadToggle();
+
+const char* relayPayload(RelayStatus status);
+
+void relaySetupDummy(unsigned char size, bool reconfigure = false);
+

--- a/code/espurna/relay.h
+++ b/code/espurna/relay.h
@@ -8,6 +8,9 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #pragma once
 
+#include <bitset>
+#include "utils.h"
+
 constexpr size_t RELAYS_MAX = 32; 
 
 enum class RelayStatus : unsigned char {
@@ -15,6 +18,37 @@ enum class RelayStatus : unsigned char {
     ON = 1,
     TOGGLE = 2,
     UNKNOWN = 0xFF
+};
+
+struct RelayMask {
+
+    explicit RelayMask(const String& string) :
+        as_string(string),
+        as_u32(u32fromString(string))
+    {}
+
+    explicit RelayMask(String&& string) :
+        as_string(std::move(string)),
+        as_u32(u32fromString(as_string))
+    {}
+
+    explicit RelayMask(uint32_t value) :
+        as_string(std::move(u32toString(value, 2))),
+        as_u32(value)
+    {}
+
+    explicit RelayMask(std::bitset<RELAYS_MAX> bitset) :
+        RelayMask(bitset.to_ulong())
+    {}
+
+    RelayMask(String&& string, uint32_t value) :
+        as_string(std::move(string)),
+        as_u32(value)
+    {}
+
+    const String as_string;
+    uint32_t as_u32;
+
 };
 
 RelayStatus relayParsePayload(const char * payload);

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -44,9 +44,9 @@ typedef struct {
     Ticker pulseTicker;         // Holds the pulse back timer
 
 } relay_t;
+
 std::vector<relay_t> _relays;
 bool _relayRecursive = false;
-Ticker _relaySaveTicker;
 uint8_t _relayDummy = DUMMY_RELAY_COUNT;
 
 unsigned long _relay_flood_window = (1000 * RELAY_FLOOD_WINDOW);
@@ -248,7 +248,7 @@ void _relayProviderStatus(unsigned char id, bool status) {
 
             lightUpdate(true, true);
             return;
-        
+
         }
 
     #endif
@@ -1330,11 +1330,11 @@ void _relayLoop() {
 // 8 channels. This behaviour will be recovered with v2.
 void relaySetupDummy(unsigned char size, bool reconfigure) {
 
-    size = constrain(size, 0, RELAY_SAVE_MASK_MAX);
+    size = constrain(size + _relays.size(), _relays.size(), RELAY_SAVE_MASK_MAX);
     if (size == _relays.size()) return;
     _relayDummy = size;
 
-    _relays.assign(size, {
+    _relays.insert(_relays.end(), size, {
         GPIO_NONE, RELAY_TYPE_NORMAL, GPIO_NONE
     });
 

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -11,7 +11,9 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 #include <ArduinoJson.h>
 #include <vector>
 #include <functional>
+#include <bitset>
 
+#include "relay.h"
 #include "broker.h"
 #include "tuya.h"
 
@@ -390,6 +392,18 @@ uint32_t _relayMaskRtcmem() {
     return Rtcmem->relay;
 }
 
+void _relayMaskSettings(const String& string) {
+    setSetting("relayBootMask", string);
+}
+
+void _relayMaskSettings(uint32_t mask) {
+    _relayMaskSettings(bitsetToString(mask));
+}
+
+uint32_t _relayMaskSettings() {
+    return bitsetFromString(getSetting("relayBootMask"));
+}
+
 void relayPulse(unsigned char id) {
 
     _relays[id].pulseTicker.detach();
@@ -563,18 +577,16 @@ void relaySync(unsigned char id) {
 
 void relaySave(bool eeprom) {
 
-    auto mask = std::bitset<RELAY_SAVE_MASK_MAX>(0);
+    auto mask = std::bitset<RELAYS_MAX>(0);
 
-    unsigned char count = relayCount();
-    if (count > RELAY_SAVE_MASK_MAX) count = RELAY_SAVE_MASK_MAX;
-
-    for (unsigned int i=0; i < count; ++i) {
-        mask.set(i, relayStatus(i));
+    const unsigned char count = constrain(relayCount(), 0, RELAYS_MAX);
+    for (unsigned int id = 0; id < count; ++id) {
+        mask.set(id, relayStatus(id));
     }
 
     const uint32_t mask_value = mask.to_ulong();
-
-    DEBUG_MSG_P(PSTR("[RELAY] Setting relay mask: %u\n"), mask_value);
+    const String mask_string = bitsetToString(mask_value);
+    DEBUG_MSG_P(PSTR("[RELAY] Setting relay mask: %s\n"), mask_string.c_str());
 
     // Persist only to rtcmem, unless requested to save to the eeprom
     _relayMaskRtcmem(mask_value);
@@ -586,7 +598,7 @@ void relaySave(bool eeprom) {
     // Nevertheless, we store the value in the EEPROM buffer so it will be written
     // on the next commit.
     if (eeprom) {
-        EEPROMr.write(EEPROM_RELAY_STATUS, mask_value);
+        _relayMaskSettings(mask_string);
         // We are actually enqueuing the commit so it will be
         // executed on the main loop, in case this is called from a system context callback
         eepromCommit();
@@ -651,6 +663,17 @@ RelayStatus relayParsePayload(const char * payload) {
 // BACKWARDS COMPATIBILITY
 void _relayBackwards() {
 
+    #if defined(EEPROM_RELAY_STATUS)
+    {
+        uint8_t mask = EEPROMr.read(EEPROM_RELAY_STATUS);
+        if (mask != 0xff) {
+            _relayMaskSettings(static_cast<uint32_t>(mask));
+            EEPROMr.write(EEPROM_RELAY_STATUS, 0xff);
+            eepromCommit();
+        }
+    }
+    #endif
+
     for (unsigned int i=0; i<_relays.size(); i++) {
         if (!hasSetting("mqttGroupInv", i)) continue;
         setSetting("mqttGroupSync", i, getSetting("mqttGroupInv", i));
@@ -668,12 +691,13 @@ void _relayBoot() {
     if (rtcmemStatus()) {
         stored_mask = _relayMaskRtcmem();
     } else {
-        stored_mask = EEPROMr.read(EEPROM_RELAY_STATUS);
+        stored_mask = _relayMaskSettings();
     }
 
-    DEBUG_MSG_P(PSTR("[RELAY] Retrieving mask: %u\n"), stored_mask);
+    const String string_mask(bitsetToString(stored_mask));
+    DEBUG_MSG_P(PSTR("[RELAY] Retrieving mask: %s\n"), string_mask.c_str());
 
-    auto mask = std::bitset<RELAY_SAVE_MASK_MAX>(stored_mask);
+    auto mask = std::bitset<RELAYS_MAX>(stored_mask);
 
     // Walk the relays
     unsigned char lock;
@@ -687,16 +711,12 @@ void _relayBoot() {
         lock = RELAY_LOCK_DISABLED;
         switch (boot_mode) {
             case RELAY_BOOT_SAME:
-                if (i < 8) {
-                    status = mask.test(i);
-                }
+                status = mask.test(i);
                 break;
             case RELAY_BOOT_TOGGLE:
-                if (i < 8) {
-                    status = !mask[i];
-                    mask.flip(i);
-                    trigger_save = true;
-                }
+                status = !mask[i];
+                mask.flip(i);
+                trigger_save = true;
                 break;
             case RELAY_BOOT_LOCKED_ON:
                 status = true;
@@ -727,12 +747,12 @@ void _relayBoot() {
 
      }
 
+    const auto mask_value = mask.to_ulong();
+    _relayMaskRtcmem(mask_value);
+
     // Save if there is any relay in the RELAY_BOOT_TOGGLE mode
     if (trigger_save) {
-        _relayMaskRtcmem(mask.to_ulong());
-
-        EEPROMr.write(EEPROM_RELAY_STATUS, mask.to_ulong());
-        eepromCommit();
+        _relayMaskSettings(mask_value);
     }
 
     _relayRecursive = false;
@@ -1325,12 +1345,10 @@ void _relayLoop() {
     #endif
 }
 
-// Dummy relays for AI Light, Magic Home LED Controller, H801, Sonoff Dual and Sonoff RF Bridge
-// No delay_on or off for these devices to easily allow having more than
-// 8 channels. This behaviour will be recovered with v2.
+// Dummy relays for virtual light switches, Sonoff Dual, Sonoff RF Bridge and Tuya
 void relaySetupDummy(unsigned char size, bool reconfigure) {
 
-    size = constrain(size + _relays.size(), _relays.size(), RELAY_SAVE_MASK_MAX);
+    size = constrain(size + _relays.size(), _relays.size(), RELAYS_MAX);
     if (size == _relays.size()) return;
     _relayDummy = size;
 

--- a/code/espurna/relay_config.h
+++ b/code/espurna/relay_config.h
@@ -1,0 +1,73 @@
+/*
+
+RELAY MODULE
+
+*/
+
+#pragma once
+
+constexpr const unsigned long _relayDelayOn(unsigned char index) {
+    return (
+        (index == 0) ? RELAY1_DELAY_ON :
+        (index == 1) ? RELAY2_DELAY_ON :
+        (index == 2) ? RELAY3_DELAY_ON :
+        (index == 3) ? RELAY4_DELAY_ON :
+        (index == 4) ? RELAY5_DELAY_ON :
+        (index == 5) ? RELAY6_DELAY_ON :
+        (index == 6) ? RELAY7_DELAY_ON :
+        (index == 7) ? RELAY8_DELAY_ON : 0
+    );
+}
+
+constexpr const unsigned long _relayDelayOff(unsigned char index) {
+    return (
+        (index == 0) ? RELAY1_DELAY_OFF :
+        (index == 1) ? RELAY2_DELAY_OFF :
+        (index == 2) ? RELAY3_DELAY_OFF :
+        (index == 3) ? RELAY4_DELAY_OFF :
+        (index == 4) ? RELAY5_DELAY_OFF :
+        (index == 5) ? RELAY6_DELAY_OFF :
+        (index == 6) ? RELAY7_DELAY_OFF :
+        (index == 7) ? RELAY8_DELAY_OFF : 0
+    );
+}
+
+constexpr const unsigned char _relayPin(unsigned char index) {
+    return (
+        (index == 0) ? RELAY1_PIN :
+        (index == 1) ? RELAY2_PIN :
+        (index == 2) ? RELAY3_PIN :
+        (index == 3) ? RELAY4_PIN :
+        (index == 4) ? RELAY5_PIN :
+        (index == 5) ? RELAY6_PIN :
+        (index == 6) ? RELAY7_PIN :
+        (index == 7) ? RELAY8_PIN : GPIO_NONE
+    );
+}
+
+constexpr const unsigned char _relayType(unsigned char index) {
+    return (
+        (index == 0) ? RELAY1_TYPE :
+        (index == 1) ? RELAY2_TYPE :
+        (index == 2) ? RELAY3_TYPE :
+        (index == 3) ? RELAY4_TYPE :
+        (index == 4) ? RELAY5_TYPE :
+        (index == 5) ? RELAY6_TYPE :
+        (index == 6) ? RELAY7_TYPE :
+        (index == 7) ? RELAY8_TYPE : RELAY_TYPE_NORMAL
+    );
+}
+
+constexpr const unsigned char _relayResetPin(unsigned char index) {
+    return (
+        (index == 0) ? RELAY1_RESET_PIN :
+        (index == 1) ? RELAY2_RESET_PIN :
+        (index == 2) ? RELAY3_RESET_PIN :
+        (index == 3) ? RELAY4_RESET_PIN :
+        (index == 4) ? RELAY5_RESET_PIN :
+        (index == 5) ? RELAY6_RESET_PIN :
+        (index == 6) ? RELAY7_RESET_PIN :
+        (index == 7) ? RELAY8_RESET_PIN : GPIO_NONE
+    );
+}
+

--- a/code/espurna/rfbridge.ino
+++ b/code/espurna/rfbridge.ino
@@ -8,6 +8,8 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if RF_SUPPORT
 
+#include "relay.h"
+
 #include <queue>
 #include <Ticker.h>
 

--- a/code/espurna/rpnrules.ino
+++ b/code/espurna/rpnrules.ino
@@ -8,7 +8,9 @@ Copyright (C) 2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if RPN_RULES_SUPPORT
 
-#include "rpnlib.h"
+#include "relay.h"
+
+#include <rpnlib.h>
 
 // -----------------------------------------------------------------------------
 // Custom commands

--- a/code/espurna/scheduler.ino
+++ b/code/espurna/scheduler.ino
@@ -9,6 +9,8 @@ Adapted by Xose Pérez <xose dot perez at gmail dot com>
 
 #if SCHEDULER_SUPPORT
 
+#include "relay.h"
+
 #include <TimeLib.h>
 
 int _sch_restore = 0;

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -8,6 +8,7 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if SENSOR_SUPPORT
 
+#include "relay.h"
 #include "broker.h"
 
 #include <vector>

--- a/code/espurna/terminal.ino
+++ b/code/espurna/terminal.ino
@@ -8,11 +8,13 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if TERMINAL_SUPPORT
 
-#include <vector>
+#include "utils.h"
 #include "libs/EmbedisWrap.h"
-#include <Stream.h>
 #include "libs/StreamInjector.h"
 #include "libs/HeapStats.h"
+
+#include <vector>
+#include <Stream.h>
 
 StreamInjector _serial = StreamInjector(TERMINAL_BUFFER_SIZE);
 EmbedisWrap embedis(_serial, TERMINAL_BUFFER_SIZE);

--- a/code/espurna/thermostat.ino
+++ b/code/espurna/thermostat.ino
@@ -8,6 +8,8 @@ Copyright (C) 2017 by Dmitry Blinov <dblinov76 at gmail dot com>
 
 #if THERMOSTAT_SUPPORT
 
+#include "relay.h"
+
 #include <ArduinoJson.h>
 #include <float.h>
 

--- a/code/espurna/tuya.ino
+++ b/code/espurna/tuya.ino
@@ -10,6 +10,9 @@ Copyright (C) 2019 by Maxim Prokhorov <prokhorov dot max at outlook dot com>
 
 #if TUYA_SUPPORT
 
+#include "relay.h"
+#include "light.h"
+
 #include <functional>
 #include <queue>
 #include <StreamString.h>

--- a/code/espurna/utils.h
+++ b/code/espurna/utils.h
@@ -52,5 +52,6 @@ void nice_delay(unsigned long ms);
 
 double roundTo(double num, unsigned char positions);
 
-uint32_t bitsetFromString(const String& string);
-String bitsetToString(uint32_t bitset);
+uint32_t u32fromString(const String& string, int base);
+uint32_t u32fromString(const String& string);
+String u32toString(uint32_t bitset, int base);

--- a/code/espurna/utils.h
+++ b/code/espurna/utils.h
@@ -1,0 +1,56 @@
+/*
+
+UTILS MODULE
+
+Copyright (C) 2017-2019 by Xose Pérez <xose dot perez at gmail dot com>
+
+*/
+
+#pragma once
+
+extern "C" uint32_t _SPIFFS_start;
+extern "C" uint32_t _SPIFFS_end;
+
+String getIdentifier();
+void setDefaultHostname();
+
+void setBoardName();
+String getBoardName();
+String getAdminPass();
+
+const String& getCoreVersion();
+const String& getCoreRevision();
+
+unsigned char getHeartbeatMode();
+unsigned char getHeartbeatInterval();
+void heartbeat();
+
+String getEspurnaModules();
+String getEspurnaOTAModules();
+String getEspurnaSensors();
+
+String getEspurnaWebUI();
+
+String buildTime();
+unsigned long getUptime();
+bool haveRelaysOrSensors();
+
+void infoMemory(const char * name, unsigned int total_memory, unsigned int free_memory);
+void info();
+
+bool sslCheckFingerPrint(const char * fingerprint);
+bool sslFingerPrintArray(const char * fingerprint, unsigned char * bytearray);
+bool sslFingerPrintChar(const char * fingerprint, char * destination);
+
+bool eraseSDKConfig();
+
+char * ltrim(char * s);
+char * strnstr(const char * buffer, const char * token, size_t n);
+bool isNumber(const char * s);
+
+void nice_delay(unsigned long ms);
+
+double roundTo(double num, unsigned char positions);
+
+uint32_t bitsetFromString(const String& string);
+String bitsetToString(uint32_t bitset);

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -247,7 +247,7 @@ void heartbeat() {
     #if MQTT_SUPPORT
         if (!serial && (_heartbeat_mode == HEARTBEAT_REPEAT || systemGetHeartbeat())) {
             if (hb_cfg & Heartbeat::Interval)
-                mqttSend(MQTT_TOPIC_INTERVAL, String(getHeartbeatInterval() / 1000).c_str());
+                mqttSend(MQTT_TOPIC_INTERVAL, String(getHeartbeatInterval()).c_str());
 
             if (hb_cfg & Heartbeat::App)
                 mqttSend(MQTT_TOPIC_APP, APP_NAME);

--- a/code/espurna/utils.ino
+++ b/code/espurna/utils.ino
@@ -704,13 +704,10 @@ uint32_t u32fromString(const String& string) {
             base = 8;
         } else if (string.startsWith("0x")) {
             base = 16;
-        } else {
-            return 0;
         }
-        return u32fromString(string.substring(2), base);
     }
 
-    return u32fromString(string, base);
+    return u32fromString((base == 10) ? string : string.substring(2), base);
 }
 
 String u32toString(uint32_t value, int base) {

--- a/code/espurna/web.ino
+++ b/code/espurna/web.ino
@@ -8,6 +8,8 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if WEB_SUPPORT
 
+#include "utils.h"
+
 #include <ESPAsyncTCP.h>
 #include <ESPAsyncWebServer.h>
 #include <Hash.h>


### PR DESCRIPTION
- add u32{to,from}String that use strtoul instead of itoa, add 0b 0o 0x prefix checks
- update boot mask to use kv storage instead of raw eeprom byte, add migration code
- update boot mask only after relay status really changes
- move relay prototypes.h entry into the relay.h, update .ino files to reference it  
- move relay header defaults (RELAY1_PIN etc.) to the relay_config.h
- refactor c struct into a simple c++ struct, add default and minimal pin+type+reset_pin based on id constructors, thus removing the need to push_back into the array.
- fix DUMMY_RELAY_COUNT=0, use default constructor via `_relays.resize(DUMMY_RELAY_COUNT + _relays.size)`