### PR TITLE
Thingspeak urn edit

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1419,14 +1419,11 @@
 
 #define THINGSPEAK_FINGERPRINT      "78 60 18 44 81 35 BF DF 77 84 D4 0A 22 0D 9B 4E 6C DC 57 2C"
 
-#define THINGSPEAK_HOST             "api.thingspeak.com"
 #if THINGSPEAK_USE_SSL
-#define THINGSPEAK_PORT             443
+#define THINGSPEAK_ADDRESS          "https://api.thingspeak.com/update"
 #else
-#define THINGSPEAK_PORT             80
+#define THINGSPEAK_ADDRESS          "http://api.thingspeak.com/update"
 #endif
-
-#define THINGSPEAK_URL              "/update"
 
 #define THINGSPEAK_MIN_INTERVAL     15000           // Minimum interval between POSTs (in millis)
 #define THINGSPEAK_FIELDS           8               // Number of fields

--- a/code/espurna/thinkspeak.ino
+++ b/code/espurna/thinkspeak.ino
@@ -9,6 +9,7 @@ Copyright (C) 2019 by Xose Pérez <xose dot perez at gmail dot com>
 #if THINGSPEAK_SUPPORT
 
 #include "broker.h"
+#include "libs/URL.h"
 
 #if THINGSPEAK_USE_ASYNC
 #include <ESPAsyncTCP.h>
@@ -78,9 +79,7 @@ void _tspkWebSocketOnConnected(JsonObject& root) {
     root["tspkEnabled"] = getSetting("tspkEnabled", 1 == THINGSPEAK_ENABLED);
     root["tspkKey"] = getSetting("tspkKey", THINGSPEAK_APIKEY);
     root["tspkClear"] = getSetting("tspkClear", 1 == THINGSPEAK_CLEAR_CACHE);
-    root["tspkHost"] = getSetting("tspkHost", THINGSPEAK_HOST);
-    root["tspkUrl"] = getSetting("tspkUrl", THINGSPEAK_URL);
-    root["tspkPort"] = getSetting("tspkPort", THINGSPEAK_PORT);
+    root["tspkAddress"] = getSetting("tspkAddress", THINGSPEAK_ADDRESS);
 
     JsonArray& relays = root.createNestedArray("tspkRelays");
     for (byte i=0; i<relayCount(); i++) {
@@ -103,10 +102,11 @@ void _tspkConfigure() {
         setSetting("tspkEnabled", 0);
     }
     if (_tspk_enabled && !_tspk_client) _tspkInitClient();
-  
-    _tspk_host = getSetting("tspkHost", THINGSPEAK_HOST);
-    _tspk_url = getSetting("tspkUrl", THINGSPEAK_URL);
-    _tspk_port = getSetting("tspkPort", THINGSPEAK_PORT);
+
+    URL _url(getSetting("tspkAddress", THINGSPEAK_ADDRESS));
+    _tspk_host = _url.host;
+    _tspk_url = _url.path;
+    _tspk_port = _url.port;
 }
 
 #if THINGSPEAK_USE_ASYNC

--- a/code/espurna/thinkspeak.ino
+++ b/code/espurna/thinkspeak.ino
@@ -106,7 +106,7 @@ void _tspkConfigure() {
   
     _tspk_host = getSetting("tspkHost", THINGSPEAK_HOST);
     _tspk_url = getSetting("tspkUrl", THINGSPEAK_URL);
-    _tspk_port = getSetting("tspkPort", THINGSPEAK_PORT).toInt();
+    _tspk_port = getSetting("tspkPort", THINGSPEAK_PORT);
 }
 
 #if THINGSPEAK_USE_ASYNC

--- a/code/espurna/thinkspeak.ino
+++ b/code/espurna/thinkspeak.ino
@@ -40,18 +40,9 @@ unsigned char _tspk_tries = THINGSPEAK_TRIES;
 class AsyncThingspeak : public AsyncClient
 {
   public:
-    URL* address;
-    AsyncThingspeak(const String&);
-    ~AsyncThingspeak();
+    URL address;
+    AsyncThingspeak(const String& _url) : address(_url) { };
 };
-
-AsyncThingspeak::AsyncThingspeak(const String& _url) {
-  address = new URL(_url);
-}
-
-AsyncThingspeak::~AsyncThingspeak() {
-  delete(address);
-}
 
 AsyncThingspeak * _tspk_client;
 
@@ -212,9 +203,9 @@ void _tspkInitClient(const String& _url) {
 
         _tspk_connected = true;
         _tspk_connecting = false;
-        AsyncThingspeak* _tspk_url = reinterpret_cast<AsyncThingspeak*>(client);
+        AsyncThingspeak* _tspk_client = reinterpret_cast<AsyncThingspeak*>(client);
 
-    DEBUG_MSG_P(PSTR("[THINGSPEAK] Connected to %s:%u\n"), _tspk_url->address->host.c_str(), _tspk_url->address->port);
+    DEBUG_MSG_P(PSTR("[THINGSPEAK] Connected to %s:%u\n"), _tspk_client->address.host.c_str(), _tspk_client->address.port);
 
         #if THINGSPEAK_USE_SSL
             uint8_t fp[20] = {0};
@@ -225,12 +216,12 @@ void _tspkInitClient(const String& _url) {
             }
         #endif
 
-        DEBUG_MSG_P(PSTR("[THINGSPEAK] POST %s?%s\n"), _tspk_url->address->path.c_str(), _tspk_data.c_str());
-        char headers[strlen_P(THINGSPEAK_REQUEST_TEMPLATE) + _tspk_url->address->path.length() + _tspk_url->address->host.length() + 1];
+        DEBUG_MSG_P(PSTR("[THINGSPEAK] POST %s?%s\n"), _tspk_client->address.path.c_str(), _tspk_data.c_str());
+        char headers[strlen_P(THINGSPEAK_REQUEST_TEMPLATE) + _tspk_client->address.path.length() + _tspk_client->address.host.length() + 1];
         snprintf_P(headers, sizeof(headers),
             THINGSPEAK_REQUEST_TEMPLATE,
-            _tspk_url->address->path.c_str(),
-            _tspk_url->address->host.c_str(),
+            _tspk_client->address.path.c_str(),
+            _tspk_client->address.host.c_str(),
             _tspk_data.length()
         );
 
@@ -250,7 +241,7 @@ void _tspkPost() {
     #if THINGSPEAK_USE_SSL
         bool connected = _tspk_client->connect(_tspk_host.c_str(), _tspk_port, THINGSPEAK_USE_SSL);
     #else
-        bool connected = _tspk_client->connect(_tspk_client->address->host.c_str(), _tspk_client->address->port);
+        bool connected = _tspk_client->connect(_tspk_client->address.host.c_str(), _tspk_client->address.port);
     #endif
 
     _tspk_connecting = connected;
@@ -280,12 +271,12 @@ void _tspkPost() {
             DEBUG_MSG_P(PSTR("[THINGSPEAK] Warning: certificate doesn't match\n"));
         }
 
-        DEBUG_MSG_P(PSTR("[THINGSPEAK] POST %s?%s\n"), _tspk_url.path.c_str(), _tspk_data.c_str());
-        char headers[strlen_P(THINGSPEAK_REQUEST_TEMPLATE) + _tspk_url.path.length() + _tspk_url.host.lengh() + 1];
+        DEBUG_MSG_P(PSTR("[THINGSPEAK] POST %s?%s\n"), _tspk_client.path.c_str(), _tspk_data.c_str());
+        char headers[strlen_P(THINGSPEAK_REQUEST_TEMPLATE) + _tspk_client.path.length() + _tspk_client.host.lengh() + 1];
         snprintf_P(headers, sizeof(headers),
             THINGSPEAK_REQUEST_TEMPLATE,
-            _tspk_url.path.c_str(),
-            _tspk_url.host.c_str(),
+            _tspk_client.path.c_str(),
+            _tspk_client.host.c_str(),
             _tspk_data.length()
         );
 

--- a/code/espurna/thinkspeak.ino
+++ b/code/espurna/thinkspeak.ino
@@ -237,10 +237,11 @@ void _tspkPost() {
     if (_tspk_connected || _tspk_connecting) return;
 
     _tspk_client_ts = millis();
-
+    
     #if THINGSPEAK_USE_SSL
         bool connected = _tspk_client->connect(_tspk_host.c_str(), _tspk_port, THINGSPEAK_USE_SSL);
     #else
+        _tspk_client->address = URL(getSetting("tspkAddress", THINGSPEAK_ADDRESS));
         bool connected = _tspk_client->connect(_tspk_client->address.host.c_str(), _tspk_client->address.port);
     #endif
 

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1356,7 +1356,7 @@
 
                                 <div class="pure-g">
                                     <label class="pure-u-1 pure-u-lg-1-4">Thingspeak API Key</label>
-                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkKey" type="text" tabindex="32" />
+                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkKey" type="text" tabindex="35" />
                                 </div>
 
                                 <legend>Sensors &amp; actuators</legend>

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1340,6 +1340,21 @@
                                 </div>
 
                                 <div class="pure-g">
+                                    <label class="pure-u-1 pure-u-lg-1-4">Thingspeak Host</label>
+                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkHost" type="text" tabindex="32" />
+                                </div>
+
+                                <div class="pure-g">
+                                    <label class="pure-u-1 pure-u-lg-1-4">Thingspeak URL</label>
+                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkUrl" type="text" tabindex="33" />
+                                </div>
+
+                                <div class="pure-g">
+                                    <label class="pure-u-1 pure-u-lg-1-4">Thingspeak Port</label>
+                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkPort" type="text" tabindex="34" />
+                                </div>
+
+                                <div class="pure-g">
                                     <label class="pure-u-1 pure-u-lg-1-4">Thingspeak API Key</label>
                                     <input class="pure-u-1 pure-u-lg-3-4" name="tspkKey" type="text" tabindex="32" />
                                 </div>

--- a/code/html/index.html
+++ b/code/html/index.html
@@ -1340,23 +1340,13 @@
                                 </div>
 
                                 <div class="pure-g">
-                                    <label class="pure-u-1 pure-u-lg-1-4">Thingspeak Host</label>
-                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkHost" type="text" tabindex="32" />
-                                </div>
-
-                                <div class="pure-g">
-                                    <label class="pure-u-1 pure-u-lg-1-4">Thingspeak URL</label>
-                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkUrl" type="text" tabindex="33" />
-                                </div>
-
-                                <div class="pure-g">
-                                    <label class="pure-u-1 pure-u-lg-1-4">Thingspeak Port</label>
-                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkPort" type="text" tabindex="34" />
+                                    <label class="pure-u-1 pure-u-lg-1-4">Thingspeak address</label>
+                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkAddress" type="text" tabindex="32" />
                                 </div>
 
                                 <div class="pure-g">
                                     <label class="pure-u-1 pure-u-lg-1-4">Thingspeak API Key</label>
-                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkKey" type="text" tabindex="35" />
+                                    <input class="pure-u-1 pure-u-lg-3-4" name="tspkKey" type="text" tabindex="33" />
                                 </div>
 
                                 <legend>Sensors &amp; actuators</legend>


### PR DESCRIPTION
A simple WebHook by modifying the Thingspeak service URL included in espurna. We can so direct those requests to the script of our choice (a PHP script in my case), and handle every notification we can imagine without having to activate any MQTT service or better in addition to the MQTT service.