### PR TITLE
Fix ADE7953 typo

### DIFF
--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -1286,7 +1286,7 @@
 // =============================================================================
 
 // I2C support when sensor needs it
-#if ( ADE7952_SUPPORT || \
+#if ( ADE7953_SUPPORT || \
     AM2320_SUPPORT || \
     BH1750_SUPPORT || \
     BMP180_SUPPORT || \


### PR DESCRIPTION
Actually add i2c dependency. Tests pass but the actual .bin that uses only ADE fails:
https://travis-ci.com/mcspr/espurna-nightly-builder/jobs/283295833#L480