### PR TITLE
Thingspeak: tweak SecureClient connection

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1420,6 +1420,9 @@
 // so you should compile it with WEB_SUPPORT to 0.
 // When THINGSPEAK_USE_ASYNC is 1, requires EspAsyncTCP to be built with ASYNC_TCP_SSL_ENABLED=1 and ESP8266 Arduino Core >= 2.4.0.
 // When THINGSPEAK_USE_ASYNC is 0, requires Arduino Core >= 2.6.0 and SECURE_CLIENT_BEARSSL
+//
+// WARNING: Thingspeak servers do not support MFLN right now, connection requires at least 30KB of free RAM.
+//          Also see MQTT comments above.
 
 #ifndef THINGSPEAK_USE_SSL
 #define THINGSPEAK_USE_SSL          0               // Use secure connection

--- a/code/espurna/ota.h
+++ b/code/espurna/ota.h
@@ -7,10 +7,10 @@ OTA MODULE
 #pragma once
 
 #include <Updater.h>
+#include <ArduinoOTA.h>
 
 #if OTA_ARDUINOOTA_SUPPORT
 
-#include <ArduinoOTA.h>
 void arduinoOtaSetup();
 
 #endif // OTA_ARDUINOOTA_SUPPORT == 1

--- a/code/espurna/thingspeak.h
+++ b/code/espurna/thingspeak.h
@@ -12,6 +12,8 @@ Copyright (C) 2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 #if THINGSPEAK_USE_ASYNC
 #include <ESPAsyncTCP.h>
+#else
+#include <ESP8266HTTPClient.h>
 #endif
 
 constexpr const size_t tspkDataBufferSize = 256;

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -61,6 +61,9 @@ debug_flags = -DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP
 #    -DPIO_FRAMEWORK_ARDUINO_LWIP2_LOW_MEMORY       = v2 Lower Memory
 #    -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH = v2 Higher Bandwidth
 #
+# BearSSL performance:
+#  When building with -DSECURE_CLIENT=SECURE_CLIENT_BEARSSL, please add `board_build.f_cpu = 160000000` to the environment configuration
+#
 # BearSSL ciphers:
 #   When building on core >= 2.5, you can add the build flag -DBEARSSL_SSL_BASIC in order to build BearSSL with a limited set of ciphers:
 #     TLS_RSA_WITH_AES_128_CBC_SHA256 / AES128-SHA256
@@ -284,6 +287,7 @@ src_build_flags =
 [env:nodemcu-lolin-secure-client]
 platform = ${common.platform_latest}
 board = ${common.board_4m}
+board_build.f_cpu = 160000000
 build_flags =
 	${common.build_flags_4m1m}
 	-DDEBUG_FAUXMO=Serial


### PR DESCRIPTION
- continue #2140 , use the correct implementation for http requests not confuse code readers with our parsing
- fix data sender data duplication, run build test
- add note that this is actually really RAM heavy, some connection failures are not easily distinguishable from any code errors and are simply OOM.

also
- fix arduinoota prototype error when building without it (... ino2cpp, again)
- add comment about 160mhz into the platformio.ini