### PR TITLE
Fixed small aesthetic problem

### DIFF
--- a/code/html/index.html
+++ b/code/html/index.html
@@ -422,7 +422,7 @@
                             <fieldset>
 
                                 <div class="pure-g module module-led">
-                                    <div class="pure-u-0 pure-u-lg-1-4">Modes</div>
+                                    <div class="pure-u-1 pure-u-lg-1-4">Modes</div>
                                     <div class="pure-u-1 pure-u-lg-3-4 hint">
                                         <li><strong>WiFi status</strong> will blink at 1Hz when trying to connect. If successfully connected it will briefly blink every 5 seconds if in STA mode or every second if in AP mode.</li>
                                         <li><strong>Follow switch</strong> will force the LED to follow the status of a given switch (you must define which switch to follow in the side field).</li>

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -421,8 +421,8 @@
 
                             <fieldset>
 
+                                <legend class="module module-led">Modes</legend>
                                 <div class="pure-g module module-led">
-                                    <div class="pure-u-1 pure-u-lg-1-4">Modes</div>
                                     <div class="pure-u-1 pure-u-lg-3-4 hint">
                                         <li><strong>WiFi status</strong> will blink at 1Hz when trying to connect. If successfully connected it will briefly blink every 5 seconds if in STA mode or every second if in AP mode.</li>
                                         <li><strong>Follow switch</strong> will force the LED to follow the status of a given switch (you must define which switch to follow in the side field).</li>


### PR DESCRIPTION
The letter-spacing in the "Modes" label (LED tab) gets broken when on small display (see the photo below)

![2019-12-02_211253](https://user-images.githubusercontent.com/52827101/69988936-486c2980-154b-11ea-8a5e-bb10f04e3de9.png)

Fixed it by changing from pure-u-0 to pure-u-1