### PR TITLE
ci: capitalization fix

### DIFF
--- a/travis_install.sh
+++ b/travis_install.sh
@@ -15,11 +15,11 @@ pio_install() {
 
 cd code
 
-if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test host" ]; then
+if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test Host" ]; then
     pio_install
-elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test webui" ]; then
+elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test WebUI" ]; then
     npm_install
-elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test platformio build" ]; then
+elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test PlatformIO Build" ]; then
     pio_install
 elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Release" ]; then
     npm_install

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -4,11 +4,11 @@ set -x -e -v
 
 cd code
 
-if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test host" ]; then
+if [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test Host" ]; then
     cd test/ && pio test
-elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test webui" ]; then
+elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test WebUI" ]; then
     ./build.sh -f environments
-elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test platformio build" ]; then
+elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test PlatformIO Build" ]; then
     # shellcheck disable=SC2086
     scripts/test_build.py -e "$TEST_ENV" $TEST_EXTRA_ARGS
 elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Release" ]; then


### PR DESCRIPTION
Something fixed by travis-ci? Capitalization (implicit, we already do it) is still there, but other words no longer become lowercase

No mention of changes here:
https://docs.travis-ci.com/user/build-stages/#naming-your-build-stages
https://docs.travis-ci.com/user/environment-variables#default-environment-variables
https://changelog.travis-ci.com/
https://travis-ci.community/
Maybe this is something back-logged :/ New behaviour is actually the correct one from the user perspective.