### PR TITLE
Fixed update of led bug and GPIO16 support

### DIFF
--- a/code/espurna/config/dependencies.h
+++ b/code/espurna/config/dependencies.h
@@ -47,6 +47,10 @@
 #define MQTT_SUPPORT                1
 #endif
 
+#if LED_SUPPORT
+#undef BROKER_SUPPORT
+#define BROKER_SUPPORT              1               // If LED is enabled enable BROKER to supply status changes
+#endif
 
 #if INFLUXDB_SUPPORT
 #undef BROKER_SUPPORT

--- a/code/espurna/gpio.ino
+++ b/code/espurna/gpio.ino
@@ -59,6 +59,7 @@ void gpioSetup() {
         || (efuse_blocks[2] & (1 << 16))
     );
 
+    // TODO: GPIO16 is only for basic I/O, gpioGetLock before attachInterrupt should check for that
     for (unsigned char pin=0; pin < GPIO_PINS; ++pin) {
         if (pin <= 5) _gpio_available.set(pin);
         if (((pin == 9) || (pin == 10)) && (esp8285)) _gpio_available.set(pin);

--- a/code/espurna/gpio.ino
+++ b/code/espurna/gpio.ino
@@ -8,7 +8,7 @@ Copyright (C) 2017-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #include <bitset>
 
-constexpr const size_t GPIO_PINS = 16;
+constexpr const size_t GPIO_PINS = 17;
 
 std::bitset<GPIO_PINS> _gpio_locked;
 std::bitset<GPIO_PINS> _gpio_available;
@@ -62,7 +62,7 @@ void gpioSetup() {
     for (unsigned char pin=0; pin < GPIO_PINS; ++pin) {
         if (pin <= 5) _gpio_available.set(pin);
         if (((pin == 9) || (pin == 10)) && (esp8285)) _gpio_available.set(pin);
-        if (12 <= pin && pin <= 15) _gpio_available.set(pin);
+        if (12 <= pin && pin <= 16) _gpio_available.set(pin);
     }
 
 }

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -383,7 +383,7 @@ void _relayProcess(bool mode) {
     if (_relay_sync_locked && needs_unlock && changed) {
         _relaySyncUnlock();
     }
-
+	ledUpdate(true);
 }
 
 #if defined(ITEAD_SONOFF_IFAN02)

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -383,7 +383,6 @@ void _relayProcess(bool mode) {
     if (_relay_sync_locked && needs_unlock && changed) {
         _relaySyncUnlock();
     }
-	ledUpdate(true);
 }
 
 #if defined(ITEAD_SONOFF_IFAN02)


### PR DESCRIPTION
I bought ZSP-001 Device
https://templates.blakadder.com/ZSP-001.html

When I tried to configure it, I couldn't, because Espurna ignored GPIO16 on setup (which caused the led (LED2) not to function on that specific device).
I also saw that Xose noticed this issue before (https://github.com/xoseperez/espurna/issues/376) but didn't change anything about it.
Anyhow I have added support for the GPIO16.

What I also noticed is that when I choose "Follow Switch#" on LED configuration tab it didn't function at all, as far as I saw the only function that supposed to update the led status according to the relay status is `ledUpdate` and its not being called anywhere but from MQTT, so I have added a call to it after every relay status change. that solved the problem for me.