### PR TITLE
Use deveopment version of PlatformIO Core

### DIFF
--- a/travis_install.sh
+++ b/travis_install.sh
@@ -9,6 +9,7 @@ npm_install() {
 
 pio_install() {
     pip install -U platformio
+    pio upgrade --dev
     pio platform update -p
 }
 


### PR DESCRIPTION
We would be thankful if you could use a development version of PlatformIO Core. in 99.999% it's very stable but there sometimes the cases which we didn't expect, such as https://github.com/platformio/platformio-core/issues/3377

So, if you will see any issues with PlatformIO Core-dev, please report us and we will fix ASAP. Thanks!