### PR TITLE
Deltaco smart home

### DIFF
--- a/code/espurna/config/arduino.h
+++ b/code/espurna/config/arduino.h
@@ -117,6 +117,7 @@
 //#define MUVIT_IO_MIOBULB001
 //#define NEO_COOLCAM_NAS_WR01W
 //#define DELTACO_SH_P01
+//#define DELTACO_SH_LEXXW
 //#define NEXETE_A19
 //#define NODEMCU_BASIC
 //#define NODEMCU_LOLIN

--- a/code/espurna/config/arduino.h
+++ b/code/espurna/config/arduino.h
@@ -116,6 +116,7 @@
 //#define MAXCIO_WUS002S
 //#define MUVIT_IO_MIOBULB001
 //#define NEO_COOLCAM_NAS_WR01W
+//#define DELTACO_SH_P01
 //#define NEXETE_A19
 //#define NODEMCU_BASIC
 //#define NODEMCU_LOLIN

--- a/code/espurna/config/arduino.h
+++ b/code/espurna/config/arduino.h
@@ -26,6 +26,10 @@
 //#define BLITZWOLF_BWSHPX
 //#define BLITZWOLF_BWSHPX_V23
 //#define BLITZWOLF_BWSHP5
+//#define DELTACO_SH_LEXXW
+//#define DELTACO_SH_LEXXRGB
+//#define DELTACO_SH_P01
+//#define DELTACO_SH_P03USB
 //#define DIGOO_NX_SP202
 //#define EHOMEDIY_WT02
 //#define EHOMEDIY_WT03
@@ -116,8 +120,6 @@
 //#define MAXCIO_WUS002S
 //#define MUVIT_IO_MIOBULB001
 //#define NEO_COOLCAM_NAS_WR01W
-//#define DELTACO_SH_P01
-//#define DELTACO_SH_LEXXW
 //#define NEXETE_A19
 //#define NODEMCU_BASIC
 //#define NODEMCU_LOLIN

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -2835,6 +2835,39 @@
 
 
 // ------------------------------------------------------------------------------
+// DELTACO_SH_P03USB Wifi Smart Power Plug 
+// -----------------------------------------------------------------------------
+
+#elif defined(DELTACO_SH_P03USB)
+
+    // Info
+    #define MANUFACTURER        "DELTACO"
+    #define DEVICE              "SH_P03USB"
+
+    // Buttons
+    #define BUTTON1_PIN         13
+    #define BUTTON1_MODE        BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
+    #define BUTTON1_RELAY       2
+
+    // Relays
+    #define RELAY1_PIN          15  // USB power
+    #define RELAY2_PIN          12  // power plug 1
+    #define RELAY3_PIN          14  // power plug 2
+    #define RELAY4_PIN          5   // power plug 3
+
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY2_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY3_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY4_TYPE         RELAY_TYPE_NORMAL
+
+    // LEDs
+    #define LED1_PIN            0   // power led
+    #define LED1_PIN_INVERSE    1
+    #define LED1_MODE           LED_MODE_FINDME
+
+
+
+// ------------------------------------------------------------------------------
 // Fornorm Wi-Fi USB Extension Socket (ZLD-34EU)
 // https://www.aliexpress.com/item/Fornorm-WiFi-Extension-Socket-with-Surge-Protector-Smart-Power-Strip-3-Outlets-and-4-USB-Charging/32849743948.html
 // Also: Estink Wifi Power Strip
@@ -3606,8 +3639,7 @@
     #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
-// Generic E14
-// https://www.ebay.com/itm/LED-Bulb-Wifi-E14-4-5W-Candle-RGB-W-4in1-Dimmable-V-tac-Smart-VT-5114/163899840601
+// Deltaco white e14 (SH-LE14W) and e27 (SH-LE27W)
 // -----------------------------------------------------------------------------
 
 #elif defined(DELTACO_SH_LEXXW)
@@ -3621,10 +3653,36 @@
 
     // Light
     #define LIGHT_CHANNELS      2
-    #define LIGHT_CH1_PIN       12       // RED
-    #define LIGHT_CH2_PIN       14       // WHITE
+    #define LIGHT_CH1_PIN       12      // WARM WHITE
+    #define LIGHT_CH2_PIN       14      // COLD WHITE
     #define LIGHT_CH1_INVERSE   0
+    #define LIGHT_CH2_INVERSE   0
+
+// -----------------------------------------------------------------------------
+// Deltaco rgbw e27 (SH-LE27RGB)
+// -----------------------------------------------------------------------------
+
+#elif defined(DELTACO_SH_LEXXRGB)
+
+    // Info
+    #define MANUFACTURER        "DELTACO"
+    #define DEVICE              "SH_LEXXRGB"
+    #define RELAY_PROVIDER      RELAY_PROVIDER_LIGHT
+    #define LIGHT_PROVIDER      LIGHT_PROVIDER_DIMMER
+    #define DUMMY_RELAY_COUNT   1
+
+    // Light
+    #define LIGHT_CHANNELS      5
+    #define LIGHT_CH1_PIN       5        // RED
+    #define LIGHT_CH2_PIN       4        // GREEN
+    #define LIGHT_CH3_PIN       13       // BLUE
+    #define LIGHT_CH4_PIN       14       // WARM WHITE
+    #define LIGHT_CH5_PIN       12       // COLD WHITE
+    #define LIGHT_CH1_INVERSE   0
+    #define LIGHT_CH2_INVERSE   0
+    #define LIGHT_CH3_INVERSE   0
     #define LIGHT_CH4_INVERSE   0
+    #define LIGHT_CH5_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Nexete A19

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -2809,6 +2809,31 @@
     #define LED1_PIN_INVERSE    1
 
 
+// -----------------------------------------------------------------------------
+// Deltaco SH_P01 Wifi Smart Power Plug
+// -----------------------------------------------------------------------------
+
+#elif defined(DELTACO_SH_P01)
+
+    // Info
+    #define MANUFACTURER        "DELTACO"
+    #define DEVICE              "SH_P01"
+
+    // Buttons
+    #define BUTTON1_PIN         13
+    #define BUTTON1_MODE        BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_RELAY       1
+
+    // Relays
+    #define RELAY1_PIN          12
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+
+    // LEDs
+    #define LED1_PIN            5
+    #define LED1_PIN_INVERSE    1
+    #define LED1_MODE           LED_MODE_FINDME
+
+
 // ------------------------------------------------------------------------------
 // Fornorm Wi-Fi USB Extension Socket (ZLD-34EU)
 // https://www.aliexpress.com/item/Fornorm-WiFi-Extension-Socket-with-Surge-Protector-Smart-Power-Strip-3-Outlets-and-4-USB-Charging/32849743948.html
@@ -3570,15 +3595,15 @@
     #define DUMMY_RELAY_COUNT   1
 
     // Light
-    #define LIGHT_CHANNELS      4
+    #define LIGHT_CHANNELS      3
     #define LIGHT_CH1_PIN       4       // RED
     #define LIGHT_CH2_PIN       12      // GREEN
     #define LIGHT_CH3_PIN       14      // BLUE
-    #define LIGHT_CH4_PIN       5       // WHITE
+    // #define LIGHT_CH4_PIN       5       // WHITE
     #define LIGHT_CH1_INVERSE   0
     #define LIGHT_CH2_INVERSE   0
     #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
+    // #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Nexete A19

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -3595,15 +3595,36 @@
     #define DUMMY_RELAY_COUNT   1
 
     // Light
-    #define LIGHT_CHANNELS      3
+    #define LIGHT_CHANNELS      4
     #define LIGHT_CH1_PIN       4       // RED
     #define LIGHT_CH2_PIN       12      // GREEN
     #define LIGHT_CH3_PIN       14      // BLUE
-    // #define LIGHT_CH4_PIN       5       // WHITE
+    #define LIGHT_CH4_PIN       5       // WHITE
     #define LIGHT_CH1_INVERSE   0
     #define LIGHT_CH2_INVERSE   0
     #define LIGHT_CH3_INVERSE   0
-    // #define LIGHT_CH4_INVERSE   0
+    #define LIGHT_CH4_INVERSE   0
+
+// -----------------------------------------------------------------------------
+// Generic E14
+// https://www.ebay.com/itm/LED-Bulb-Wifi-E14-4-5W-Candle-RGB-W-4in1-Dimmable-V-tac-Smart-VT-5114/163899840601
+// -----------------------------------------------------------------------------
+
+#elif defined(DELTACO_SH_LEXXW)
+
+    // Info
+    #define MANUFACTURER        "DELTACO"
+    #define DEVICE              "SH_LEXXW"
+    #define RELAY_PROVIDER      RELAY_PROVIDER_LIGHT
+    #define LIGHT_PROVIDER      LIGHT_PROVIDER_DIMMER
+    #define DUMMY_RELAY_COUNT   1
+
+    // Light
+    #define LIGHT_CHANNELS      2
+    #define LIGHT_CH1_PIN       12       // RED
+    #define LIGHT_CH2_PIN       14       // WHITE
+    #define LIGHT_CH1_INVERSE   0
+    #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Nexete A19

--- a/code/espurna/migrate.ino
+++ b/code/espurna/migrate.ino
@@ -1425,15 +1425,49 @@ void migrate() {
             setSetting("relayGPIO", 0, 12);
             setSetting("relayType", 0, RELAY_TYPE_NORMAL);
 
-        #elif defined(DELTACO_SH_LEXXW)
+        #elif defined(DELTACO_SH_P03USB)
 
             setSetting("board", 106);
+            setSetting("btnGPIO", 0, 13);
+            setSetting("btnRelay", 0, 2);
+            setSetting("ledGPIO", 0, 0);
+            setSetting("ledLogic", 0, 1);
+            setSetting("ledMode", 0, LED_MODE_FINDME);
+            setSetting("relayGPIO", 0, 15);
+            setSetting("relayGPIO", 1, 12);
+            setSetting("relayGPIO", 2, 14);
+            setSetting("relayGPIO", 3, 5);
+            setSetting("relayType", 0, RELAY_TYPE_NORMAL);
+            setSetting("relayType", 1, RELAY_TYPE_NORMAL);
+            setSetting("relayType", 2, RELAY_TYPE_NORMAL);
+            setSetting("relayType", 3, RELAY_TYPE_NORMAL);
+
+        #elif defined(DELTACO_SH_LEXXW)
+
+            setSetting("board", 107);
             setSetting("relayProvider", RELAY_PROVIDER_LIGHT);
             setSetting("lightProvider", LIGHT_PROVIDER_DIMMER);
             setSetting("chGPIO", 0, 12);
             setSetting("chGPIO", 1, 14);
             setSetting("chLogic", 0, 0);
             setSetting("chLogic", 1, 0);
+            setSetting("relays", 1);
+
+        #elif defined(DELTACO_SH_LEXXRGB)
+
+            setSetting("board", 108);
+            setSetting("relayProvider", RELAY_PROVIDER_LIGHT);
+            setSetting("lightProvider", LIGHT_PROVIDER_DIMMER);
+            setSetting("chGPIO", 0, 5);
+            setSetting("chGPIO", 1, 4);
+            setSetting("chGPIO", 2, 13);
+            setSetting("chGPIO", 3, 14);
+            setSetting("chGPIO", 4, 12);
+            setSetting("chLogic", 0, 0);
+            setSetting("chLogic", 1, 0);
+            setSetting("chLogic", 2, 0);
+            setSetting("chLogic", 3, 0);
+            setSetting("chLogic", 4, 0);
             setSetting("relays", 1);
 
         #else

--- a/code/espurna/migrate.ino
+++ b/code/espurna/migrate.ino
@@ -1414,6 +1414,17 @@ void migrate() {
             setSetting("chLogic", 3, 0);
             setSetting("relays", 1);
 
+        #elif defined(DELTACO_SH_P01)
+
+            setSetting("board", 105);
+            setSetting("ledGPIO", 0, 5);
+            setSetting("ledLogic", 0, 1);
+            setSetting("ledMode", 0, LED_MODE_FOLLOW);
+            setSetting("btnGPIO", 0, 13);
+            setSetting("btnRelay", 0, 0);
+            setSetting("relayGPIO", 0, 12);
+            setSetting("relayType", 0, RELAY_TYPE_NORMAL);
+
         #else
 
             // Allow users to define new settings without migration config

--- a/code/espurna/migrate.ino
+++ b/code/espurna/migrate.ino
@@ -1425,6 +1425,17 @@ void migrate() {
             setSetting("relayGPIO", 0, 12);
             setSetting("relayType", 0, RELAY_TYPE_NORMAL);
 
+        #elif defined(DELTACO_SH_LEXXW)
+
+            setSetting("board", 106);
+            setSetting("relayProvider", RELAY_PROVIDER_LIGHT);
+            setSetting("lightProvider", LIGHT_PROVIDER_DIMMER);
+            setSetting("chGPIO", 0, 12);
+            setSetting("chGPIO", 1, 14);
+            setSetting("chLogic", 0, 0);
+            setSetting("chLogic", 1, 0);
+            setSetting("relays", 1);
+
         #else
 
             // Allow users to define new settings without migration config

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1222,6 +1222,16 @@ build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_P01
 upload_port = ${common.ota_upload_port}
 upload_flags = ${common.ota_upload_flags}
 
+[env:deltaco-sh-lexxw]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXW
+
+[env:deltaco-sh-lexxw-ota]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXW
+upload_port = ${common.ota_upload_port}
+upload_flags = ${common.ota_upload_flags}
+
 [env:estink-wifi-power-strip]
 board = ${common.board_1m}
 build_flags = ${common.build_flags_1m0m} -DFORNORM_ZLD_34EU

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1212,6 +1212,16 @@ build_flags = ${common.build_flags_1m0m} -DNEO_COOLCAM_NAS_WR01W
 upload_port = ${common.ota_upload_port}
 upload_flags = ${common.ota_upload_flags}
 
+[env:deltaco-sh-p01]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_P01
+
+[env:deltaco-sh-p01-ota]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_P01
+upload_port = ${common.ota_upload_port}
+upload_flags = ${common.ota_upload_flags}
+
 [env:estink-wifi-power-strip]
 board = ${common.board_1m}
 build_flags = ${common.build_flags_1m0m} -DFORNORM_ZLD_34EU

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1222,6 +1222,16 @@ build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_P01
 upload_port = ${common.ota_upload_port}
 upload_flags = ${common.ota_upload_flags}
 
+[env:deltaco-sh-p03usb]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_P03USB
+
+[env:deltaco-sh-p03usb-ota]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_P03USB
+upload_port = ${common.ota_upload_port}
+upload_flags = ${common.ota_upload_flags}
+
 [env:deltaco-sh-lexxw]
 board = ${common.board_1m}
 build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXW
@@ -1229,6 +1239,16 @@ build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXW
 [env:deltaco-sh-lexxw-ota]
 board = ${common.board_1m}
 build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXW
+upload_port = ${common.ota_upload_port}
+upload_flags = ${common.ota_upload_flags}
+
+[env:deltaco-sh-lexxrgb]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXRGB
+
+[env:deltaco-sh-lexxrgb-ota]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXRGB
 upload_port = ${common.ota_upload_port}
 upload_flags = ${common.ota_upload_flags}
 


### PR DESCRIPTION
add support for deltaco smart home wifi devices
**Lights:**
* [Deltaco SH-LE14W](https://www.deltaco.se/produkter/deltaco/smart-home/belysning/SH-LE14W) (uses DELTACO_SH_LEXXW) 
* [Deltaco SH-LE27W](https://www.deltaco.se/produkter/deltaco/smart-home/belysning/SH-LE27W) (uses DELTACO_SH_LEXXW)
* [Deltaco SH-LE27RGB](https://www.deltaco.se/produkter/deltaco/smart-home/belysning/SH-LE27RGB) (uses DELTACO_SH_LEXXRGB) to large for OTA need TwoStepUpdates

**Switches:**
* [Deltaco SH-P01](https://www.deltaco.se/produkter/deltaco/smart-home/grenuttag/SH-P01)
* [Deltaco SH-P03USB](https://www.deltaco.se/produkter/deltaco/smart-home/grenuttag/SH-P03USB)