### PR TITLE
Add default relay for GOSUND_WP3 BUTTON1

### DIFF
--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -3262,6 +3262,7 @@
     // Buttons
     #define BUTTON1_PIN                 4
     #define BUTTON1_CONFIG              BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_RELAY               1
 
     // Relays
     #define RELAY1_PIN                  14


### PR DESCRIPTION
Following up on #2191, I wanted to define the default relay controlled by BUTTON1 similar to other devices. Without this default relay definition, pressing the button won't control the relay and rendering this switch to be remote controlled only.

Patched and tested on several of my WP3s.