### PR TITLE
Clean-up hardware.h and relay dependencies, fix IR typo

### DIFF
--- a/code/espurna/button.ino
+++ b/code/espurna/button.ino
@@ -411,6 +411,8 @@ void buttonEvent(unsigned char id, button_event_t event) {
     #endif
 
     switch (action) {
+
+    #if RELAY_SUPPORT
         case BUTTON_ACTION_TOGGLE:
             relayToggle(button.relayID);
             break;
@@ -422,6 +424,7 @@ void buttonEvent(unsigned char id, button_event_t event) {
         case BUTTON_ACTION_OFF:
             relayStatus(button.relayID, false);
             break;
+    #endif // RELAY_SUPPORT == 1
 
         case BUTTON_ACTION_AP:
             if (wifiState() & WIFI_STATE_AP) {

--- a/code/espurna/config/dependencies.h
+++ b/code/espurna/config/dependencies.h
@@ -38,6 +38,8 @@
 #if ALEXA_SUPPORT
 #undef BROKER_SUPPORT
 #define BROKER_SUPPORT              1               // If Alexa enabled enable BROKER
+#undef RELAY_SUPPORT
+#define RELAY_SUPPORT               1               // and switches
 #endif
 
 #if RPN_RULES_SUPPORT
@@ -45,6 +47,11 @@
 #define BROKER_SUPPORT              1               // If RPN Rules enabled enable BROKER
 #undef MQTT_SUPPORT
 #define MQTT_SUPPORT                1
+#endif
+
+#if RF_SUPPORT
+#undef RELAY_SUPPORT
+#define RELAY_SUPPORT               1
 #endif
 
 #if LED_SUPPORT
@@ -74,11 +81,18 @@
 #define BROKER_SUPPORT              1               // If Thingspeak enabled enable BROKER
 #endif
 
+#if THERMOSTAT_SUPPORT
+#undef RELAY_SUPPORT
+#define RELAY_SUPPORT               1           // Thermostat depends on switches
+#endif
+
 #if SCHEDULER_SUPPORT
 #undef NTP_SUPPORT
 #define NTP_SUPPORT                 1           // Scheduler needs NTP to work
 #undef BROKER_SUPPORT
 #define BROKER_SUPPORT              1           // Scheduler needs Broker to trigger every minute
+#undef RELAY_SUPPORT
+#define RELAY_SUPPORT               1           // Scheduler needs relays
 #endif
 
 #if LWIP_VERSION_MAJOR != 1
@@ -101,6 +115,8 @@
 #if TUYA_SUPPORT
 #undef BROKER_SUPPORT
 #define BROKER_SUPPORT              1           // Broker is required to process relay & lights events
+#undef RELAY_SUPPORT
+#define RELAY_SUPPORT               1           // Most of the time we require it
 #endif
 
 //------------------------------------------------------------------------------

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -426,6 +426,10 @@
 // RELAY
 //------------------------------------------------------------------------------
 
+#ifndef RELAY_SUPPORT
+#define RELAY_SUPPORT               1
+#endif
+
 // Default boot mode: 0 means OFF, 1 ON and 2 whatever was before
 #ifndef RELAY_BOOT_MODE
 #define RELAY_BOOT_MODE             RELAY_BOOT_OFF

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -75,13 +75,13 @@
     //#define LED_SUPPORT             0 // don't need wifi indicator
     //#define RELAY_SUPPORT           0 // don't need to preserve pin state between resets
     //#define OTA_ARDUINOOTA_SUPPORT  0 // when only using `ota` command
-    //#define MDNS_SERVER_SUPPORT     0 // 
+    //#define MDNS_SERVER_SUPPORT     0 //
     //#define TELNET_SUPPORT          0 // when only using espota.py
     //#define TERMINAL_SUPPORT        0 //
 
 #elif defined(ESPURNA_BASE)
 
-    // This is a special device with no specific hardware 
+    // This is a special device with no specific hardware
     // with the basics to easily upgrade it to a device-specific image
 
     // Info
@@ -768,7 +768,6 @@
     // Light
     #define LIGHT_CHANNELS      1
     #define LIGHT_CH1_PIN       12
-    #define LIGHT_CH1_INVERSE   0
 
 #elif defined(ITEAD_SONOFF_RFBRIDGE)
 
@@ -840,8 +839,6 @@
     #define LIGHT_CHANNELS      2
     #define LIGHT_CH1_PIN       12  // Cold white
     #define LIGHT_CH2_PIN       14  // Warm white
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
 
 #elif defined(ITEAD_SONOFF_T1_1CH)
 
@@ -1295,10 +1292,6 @@
     #define LIGHT_CH2_PIN       5       // GREEN
     #define LIGHT_CH3_PIN       12      // BLUE
     #define LIGHT_CH4_PIN       13      // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
     // IR
     #define IR_SUPPORT          1
@@ -1324,10 +1317,6 @@
     #define LIGHT_CH2_PIN       12      // GREEN
     #define LIGHT_CH3_PIN       13      // BLUE
     #define LIGHT_CH4_PIN       15      // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
     // IR
     #define IR_SUPPORT          1
@@ -1355,10 +1344,6 @@
     #define LIGHT_CH2_PIN       5       // GREEN
     #define LIGHT_CH3_PIN       13      // BLUE
     #define LIGHT_CH4_PIN       14      // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
     // IR
     #define IR_SUPPORT          1
@@ -1386,10 +1371,6 @@
     #define LIGHT_CH2_PIN       5       // GREEN
     #define LIGHT_CH3_PIN       12      // BLUE
     #define LIGHT_CH4_PIN       13      // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
     // RF
     #define RF_SUPPORT          1
@@ -1443,11 +1424,6 @@
     #define LIGHT_CH3_PIN       13      // BLUE
     #define LIGHT_CH4_PIN       5       // COLD WHITE
     #define LIGHT_CH5_PIN       15      // WARM WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
-    #define LIGHT_CH5_INVERSE   0
 
 #elif defined(MAGICHOME_ZJ_LB_RGBWW_L)
 
@@ -1465,11 +1441,6 @@
     #define LIGHT_CH3_PIN       14      // BLUE
     #define LIGHT_CH4_PIN       12      // COLD WHITE
     #define LIGHT_CH5_PIN       13      // WARM WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
-    #define LIGHT_CH5_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // HUACANXING H801 & H802
@@ -1497,11 +1468,6 @@
     #define LIGHT_CH3_PIN       12      // BLUE
     #define LIGHT_CH4_PIN       14      // WHITE1
     #define LIGHT_CH5_PIN       4       // WHITE2
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
-    #define LIGHT_CH5_INVERSE   0
 
 #elif defined(HUACANXING_H802)
 
@@ -1520,10 +1486,6 @@
     #define LIGHT_CH2_PIN       14      // GREEN
     #define LIGHT_CH3_PIN       13      // BLUE
     #define LIGHT_CH4_PIN       15      // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Jan Goedeke Wifi Relay
@@ -1789,8 +1751,6 @@
     #define LIGHT_CHANNELS      2
     #define LIGHT_CH1_PIN       0
     #define LIGHT_CH2_PIN       2
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Arilux AL-LC06
@@ -1810,9 +1770,6 @@
     #define LIGHT_CH1_PIN       5       // RED
     #define LIGHT_CH2_PIN       12      // GREEN
     #define LIGHT_CH3_PIN       13      // BLUE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
 
 #elif defined(ARILUX_AL_LC02)
 
@@ -1829,10 +1786,6 @@
     #define LIGHT_CH2_PIN       5       // GREEN
     #define LIGHT_CH3_PIN       13      // BLUE
     #define LIGHT_CH4_PIN       15      // WHITE1
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 #elif defined(ARILUX_AL_LC02_V14)
 
@@ -1849,10 +1802,6 @@
     #define LIGHT_CH2_PIN       5       // GREEN
     #define LIGHT_CH3_PIN       12      // BLUE
     #define LIGHT_CH4_PIN       13      // WHITE1
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 #elif defined(ARILUX_AL_LC06)
 
@@ -1875,11 +1824,6 @@
     #define LIGHT_CH3_PIN       13      // BLUE
     #define LIGHT_CH4_PIN       15      // WHITE1
     #define LIGHT_CH5_PIN       5       // WHITE2
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
-    #define LIGHT_CH5_INVERSE   0
 
 #elif defined(ARILUX_AL_LC11)
 
@@ -1897,11 +1841,6 @@
     #define LIGHT_CH3_PIN       14      // BLUE
     #define LIGHT_CH4_PIN       13      // WHITE1
     #define LIGHT_CH5_PIN       12      // WHITE1
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
-    #define LIGHT_CH5_INVERSE   0
 
 #elif defined(ARILUX_E27)
 
@@ -1989,10 +1928,6 @@
     #define LIGHT_CH2_PIN       12      // GREEN
     #define LIGHT_CH3_PIN       14      // BLUE
     #define LIGHT_CH4_PIN       2       // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
     #define LIGHT_ENABLE_PIN    15
 
@@ -2025,9 +1960,6 @@
     #define LIGHT_CH1_PIN       15       // RED
     #define LIGHT_CH2_PIN       12       // GREEN
     #define LIGHT_CH3_PIN       13      // BLUE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // KMC 70011
@@ -2899,7 +2831,7 @@
     #define HLW8012_VOLTAGE_RATIO       313400
     #define HLW8012_POWER_RATIO         3414290
     #define HLW8012_INTERRUPT_ON        FALLING
-    
+
 // -----------------------------------------------------------------------------
 // NEO Coolcam NAS-WR01W Wifi Smart Power Plug
 // https://es.aliexpress.com/item/-/32854589733.html?spm=a219c.12010608.0.0.6d084e68xX0y5N
@@ -2952,7 +2884,7 @@
 
 
 // ------------------------------------------------------------------------------
-// DELTACO_SH_P03USB Wifi Smart Power Plug 
+// DELTACO_SH_P03USB Wifi Smart Power Plug
 // -----------------------------------------------------------------------------
 
 #elif defined(DELTACO_SH_P03USB)
@@ -3191,7 +3123,7 @@
 
     // Disable UART noise
     #define DEBUG_SERIAL_SUPPORT        0
-    
+
     // CSE7766
     #ifndef CSE7766_SUPPORT
     #define CSE7766_SUPPORT     1
@@ -3268,14 +3200,14 @@
 
 // -----------------------------------------------------------------------------
 // Teckin SP22 v1.4 - v1.6
-// 
-// NB Notes suggest that energy monitoring is removed from later versions 
+//
+// NB Notes suggest that energy monitoring is removed from later versions
 // -----------------------------------------------------------------------------
 
 #elif defined(TECKIN_SP23_V13)
 
-    // Info  .. NB Newer versions apparently lack energy monitor 
-    // The board revision is not indicated externally 
+    // Info  .. NB Newer versions apparently lack energy monitor
+    // The board revision is not indicated externally
     #define MANUFACTURER                "TECKIN"
     #define DEVICE                      "SP23_V13"
 
@@ -3289,9 +3221,9 @@
     #define RELAY1_TYPE                 RELAY_TYPE_NORMAL
 
     // LEDs
-    #define LED1_PIN                    4 
+    #define LED1_PIN                    4
     #define LED1_PIN_INVERSE            1
-    #define LED2_PIN                    2 
+    #define LED2_PIN                    2
     #define LED2_PIN_INVERSE            0
     #define LED2_MODE                   LED_MODE_FINDME
     #define LED2_RELAY                  1
@@ -3305,8 +3237,8 @@
     #define HLW8012_CF_PIN              5
 
     #define HLW8012_SEL_CURRENT         LOW
-    #define HLW8012_CURRENT_RATIO       23324  
-    #define HLW8012_VOLTAGE_RATIO       324305 
+    #define HLW8012_CURRENT_RATIO       23324
+    #define HLW8012_VOLTAGE_RATIO       324305
     #define HLW8012_POWER_RATIO         3580841
     #define HLW8012_INTERRUPT_ON        FALLING
 
@@ -3479,9 +3411,6 @@
     #define LIGHT_CH1_PIN               14       // RED
     #define LIGHT_CH2_PIN               13       // GREEN
     #define LIGHT_CH3_PIN               12      // BLUE
-    #define LIGHT_CH1_INVERSE           0
-    #define LIGHT_CH2_INVERSE           0
-    #define LIGHT_CH3_INVERSE           0
 
 // -----------------------------------------------------------------------------
 
@@ -3519,7 +3448,7 @@
     #define RELAY1_TYPE         RELAY_TYPE_NORMAL
     #define RELAY2_PIN          5
     #define RELAY2_TYPE         RELAY_TYPE_NORMAL
-    
+
 #elif defined(ALLTERCO_SHELLY1PM)
     // Info
     #define MANUFACTURER        "ALLTERCO"
@@ -3558,9 +3487,9 @@
     //Temperature
      #define NTC_SUPPORT        1
      #define SENSOR_SUPPORT     1
-     #define NTC_BETA           3350    
-     #define NTC_R_UP           10000   
-     #define NTC_R_DOWN         0       
+     #define NTC_BETA           3350
+     #define NTC_R_UP           10000
+     #define NTC_R_DOWN         0
      #define NTC_R0             8000
 
 #elif defined(ALLTERCO_SHELLY25)
@@ -3596,16 +3525,16 @@
     //Temperature
      #define NTC_SUPPORT        1
      #define SENSOR_SUPPORT     1
-     #define NTC_BETA           3350    
-     #define NTC_R_UP           10000   
-     #define NTC_R_DOWN         0       
-     #define NTC_R0             8000 
+     #define NTC_BETA           3350
+     #define NTC_R_UP           10000
+     #define NTC_R_DOWN         0
+     #define NTC_R0             8000
 
     //Current
     #define ADE7953_SUPPORT     1
     #define I2C_SDA_PIN         12
     #define I2C_SCL_PIN         14
- 
+
 // -----------------------------------------------------------------------------
 
 // also works with https://www.amazon.com/gp/product/B07TMY394G/
@@ -3703,9 +3632,7 @@
     #define LIGHT_STEP          8
     #define LIGHT_CHANNELS      2
     #define LIGHT_CH1_PIN       5   // warm white
-    #define LIGHT_CH1_INVERSE   0
     #define LIGHT_CH2_PIN       4   // cold white
-    #define LIGHT_CH2_INVERSE   0
 
     // https://www.xiaomitoday.com/xiaomi-mijia-mjtd01yl-led-desk-lamp-review/
     #define LIGHT_COLDWHITE_MIRED 153
@@ -3739,9 +3666,6 @@
     #define LIGHT_CH1_PIN       4       // RED
     #define LIGHT_CH2_PIN       14      // GREEN
     #define LIGHT_CH3_PIN       12      // BLUE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // iWoole LED Table Lamp
@@ -3763,10 +3687,6 @@
     #define LIGHT_CH2_PIN       5       // GREEN
     #define LIGHT_CH3_PIN       14      // BLUE
     #define LIGHT_CH4_PIN       4       // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Generic GU10
@@ -3788,10 +3708,6 @@
     #define LIGHT_CH2_PIN       12      // GREEN
     #define LIGHT_CH3_PIN       13      // BLUE
     #define LIGHT_CH4_PIN       4       // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Generic E14
@@ -3813,10 +3729,6 @@
     #define LIGHT_CH2_PIN       12      // GREEN
     #define LIGHT_CH3_PIN       14      // BLUE
     #define LIGHT_CH4_PIN       5       // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Deltaco white e14 (SH-LE14W) and e27 (SH-LE27W)
@@ -3835,8 +3747,6 @@
     #define LIGHT_CHANNELS      2
     #define LIGHT_CH1_PIN       12      // WARM WHITE
     #define LIGHT_CH2_PIN       14      // COLD WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Deltaco rgbw e27 (SH-LE27RGB)
@@ -3858,11 +3768,6 @@
     #define LIGHT_CH3_PIN       13       // BLUE
     #define LIGHT_CH4_PIN       14       // WARM WHITE
     #define LIGHT_CH5_PIN       12       // COLD WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
-    #define LIGHT_CH5_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Nexete A19
@@ -3884,10 +3789,6 @@
     #define LIGHT_CH2_PIN       15      // GREEN
     #define LIGHT_CH3_PIN       14      // BLUE
     #define LIGHT_CH4_PIN       5       // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Lombex Lux Nova 2 Tunable White
@@ -3977,9 +3878,9 @@
 
     // Relays
     #define RELAY1_PIN          15
-    #define RELAY1_TYPE         RELAY_TYPE_NORMAL 
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
 
-    // Light RGBW 
+    // Light RGBW
     #define RELAY_PROVIDER      RELAY_PROVIDER_LIGHT
     #define LIGHT_PROVIDER      LIGHT_PROVIDER_DIMMER
     #define DUMMY_RELAY_COUNT   1
@@ -3989,11 +3890,7 @@
     #define LIGHT_CH2_PIN       14      // GREEN
     #define LIGHT_CH3_PIN       12      // BLUE
     #define LIGHT_CH4_PIN       4       // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0	
-    
+
 // ----------------------------------------------------------------------------------------
 // Smart life Mini Smart Socket is similar Homecube 16A but some GPIOs differ
 // https://www.ebay.de/itm/Smart-Steckdose-WIFI-WLAN-Amazon-Alexa-Fernbedienung-Home-Socket-Zeitschaltuh-DE/123352026749?hash=item1cb85a8e7d:g:IasAAOSwk6dbj390
@@ -4029,9 +3926,6 @@
     #define LIGHT_CH1_PIN               0       // RED
     #define LIGHT_CH2_PIN               4       // GREEN
     #define LIGHT_CH3_PIN               2       // BLUE
-    #define LIGHT_CH1_INVERSE           0
-    #define LIGHT_CH2_INVERSE           0
-    #define LIGHT_CH3_INVERSE           0
 
     // HJL01 / BL0937
     #ifndef HLW8012_SUPPORT
@@ -4203,7 +4097,7 @@
     #define LED1_PIN            4  // 4 blue led
     #define LED1_MODE           LED_MODE_WIFI
     #define LED1_PIN_INVERSE    1
-    
+
     #define LED2_PIN            5  // 5 red led
     #define LED2_MODE           LED_MODE_RELAY
     #define LED2_PIN_INVERSE    1
@@ -4245,10 +4139,6 @@
     #define LIGHT_CH2_PIN       4      // GREEN
     #define LIGHT_CH3_PIN       12     // BLUE
     #define LIGHT_CH4_PIN       14     // WHITE1
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 #elif defined(PSH_WIFI_SENSOR)
 
@@ -4308,7 +4198,7 @@
     #define DUMMY_RELAY_COUNT   0
 
 // -----------------------------------------------------------------------------
-// Etekcity ESW01-USA 
+// Etekcity ESW01-USA
 // https://www.amazon.com/Etekcity-Voltson-Outlet-Monitoring-Required/dp/B01M3MYIFS
 // -----------------------------------------------------------------------------
 
@@ -4330,11 +4220,9 @@
     // LEDs
     // Blue
     #define LED1_PIN                    5
-    #define LED1_PIN_INVERSE            0    
     #define LED1_MODE                   LED_MODE_WIFI
     // Yellow
     #define LED2_PIN                    16
-    #define LED2_PIN_INVERSE            0
     #define LED2_MODE                   LED_MODE_FOLLOW
     #define LED2_RELAY                  1
 
@@ -4379,7 +4267,6 @@
 
     // LEDs
     #define LED1_PIN                2
-    #define LED1_PIN_INVERSE        0
 
     // Disable UART noise
     #define DEBUG_SERIAL_SUPPORT    0
@@ -4445,10 +4332,6 @@
     #define LIGHT_CH2_PIN       12      // GREEN
     #define LIGHT_CH3_PIN       13      // BLUE
     #define LIGHT_CH4_PIN       4       // WHITE
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
 // -----------------------------------------------------------------------------
 // Hykker Power Plug (Smart Home Series) available in Jerónimo Martins Polska (Biedronka)
@@ -4568,10 +4451,6 @@
     #define LIGHT_CH3_PIN       14      // BLUE
     #define LIGHT_CH4_PIN       13      // WHITE
     // #define LIGHT_CH5_PIN    5       // CW (not connected, but circuit supports it)
-    #define LIGHT_CH1_INVERSE   0
-    #define LIGHT_CH2_INVERSE   0
-    #define LIGHT_CH3_INVERSE   0
-    #define LIGHT_CH4_INVERSE   0
 
     // IR
     #define IR_SUPPORT          1

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -56,10 +56,10 @@
     #define ALEXA_SUPPORT           0
     #define API_SUPPORT             0
     #define BROKER_SUPPORT          0
-    #define DOMOTICZ_SUPPORT        0
     #define DEBUG_SERIAL_SUPPORT    0
     #define DEBUG_TELNET_SUPPORT    0
     #define DEBUG_WEB_SUPPORT       0
+    #define DOMOTICZ_SUPPORT        0
     #define HOMEASSISTANT_SUPPORT   0
     #define I2C_SUPPORT             0
     #define MQTT_SUPPORT            0
@@ -71,11 +71,13 @@
     #define WEB_SUPPORT             0
 
     // Extra light-weight image
-    //#define BUTTON_SUPPORT          0
-    //#define LED_SUPPORT             0
-    //#define MDNS_SERVER_SUPPORT     0
-    //#define TELNET_SUPPORT          0
-    //#define TERMINAL_SUPPORT        0
+    //#define BUTTON_SUPPORT          0 // don't need / have buttons
+    //#define LED_SUPPORT             0 // don't need wifi indicator
+    //#define RELAY_SUPPORT           0 // don't need to preserve pin state between resets
+    //#define OTA_ARDUINOOTA_SUPPORT  0 // when only using `ota` command
+    //#define MDNS_SERVER_SUPPORT     0 // 
+    //#define TELNET_SUPPORT          0 // when only using espota.py
+    //#define TERMINAL_SUPPORT        0 //
 
 #elif defined(ESPURNA_BASE)
 

--- a/code/espurna/domoticz.ino
+++ b/code/espurna/domoticz.ino
@@ -128,7 +128,9 @@ void _domoticzMqtt(unsigned int type, const char * topic, char * payload) {
         mqttSubscribeRaw(dczTopicOut.c_str());
 
         // Send relays state on connection
-        domoticzSendRelays();
+        #if RELAY_SUPPORT
+            domoticzSendRelays();
+        #endif
 
     }
 
@@ -231,7 +233,10 @@ void _domoticzConfigure() {
     const bool enabled = getSetting("dczEnabled", 1 == DOMOTICZ_ENABLED);
     if (enabled != _dcz_enabled) _domoticzMqttSubscribe(enabled);
 
-    _domoticzRelayConfigure(relayCount());
+    #if RELAY_SUPPORT
+        _domoticzRelayConfigure(relayCount());
+    #endif
+
     _dcz_enabled = enabled;
 }
 

--- a/code/espurna/espurna.ino
+++ b/code/espurna/espurna.ino
@@ -193,7 +193,9 @@ void setup() {
     #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
         lightSetup();
     #endif
-    relaySetup();
+    #if RELAY_SUPPORT
+        relaySetup();
+    #endif
     #if BUTTON_SUPPORT
         buttonSetup();
     #endif

--- a/code/espurna/ir.ino
+++ b/code/espurna/ir.ino
@@ -284,6 +284,8 @@ void _irProcess(unsigned char type, unsigned long code) {
                 unsigned long button_value = pgm_read_dword(&IR_BUTTON[i][2]);
 
                 switch (button_action) {
+
+                #if RELAY_SUPPORT
                     case IR_BUTTON_ACTION_STATE:
                         relayStatus(0, button_value);
                         break;
@@ -291,6 +293,7 @@ void _irProcess(unsigned char type, unsigned long code) {
                     case IR_BUTTON_ACTION_TOGGLE:
                         relayToggle(button_value);
                         break;
+                #endif // RELAY_SUPPORT == 1
 
                 #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
 

--- a/code/espurna/ir.ino
+++ b/code/espurna/ir.ino
@@ -317,8 +317,9 @@ void _irProcess(unsigned char type, unsigned long code) {
                     case IR_BUTTON_ACTION_HSV:
                         lightColor(button_value);
                         break;
-                }
                 */
+
+                }
 
                 #endif // LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
 

--- a/code/espurna/led.ino
+++ b/code/espurna/led.ino
@@ -394,6 +394,8 @@ void ledLoop() {
                 }
                 break;
 
+        #if RELAY_SUPPORT
+
             case LED_MODE_FINDME_WIFI:
                 if ((wifi_state & WIFI_STATE_WPS) || (wifi_state & WIFI_STATE_SMARTCONFIG)) {
                     _ledBlink(led, LedMode::NetworkAutoconfig);
@@ -470,6 +472,8 @@ void ledLoop() {
                 _ledStatus(led, status);
                 break;
             }
+
+        #endif // RELAY_SUPPORT == 1
 
             case LED_MODE_ON:
                 if (!_led_update) break;

--- a/code/espurna/relay.ino
+++ b/code/espurna/relay.ino
@@ -6,6 +6,8 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 
 */
 
+#if RELAY_SUPPORT
+
 #include <Ticker.h>
 #include <ArduinoJson.h>
 #include <vector>
@@ -1437,3 +1439,5 @@ void relaySetup() {
     DEBUG_MSG_P(PSTR("[RELAY] Number of relays: %d\n"), _relays.size());
 
 }
+
+#endif // RELAY_SUPPORT == 1

--- a/code/espurna/rpc.ino
+++ b/code/espurna/rpc.ino
@@ -6,8 +6,6 @@ Copyright (C) 2020 by Maxim Prokhorov <prokhorov dot max at outlook dot com>
 
 */
 
-#if MQTT_SUPPORT || API_SUPPORT
-
 #include <Schedule.h>
 #include <cstring>
 
@@ -66,5 +64,3 @@ PayloadStatus rpcParsePayload(const char* payload, const rpc_payload_check_t ext
     return PayloadStatus::Unknown;
 
 }
-
-#endif // MQTT_SUPPORT || API_SUPPORT

--- a/code/espurna/rpnrules.ino
+++ b/code/espurna/rpnrules.ino
@@ -215,17 +215,21 @@ void _rpnInit() {
     });
 
     // Accept relay number and numeric API status value (0, 1 and 2)
-    rpn_operator_set(_rpn_ctxt, "relay", 2, [](rpn_context & ctxt) {
-        float status, id;
-        rpn_stack_pop(ctxt, id);
-        rpn_stack_pop(ctxt, status);
-        if (int(status) == 2) {
-            relayToggle(int(id));
-        } else {
-            relayStatus(int(id), int(status) == 1);
-        }
-        return true;
-    });
+    #if RELAY_SUPPORT
+
+        rpn_operator_set(_rpn_ctxt, "relay", 2, [](rpn_context & ctxt) {
+            float status, id;
+            rpn_stack_pop(ctxt, id);
+            rpn_stack_pop(ctxt, status);
+            if (int(status) == 2) {
+                relayToggle(int(id));
+            } else {
+                relayStatus(int(id), int(status) == 1);
+            }
+            return true;
+        });
+
+    #endif // RELAY_SUPPORT == 1
 
     // Channel operators
     #if RELAY_PROVIDER == RELAY_PROVIDER_LIGHT

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -2028,7 +2028,7 @@ void sensorLoop() {
         _sensorPre();
 
         // Get the first relay state
-        #if SENSOR_POWER_CHECK_STATUS
+        #if RELAY_SUPPORT && SENSOR_POWER_CHECK_STATUS
             bool relay_off = (relayCount() == 1) && (relayStatus(0) == 0);
         #endif
 
@@ -2046,7 +2046,7 @@ void sensorLoop() {
                 value_raw = magnitude.sensor->value(magnitude.local);
 
                 // Completely remove spurious values if relay is OFF
-                #if SENSOR_POWER_CHECK_STATUS
+                #if RELAY_SUPPORT && SENSOR_POWER_CHECK_STATUS
                     if (relay_off) {
                         if (magnitude.type == MAGNITUDE_POWER_ACTIVE ||
                             magnitude.type == MAGNITUDE_POWER_REACTIVE ||

--- a/code/test/build/core.h
+++ b/code/test/build/core.h
@@ -1,10 +1,10 @@
 #define ALEXA_SUPPORT           0
 #define API_SUPPORT             0
 #define BROKER_SUPPORT          0
-#define DOMOTICZ_SUPPORT        0
 #define DEBUG_SERIAL_SUPPORT    0
 #define DEBUG_TELNET_SUPPORT    0
 #define DEBUG_WEB_SUPPORT       0
+#define DOMOTICZ_SUPPORT        0
 #define HOMEASSISTANT_SUPPORT   0
 #define I2C_SUPPORT             0
 #define MQTT_SUPPORT            0


### PR DESCRIPTION
Fix https://travis-ci.com/github/mcspr/espurna-nightly-builder/builds/153119487

- IR module typo in switch statement (too long to read)
- RELAY_SUPPORT through-out the code, saves ~5KB
- LED_SUPPORT & BUTTON_SUPPORT & RELAY_SUPPORT set to 0 can save ~15KB for the OTA .bin. Kept as-is for the possibility to have something in settings to bootstrap them
- hardware.h remove trailing spaces
- hardware.h clean-up explicit CH[1-5]_INVERSE that seems to be duplicated all over the place