### PR TITLE
Upgrade to core 2.6.2, fixes WiFi issues

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -26,13 +26,14 @@ arduino_core_2_5_0 = espressif8266@2.0.4
 arduino_core_2_5_1 = espressif8266@2.1.1
 arduino_core_2_5_2 = espressif8266@2.2.3
 arduino_core_2_6_1 = espressif8266@2.3.0
+arduino_core_2_6_2 = espressif8266@2.3.1
 
 # Development platforms
 arduino_core_develop = https://github.com/platformio/platform-espressif8266#develop
 arduino_core_git = https://github.com/platformio/platform-espressif8266#feature/stage
 
 platform = ${common.arduino_core_2_3_0}
-platform_latest = ${common.arduino_core_2_6_1}
+platform_latest = ${common.arduino_core_2_6_2}
 
 # ------------------------------------------------------------------------------
 # FLAGS: DEBUG


### PR DESCRIPTION
This is a follow-up of yesterday's PR: https://github.com/xoseperez/espurna/pull/2018

This should fix the WiFi connectivity issues.