### PR TITLE
Add Magic Home ZJ_LB_RGBWW_L support

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1433,6 +1433,28 @@
     #define LIGHT_CH4_INVERSE   0
     #define LIGHT_CH5_INVERSE   0
 
+#elif defined(MAGICHOME_ZJ_LB_RGBWW_L)
+
+    // Info
+    #define MANUFACTURER        "MAGICHOME"
+    #define DEVICE              "ZJ_LB_RGBWW_L"
+    #define RELAY_PROVIDER      RELAY_PROVIDER_LIGHT
+    #define LIGHT_PROVIDER      LIGHT_PROVIDER_DIMMER
+    #define DUMMY_RELAY_COUNT   1
+
+    // Light
+    #define LIGHT_CHANNELS      5
+    #define LIGHT_CH1_PIN       5       // RED
+    #define LIGHT_CH2_PIN       4       // GREEN
+    #define LIGHT_CH3_PIN       14      // BLUE
+    #define LIGHT_CH4_PIN       12      // COLD WHITE
+    #define LIGHT_CH5_PIN       13      // WARM WHITE
+    #define LIGHT_CH1_INVERSE   0
+    #define LIGHT_CH2_INVERSE   0
+    #define LIGHT_CH3_INVERSE   0
+    #define LIGHT_CH4_INVERSE   0
+    #define LIGHT_CH5_INVERSE   0
+
 // -----------------------------------------------------------------------------
 // HUACANXING H801 & H802
 // -----------------------------------------------------------------------------

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -758,6 +758,16 @@ build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_ESPM_5CH_B_13
 upload_port = ${common.ota_upload_port}
 upload_flags = ${common.ota_upload_flags}
 
+[env:magichome-zj-lb-rgbww-l]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_LB_RGBWW_L
+
+[env:magichome-zj-lb-rgbww-l-ota]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_LB_RGBWW_L
+upload_port = ${common.ota_upload_port}
+upload_flags = ${common.ota_upload_flags}
+
 [env:magichome-zj-wfmn-c-11]
 board = ${common.board_1m}
 build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_WFMN_C_11


### PR DESCRIPTION
Adds support for [this bulb](https://www.amazon.com/gp/product/B07GGWNQT7/ref=ppx_yo_dt_b_asin_title_o00_s01) sold under the brand "Berennis", but is actually a Magic Home product.

### Photos

![IMG_0542](https://user-images.githubusercontent.com/5005153/71838671-0325a500-307f-11ea-9abc-a8640330c10a.jpeg)
![IMG_0543](https://user-images.githubusercontent.com/5005153/71838707-19cbfc00-307f-11ea-9501-8dfdb9fbe014.jpeg)
![IMG_0544](https://user-images.githubusercontent.com/5005153/71838670-028d0e80-307f-11ea-9c48-0d7e073b68ab.jpeg)
