### PR TITLE
Fix "Fix AsyncTCP dependency"

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -99,7 +99,6 @@ lib_extra_dirs =
 # LIBRARIES: required dependencies
 #   Please note that we don't always use the latest version of a library.
 # ------------------------------------------------------------------------------
-lib_compat_mode = strict
 lib_deps =
     ArduinoJson@5.13.4
     https://github.com/marvinroger/async-mqtt-client#v0.8.1

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -131,6 +131,7 @@ lib_deps =
     https://github.com/mcleng/MAX6675-Library#2.0.1
     https://github.com/ElderJoy/esp8266-oled-ssd1306#4.0.1
 lib_ignore =
+    AsyncTCP
 
 # ------------------------------------------------------------------------------
 # ESPURNA CORE BUILDS


### PR DESCRIPTION
Reverts xoseperez/espurna#2147
Patch lib_ignore entry instead, since rfm69 & spi libs become incompatible