### PR TITLE
Fix rpnSticky inverse condition

### DIFF
--- a/code/espurna/rpnrules.ino
+++ b/code/espurna/rpnrules.ino
@@ -322,7 +322,7 @@ void _rpnRun() {
         rpn_stack_clear(_rpn_ctxt);
     }
 
-    if (getSetting("rpnSticky", 1 == RPN_STICKY)) {
+    if (!getSetting("rpnSticky", 1 == RPN_STICKY)) {
         rpn_variables_clear(_rpn_ctxt);
     }
 


### PR DESCRIPTION
Issue introduced by the #2048, erases variables when sticky is enabled