### PR TITLE
Change naming for pin read value, fix actions variable size

### DIFF
--- a/code/espurna/button.h
+++ b/code/espurna/button.h
@@ -16,6 +16,8 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 constexpr size_t ButtonsPresetMax = 8;
 constexpr size_t ButtonsMax = 32;
 
+using button_action_t = uint8_t;
+
 enum class button_event_t {
     None = 0,
     Pressed = 1,
@@ -27,12 +29,12 @@ enum class button_event_t {
 };
 
 struct button_actions_t {
-    uint16_t pressed;
-    uint16_t click;
-    uint16_t dblclick;
-    uint16_t lngclick;
-    uint16_t lnglngclick;
-    uint16_t trplclick;
+    button_action_t pressed;
+    button_action_t click;
+    button_action_t dblclick;
+    button_action_t lngclick;
+    button_action_t lnglngclick;
+    button_action_t trplclick;
 };
 
 struct button_event_delays_t {
@@ -64,7 +66,7 @@ struct button_t {
 };
 
 bool buttonState(unsigned char id);
-uint16_t buttonAction(unsigned char id, const button_event_t event);
+button_action_t buttonAction(unsigned char id, const button_event_t event);
 
 void buttonMQTT(unsigned char id, button_event_t event);
 void buttonEvent(unsigned char id, button_event_t event);

--- a/code/espurna/button.ino
+++ b/code/espurna/button.ino
@@ -330,7 +330,7 @@ bool buttonState(unsigned char id) {
     return _buttons[id].state();
 }
 
-uint16_t buttonAction(unsigned char id, const button_event_t event) {
+button_action_t buttonAction(unsigned char id, const button_event_t event) {
     if (id >= _buttons.size()) return 0;
     return _buttonDecodeEventAction(_buttons[id].actions, event);
 }

--- a/code/espurna/button.ino
+++ b/code/espurna/button.ino
@@ -40,13 +40,13 @@ debounce_event::types::Mode convert(const String& value) {
 }
 
 template<>
-debounce_event::types::DefaultState convert(const String& value) {
+debounce_event::types::PinValue convert(const String& value) {
     switch (value.toInt()) {
         case 0:
-            return debounce_event::types::DefaultState::Low;
+            return debounce_event::types::PinValue::Low;
         case 1:
         default:
-            return debounce_event::types::DefaultState::High;
+            return debounce_event::types::PinValue::High;
     }
 }
 
@@ -74,15 +74,15 @@ constexpr const debounce_event::types::Config _buttonDecodeConfigBitmask(const u
             ? debounce_event::types::Mode::Pushbutton
             : debounce_event::types::Mode::Switch),
         ((bitmask & ButtonMask::DefaultHigh) 
-            ? debounce_event::types::DefaultState::High
-            : debounce_event::types::DefaultState::Low),
+            ? debounce_event::types::PinValue::High
+            : debounce_event::types::PinValue::Low),
         ((bitmask & ButtonMask::SetPullup) 
             ? debounce_event::types::PinMode::InputPullup : (bitmask & ButtonMask::SetPulldown) 
             ? debounce_event::types::PinMode::InputPullup : debounce_event::types::PinMode::Input)
     };
 }
 
-constexpr const uint16_t _buttonDecodeEventAction(const button_actions_t& actions, button_event_t event) {
+constexpr const button_action_t _buttonDecodeEventAction(const button_actions_t& actions, button_event_t event) {
     return (
         (event == button_event_t::Pressed) ? actions.pressed :
         (event == button_event_t::Click) ? actions.click :
@@ -120,7 +120,7 @@ debounce_event::types::Config _buttonConfig(unsigned char index) {
     const auto config = _buttonDecodeConfigBitmask(_buttonConfigBitmask(index));
     return {
         getSetting({"btnMode", index}, config.mode),
-        getSetting({"btnDefState", index}, config.default_state),
+        getSetting({"btnDefVal", index}, config.default_value),
         getSetting({"btnPinMode", index}, config.pin_mode)
     };
 }
@@ -252,7 +252,7 @@ void _buttonWebSocketOnConnected(JsonObject& root) {
 
     schema.add("GPIO");
     schema.add("Mode");
-    schema.add("DefState");
+    schema.add("DefVal");
     schema.add("PinMode");
 
     schema.add("Relay");
@@ -284,7 +284,7 @@ void _buttonWebSocketOnConnected(JsonObject& root) {
             button.add(getSetting({"btnGPIO", index}, _buttonPin(index)));
             const auto config = _buttonConfig(index);
             button.add(static_cast<int>(config.mode));
-            button.add(static_cast<int>(config.default_state));
+            button.add(static_cast<int>(config.default_value));
             button.add(static_cast<int>(config.pin_mode));
         } else {
             button.add(GPIO_NONE);

--- a/code/espurna/libs/DebounceEvent.h
+++ b/code/espurna/libs/DebounceEvent.h
@@ -50,7 +50,7 @@ namespace types {
         Switch
     };
 
-    enum class DefaultState {
+    enum class PinValue {
         Low,
         High
     };
@@ -63,7 +63,7 @@ namespace types {
 
     struct Config {
         Mode mode;
-        DefaultState default_state;
+        PinValue default_value;
         PinMode pin_mode;
     };
 
@@ -83,8 +83,8 @@ class EventEmitter {
 
     public:
 
-        EventEmitter(types::Pin pin, const types::Config& config = {types::Mode::Pushbutton, types::DefaultState::High, types::PinMode::Input}, unsigned long delay = DebounceDelay, unsigned long repeat = RepeatDelay);
-        EventEmitter(types::Pin pin, types::EventHandler callback, const types::Config& = {types::Mode::Pushbutton, types::DefaultState::High, types::PinMode::Input}, unsigned long delay = DebounceDelay, unsigned long repeat = RepeatDelay);
+        EventEmitter(types::Pin pin, const types::Config& config = {types::Mode::Pushbutton, types::PinValue::High, types::PinMode::Input}, unsigned long delay = DebounceDelay, unsigned long repeat = RepeatDelay);
+        EventEmitter(types::Pin pin, types::EventHandler callback, const types::Config& = {types::Mode::Pushbutton, types::PinValue::High, types::PinMode::Input}, unsigned long delay = DebounceDelay, unsigned long repeat = RepeatDelay);
 
         types::Event loop();
         bool isPressed();
@@ -103,12 +103,12 @@ class EventEmitter {
         const types::Config _config;
 
         const bool _is_switch;
-        const bool _default_status;
+        const bool _default_value;
 
         const unsigned long _delay;
         const unsigned long _repeat;
 
-        bool _status;
+        bool _value;
 
         bool _ready;
         bool _reset_count;


### PR DESCRIPTION
Inconsistent naming of HIGH / LOW could be just `value` instead of `status` or `state` (whatever would that mean). Fix enumerations and configuration entries. Use `btnDefVal` as config option.

uint16_t -> uint8_t for actions