### PR TITLE
Update IRremoteESP8266 to 2.7.4

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -113,7 +113,7 @@ lib_deps =
     https://github.com/me-no-dev/ESPAsyncWebServer#b0c6144
     https://bitbucket.org/xoseperez/fauxmoesp.git#3.1.0
     https://github.com/xoseperez/hlw8012.git#1.1.0
-    IRremoteESP8266@v2.7.4
+    IRremoteESP8266@2.7.4
     https://github.com/xoseperez/justwifi.git#2.0.2
     https://github.com/madpilot/mDNSResolver#4cfcda1
     https://github.com/xoseperez/my92xx#3.0.1

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -113,7 +113,7 @@ lib_deps =
     https://github.com/me-no-dev/ESPAsyncWebServer#b0c6144
     https://bitbucket.org/xoseperez/fauxmoesp.git#3.1.0
     https://github.com/xoseperez/hlw8012.git#1.1.0
-    https://github.com/markszabo/IRremoteESP8266#v2.2.0
+    IRremoteESP8266@v2.7.4
     https://github.com/xoseperez/justwifi.git#2.0.2
     https://github.com/madpilot/mDNSResolver#4cfcda1
     https://github.com/xoseperez/my92xx#3.0.1


### PR DESCRIPTION
Fix version specifier, use PIO registry instead of git
Need this for -DALLOW_DELAY_CALLS=false