### PR TITLE
Async MQTT: buffer some data

### DIFF
--- a/code/espurna/button.ino
+++ b/code/espurna/button.ino
@@ -677,7 +677,7 @@ void _buttonLoopSonoffDual() {
     DEBUG_MSG_P(PSTR("[BUTTON] [LIGHTFOX] Received buttons mask: %u\n"), value);
 
     for (unsigned int i=0; i<_buttons.size(); i++) {
-        if ((value & (1 << i)) > 0);
+        if ((value & (1 << i)) > 0) {
             buttonEvent(i, button_event_t::Click);
         }
     }

--- a/code/espurna/config/dependencies.h
+++ b/code/espurna/config/dependencies.h
@@ -82,6 +82,8 @@
 #endif
 
 #if THERMOSTAT_SUPPORT
+#undef MQTT_USE_JSON
+#define MQTT_USE_JSON               1           // Thermostat depends on group messages in a JSON body
 #undef RELAY_SUPPORT
 #define RELAY_SUPPORT               1           // Thermostat depends on switches
 #endif
@@ -194,4 +196,14 @@
 #define BUTTON1_CLICK           BUTTON_ACTION_DISPLAY_ON
 #undef BUTTON1_LNGCLICK
 #define BUTTON1_LNGCLICK        BUTTON_ACTION_TOGGLE
+#endif
+
+//------------------------------------------------------------------------------
+// We should always set MQTT_MAX_PACKET_SIZE
+//
+
+#if MQTT_LIBRARY == MQTT_LIBRARY_PUBSUBCLIENT
+#if not defined(MQTT_MAX_PACKET_SIZE)
+#warning "MQTT_MAX_PACKET_SIZE should be set in `build_flags = ...` of the environment! Default value is used instead."
+#endif
 #endif

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -1079,15 +1079,8 @@
 #define MQTT_SKIP_TIME              1000            // Skip messages for 1 second anter connection
 #endif
 
-
-#if THERMOSTAT_SUPPORT == 1
-    #ifndef MQTT_USE_JSON
-    #define MQTT_USE_JSON               1           // Group messages in a JSON body
-    #endif
-#else
-    #ifndef MQTT_USE_JSON
-    #define MQTT_USE_JSON               0           // Don't group messages in a JSON body (default)
-    #endif
+#ifndef MQTT_USE_JSON
+#define MQTT_USE_JSON               0               // Don't group messages in a JSON body by default
 #endif
 
 #ifndef MQTT_USE_JSON_DELAY
@@ -1098,6 +1091,10 @@
 #define MQTT_QUEUE_MAX_SIZE         20              // Size of the MQTT queue when MQTT_USE_JSON is enabled
 #endif
 
+#ifndef MQTT_BUFFER_MAX_SIZE
+#define MQTT_BUFFER_MAX_SIZE        1024            // Size of the MQTT payload buffer for MQTT_MESSAGE_EVENT. Large messages will only be available via MQTT_MESSAGE_RAW_EVENT.
+                                                    // Note: When using MQTT_LIBRARY_PUBSUBCLIENT, MQTT_MAX_PACKET_SIZE should not be more than this value.
+#endif
 
 // These are the properties that will be sent when useJson is true
 #ifndef MQTT_ENQUEUE_IP

--- a/code/espurna/mqtt.h
+++ b/code/espurna/mqtt.h
@@ -17,6 +17,9 @@ Updated secure client support by Niek van der Maas < mail at niekvandermaas dot 
 using mqtt_callback_f = std::function<void(unsigned int type, const char * topic, char * payload)>;
 using mqtt_msg_t = std::pair<String, String>; // topic, payload
 
+// TODO: need this prototype for .ino
+class AsyncMqttClientMessageProperties;
+
 #if MQTT_SUPPORT
 
 #if MQTT_LIBRARY == MQTT_LIBRARY_ASYNCMQTTCLIENT

--- a/code/espurna/mqtt.ino
+++ b/code/espurna/mqtt.ino
@@ -626,7 +626,12 @@ bool _mqttMaybeSkipRetained(char* topic) {
 // TODO: One pending issue is streaming arbitrary data (e.g. binary, for OTA). We always set '\0' and API consumer expects C-String.
 //       In that case, there could be MQTT_MESSAGE_RAW_EVENT and this callback only trigger on small messages.
 
-void _mqttOnMessageAsync(char* topic, char* payload, AsyncMqttClientMessageProperties, size_t len, size_t index, size_t total) {
+void _mqttOnMessageAsync(char* topic, char* payload, AsyncMqttClientMessageProperties properties, size_t len, size_t index, size_t total) {
+    DEBUG_MSG_P(PSTR("[MQTT] topic=%s mqtt:qos=%u:dup=%c:ret=%c msg:len=%u:idx=%u:total=%u\n"),
+        topic,
+        properties.qos, (properties.dup ? 'y' : 'n'), (properties.retain ? 'y' : 'n'),
+        len, index, total
+    );
 
     if (!len || (len > MQTT_BUFFER_MAX_SIZE) || (total > MQTT_BUFFER_MAX_SIZE)) return;
     if (_mqttMaybeSkipRetained(topic)) return;
@@ -639,6 +644,7 @@ void _mqttOnMessageAsync(char* topic, char* payload, AsyncMqttClientMessagePrope
         return;
     }
     message[len + index] = '\0';
+    DEBUG_MSG_P(PSTR("[MQTT] Received %s => %s\n"), topic, message);
 
     // Call subscribers with the message buffer
     for (auto& callback : _mqtt_callbacks) {

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -76,7 +76,7 @@ board_1m = esp01_1m
 board_2m = esp_wroom_02
 board_4m = esp12e
 
-build_flags = -g -w -DMQTT_MAX_PACKET_SIZE=1024 -DNO_GLOBAL_EEPROM -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
+build_flags = -g -w -DNO_GLOBAL_EEPROM -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
 build_flags_512k = ${common.build_flags} -Wl,-Teagle.flash.512k0m1s.ld
 build_flags_1m0m = ${common.build_flags} -Wl,-Teagle.flash.1m0m1s.ld
 build_flags_2m1m = ${common.build_flags} -Wl,-Teagle.flash.2m1m4s.ld


### PR DESCRIPTION
fix #2166 
@karmacoma92, I think this should work now.

We already buffer the data to inject '\0' at the end, but we never re-use the buffer. Instead, allocate `char buf[MQTT_MAX_PACKET_SIZE]` and place the data there until we got the full message. Static allocation, avoid dynamic `char buf[len+1]`. Default buffer size is 1024 bytes.
Also avoid using strlcpy, since we already know the length (and because of weird len+1)

