### PR TITLE
influxdb: fix http response parsing, refactor module scope

### DIFF
--- a/code/espurna/libs/AsyncClientHelpers.h
+++ b/code/espurna/libs/AsyncClientHelpers.h
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include <ESPAsyncTCP.h>
+
 enum class AsyncClientState {
     Disconnected,
     Connecting,
-    Connected
+    Connected,
+    Disconnecting
 };
     
 


### PR DESCRIPTION
fix #2152 

fix strncmp going out-of-intended-bounds
(forgetting '\0', because `char var[] = "abcde"; sizeof(var) != strlen(var)`)

change scope of variables a bit