### PR TITLE
Fixes and updates for thermostat and display:

### DIFF
--- a/code/espurna/button.ino
+++ b/code/espurna/button.ino
@@ -93,6 +93,12 @@ void buttonEvent(unsigned char id, unsigned char event) {
        }
     #endif
 
+    #if THERMOSTAT_DISPLAY_SUPPORT
+        if (BUTTON_MODE_DISPLAY_ON == action) {
+            displayOn();
+        }
+    #endif
+
     if (BUTTON_MODE_TOGGLE == action) {
         relayToggle(button.relayID);
     }

--- a/code/espurna/config/dependencies.h
+++ b/code/espurna/config/dependencies.h
@@ -156,3 +156,13 @@
 #else
 #define NTP_LEGACY_SUPPORT 0
 #endif
+
+//------------------------------------------------------------------------------
+// It looks more natural that one click will enable display
+// and long click will switch relay
+#if THERMOSTAT_DISPLAY_SUPPORT
+#undef BUTTON1_CLICK
+#define BUTTON1_CLICK           BUTTON_MODE_DISPLAY_ON
+#undef BUTTON1_LNGCLICK
+#define BUTTON1_LNGCLICK        BUTTON_MODE_TOGGLE
+#endif

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -9,7 +9,9 @@
 // GENERAL
 //------------------------------------------------------------------------------
 
+#ifndef DEVICE_NAME
 #define DEVICE_NAME             MANUFACTURER "_" DEVICE     // Concatenate both to get a unique device name
+#endif
 
 // When defined, ADMIN_PASS must be 8..63 printable ASCII characters. See:
 // https://en.wikipedia.org/wiki/Wi-Fi_Protected_Access#Target_users_(authentication_key_distribution)
@@ -232,8 +234,16 @@
 #define THERMOSTAT_DISPLAY_SUPPORT  0
 #endif
 
+#ifndef THERMOSTAT_DISPLAY_OFF_INTERVAL         // Interval in seconds after which display will be switched off
+#define THERMOSTAT_DISPLAY_OFF_INTERVAL  0      // This will prevent it from burnout
+#endif                                          // 0 - newer switch display off
+
 #define THERMOSTAT_SERVER_LOST_INTERVAL  120000 //server means lost after 2 min from last response
 #define THERMOSTAT_REMOTE_TEMP_MAX_WAIT     120 // 2 min
+
+#ifndef THERMOSTAT_REMOTE_SENSOR_NAME
+#define THERMOSTAT_REMOTE_SENSOR_NAME        "" // Get remote temp(hum) from mqtt topic of this device
+#endif
 
 //------------------------------------------------------------------------------
 // HEARTBEAT

--- a/code/espurna/config/types.h
+++ b/code/espurna/config/types.h
@@ -43,6 +43,7 @@
 #define BUTTON_MODE_SMART_CONFIG    9
 #define BUTTON_MODE_DIM_UP          10
 #define BUTTON_MODE_DIM_DOWN        11
+#define BUTTON_MODE_DISPLAY_ON      12
 
 
 // Needed for ESP8285 boards under Windows using PlatformIO (?)

--- a/code/espurna/thermostat.h
+++ b/code/espurna/thermostat.h
@@ -13,12 +13,6 @@ Copyright (C) 2017 by Dmitry Blinov <dblinov76 at gmail dot com>
 
 #if THERMOSTAT_DISPLAY_SUPPORT
 #include <SSD1306.h> // alias for `#include "SSD1306Wire.h"`
-
-// It looks more natural that one click will enable display
-// and long click will switch relay
-#define BUTTON1_CLICK           BUTTON_MODE_DISPLAY_ON
-#define BUTTON1_LNGCLICK        BUTTON_MODE_TOGGLE
-
 #endif
 
 using thermostat_callback_f = std::function<void(bool state)>;

--- a/code/espurna/thermostat.h
+++ b/code/espurna/thermostat.h
@@ -13,6 +13,12 @@ Copyright (C) 2017 by Dmitry Blinov <dblinov76 at gmail dot com>
 
 #if THERMOSTAT_DISPLAY_SUPPORT
 #include <SSD1306.h> // alias for `#include "SSD1306Wire.h"`
+
+// It looks more natural that one click will enable display
+// and long click will switch relay
+#define BUTTON1_CLICK           BUTTON_MODE_DISPLAY_ON
+#define BUTTON1_LNGCLICK        BUTTON_MODE_TOGGLE
+
 #endif
 
 using thermostat_callback_f = std::function<void(bool state)>;

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -132,7 +132,7 @@ lib_deps =
     https://github.com/sparkfun/SparkFun_VEML6075_Arduino_Library#V_1.0.3
     https://github.com/pololu/vl53l1x-arduino#1.0.1
     https://github.com/mcleng/MAX6675-Library#2.0.1
-    https://github.com/ElderJoy/esp8266-oled-ssd1306#4.0.1
+    https://github.com/ThingPulse/esp8266-oled-ssd1306
 lib_ignore =
     AsyncTCP
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -132,7 +132,7 @@ lib_deps =
     https://github.com/sparkfun/SparkFun_VEML6075_Arduino_Library#V_1.0.3
     https://github.com/pololu/vl53l1x-arduino#1.0.1
     https://github.com/mcleng/MAX6675-Library#2.0.1
-    https://github.com/ThingPulse/esp8266-oled-ssd1306
+    https://github.com/ThingPulse/esp8266-oled-ssd1306#3398c97
 lib_ignore =
     AsyncTCP
 


### PR DESCRIPTION
- Switch to original esp8266-oled-ssd1306 library
- Fixes and updates for thermostat and display
- Add display switching off after interval
- If THERMOSTAT_DISPLAY_SUPPORT enabled, then one click enable display, long click switch relay. This functionality also depend on fix for long click. See pull request https://github.com/xoseperez/espurna/pull/2172