### PR TITLE
Added pin config for Avatto NAS-WR01W

### DIFF
--- a/code/espurna/config/arduino.h
+++ b/code/espurna/config/arduino.h
@@ -21,6 +21,7 @@
 //#define ARILUX_E27
 //#define ARNIEX_SWIFITCH
 //#define AUTHOMETION_LYT8266
+//#define AVATTO_NAS_WR01W
 //#define BESTEK_MRJ1011
 //#define BH_ONOFRE
 //#define BLITZWOLF_BWSHPX

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -2784,6 +2784,45 @@
     #define LED4_RELAY          1
 
 // -----------------------------------------------------------------------------
+// Avatto NAS-WR01W Wifi Smart Power Plug
+// https://www.aliexpress.com/item/33011753732.html
+// https://todo...
+// -----------------------------------------------------------------------------
+
+#elif defined(AVATTO_NAS_WR01W)
+
+    // Info
+    #define MANUFACTURER        "AVATTO"
+    #define DEVICE              "NAS_WR01W"
+
+    // Buttons
+    #define BUTTON1_PIN         0
+    #define BUTTON1_MODE        BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_RELAY       1
+
+    // Relays
+    #define RELAY1_PIN          14
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+
+    // LEDs
+    #define LED1_PIN            13
+    #define LED1_PIN_INVERSE    1
+
+    // HJL01 / BL0937
+    #ifndef HLW8012_SUPPORT
+    #define HLW8012_SUPPORT             1
+    #endif
+    #define HLW8012_SEL_PIN             12
+    #define HLW8012_CF1_PIN             5
+    #define HLW8012_CF_PIN              4
+
+    #define HLW8012_SEL_CURRENT         LOW
+    #define HLW8012_CURRENT_RATIO       25740
+    #define HLW8012_VOLTAGE_RATIO       313400
+    #define HLW8012_POWER_RATIO         3414290
+    #define HLW8012_INTERRUPT_ON        FALLING
+    
+// -----------------------------------------------------------------------------
 // NEO Coolcam NAS-WR01W Wifi Smart Power Plug
 // https://es.aliexpress.com/item/-/32854589733.html?spm=a219c.12010608.0.0.6d084e68xX0y5N
 // https://www.fasttech.com/product/9649426-neo-coolcam-nas-wr01w-wifi-smart-power-plug-eu

--- a/code/espurna/migrate.ino
+++ b/code/espurna/migrate.ino
@@ -964,6 +964,16 @@ void migrate() {
             setSetting("relayGPIO", 0, 5);
             setSetting("relayType", 0, RELAY_TYPE_NORMAL);
 
+        #elif defined(AVATTO_NAS_WR01W)
+
+            setSetting("board", 75);
+            setSetting("ledGPIO", 0, 13);
+            setSetting("ledLogic", 0, 1);
+            setSetting("btnGPIO", 0, 0);
+            setSetting("btnRelay", 0, 0);
+            setSetting("relayGPIO", 0, 14);
+            setSetting("relayType", 0, RELAY_TYPE_NORMAL);
+
         #elif defined(NEO_COOLCAM_NAS_WR01W)
 
             setSetting("board", 75);

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1202,6 +1202,16 @@ build_flags = ${common.build_flags_1m0m} -DLUANI_HVIO
 upload_port = ${common.ota_upload_port}
 upload_flags = ${common.ota_upload_flags}
 
+[env:avatto-power-plug-wifi]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DAVATTO_NAS_WR01W
+
+[env:avatto-power-plug-wifi-ota]
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m} -DAVATTO_NAS_WR01W
+upload_port = ${common.ota_upload_port}
+upload_flags = ${common.ota_upload_flags}
+
 [env:neo-coolcam-power-plug-wifi]
 board = ${common.board_1m}
 build_flags = ${common.build_flags_1m0m} -DNEO_COOLCAM_NAS_WR01W


### PR DESCRIPTION
Support for the Avatto NAS-WR01W with power monitor.

https://www.aliexpress.com/item/33011753732.html

Same model number as Neo Coolcam NAS-WR01W but not a match in PINs.
I was not able to find an official homepage for Avatto. Only the "official" shop on AliExpress. But this is a Tuya device.

PINs for Button, Led and Relay have been tested and seems correct. But I have not disassembled the device to verify. The power monitor settings where copied from Blitzwolf but seems to work.

Values in `migrate.ino` might be wrong. Could not find any documentation for this file and it's purpose.

I added a feature request matching this PR, resolve #2114