### PR TITLE
PIO: fix env definitions (again)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ stages:
   - name: Test PlatformIO Build
     if: tag IS NOT present
   - name: Release
-    #if: tag IS present AND tag =~ ^\d+\.\d+\.\d+$
+    if: tag IS present AND tag =~ ^\d+\.\d+\.\d+$
 jobs:
   include:
     - stage: Test Host

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ jobs:
     - env: BUILDER_THREAD=3
 before_deploy:
   - mkdir -p firmware/
-  - mv code/release/*/espurna-*.bin firmware/
+  - mv firmware/*/espurna-*.bin firmware/
 deploy:
   provider: releases
   api_key:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ stages:
   - name: Test PlatformIO Build
     if: tag IS NOT present
   - name: Release
-    if: tag IS present AND tag =~ ^\d+\.\d+\.\d+$
+    #if: tag IS present AND tag =~ ^\d+\.\d+\.\d+$
 jobs:
   include:
     - stage: Test Host

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ jobs:
     - stage: Test Host
     - stage: Test WebUI
     - stage: Test PlatformIO Build
-      env: TEST_ENV=travis-2_3_0
-    - env: TEST_ENV=travis-latest
+      env: TEST_ENV=esp8266-4m-base
+    - env: TEST_ENV=esp8266-latest-4m-base
     - env: >-
-        TEST_ENV=travis-git TEST_EXTRA_ARGS="-a
+        TEST_ENV=esp8266-git-4m-base TEST_EXTRA_ARGS="-a
         test/build/extra/secure_client.h"
     - stage: Release
       env: BUILDER_THREAD=0
@@ -40,7 +40,8 @@ jobs:
     - env: BUILDER_THREAD=2
     - env: BUILDER_THREAD=3
 before_deploy:
-  - mv firmware/*/espurna-*.bin firmware/
+  - mkdir -p firmware/
+  - mv code/release/*/espurna-*.bin firmware/
 deploy:
   provider: releases
   api_key:

--- a/code/build.sh
+++ b/code/build.sh
@@ -49,8 +49,7 @@ list_envs() {
     grep -E '^\[env:' platformio.ini | sed 's/\[env:\(.*\)\]/\1/g'
 }
 
-travis=$(list_envs | grep travis | sort)
-available=$(list_envs | grep -Ev -- '-ota$|-ssl$|^esp8266-.*base' | sort)
+available=$(list_envs | grep -Ev -- '-ota$|-ssl$|-secure-client.*$|^esp8266-.*base$' | sort)
 
 # Functions
 print_available() {

--- a/code/build.sh
+++ b/code/build.sh
@@ -97,7 +97,7 @@ build_webui() {
 build_release() {
     echo "--------------------------------------------------------------"
     echo "Building release images..."
-    python scripts/generate_release_sh.py $version > release.sh
+    python scripts/generate_release_sh.py --ignore secure-client $version > release.sh
     bash release.sh
     echo "--------------------------------------------------------------"
 }

--- a/code/build.sh
+++ b/code/build.sh
@@ -24,6 +24,8 @@ version=$(grep -E '^#define APP_VERSION' $version_file | awk '{print $3}' | sed 
 script_build_environments=true
 script_build_webui=true
 
+release_mode=false
+
 if ${TRAVIS:-false}; then
     git_revision=${TRAVIS_COMMIT::7}
     git_tag=${TRAVIS_TAG}
@@ -40,19 +42,6 @@ if [[ -n $git_tag ]]; then
     sed -i -e "s@$version@$new_version@" $version_file
     version=$new_version
     trap "git checkout -- $version_file" EXIT
-fi
-
-par_build=false
-par_thread=${BUILDER_THREAD:-0}
-par_total_threads=${BUILDER_TOTAL_THREADS:-4}
-if [ ${par_thread} -ne ${par_thread} -o \
-    ${par_total_threads} -ne ${par_total_threads} ]; then
-    echo "Parallel threads should be a number."
-    exit
-fi
-if [ ${par_thread} -ge ${par_total_threads} ]; then
-    echo "Current thread is greater than total threads. Doesn't make sense"
-    exit
 fi
 
 # Available environments
@@ -81,20 +70,6 @@ print_environments() {
 }
 
 set_default_environments() {
-    # Hook to build in parallel when using travis
-    if [[ "${TRAVIS_BUILD_STAGE_NAME}" = "Release" ]] && ${par_build}; then
-        environments=$(echo ${available} | \
-            awk -v par_thread=${par_thread} -v par_total_threads=${par_total_threads} \
-            '{ for (i = 1; i <= NF; i++) if (++j % par_total_threads == par_thread ) print $i; }')
-        return
-    fi
-
-    # Only build travisN
-    if [[ "${TRAVIS_BUILD_STAGE_NAME}" = "Test" ]]; then
-        environments=$travis
-        return
-    fi
-
     # Fallback to all available environments
     environments=$available
 }
@@ -117,6 +92,14 @@ build_webui() {
     if ${TRAVIS:-false}; then
         git --no-pager diff --stat
     fi
+}
+
+build_release() {
+    echo "--------------------------------------------------------------"
+    echo "Building release images..."
+    python scripts/generate_release_sh.py $version > release.sh
+    bash release.sh
+    echo "--------------------------------------------------------------"
 }
 
 build_environments() {
@@ -146,19 +129,16 @@ Options:
 
   -f VALUE    Filter build stage by name to skip it
               Supported VALUEs are "environments" and "webui"
-              Can be specified multiple times
+              Can be specified multiple times. 
+  -r          Release mode
+              Generate build list through an external script.
   -l          Print available environments
   -d VALUE    Destination to move .bin files after building environments
-  -p          Enable parallel build
-              Depends on following exported variables:
-                BUILDER_THREAD=<number>        (default 0...4)
-                BUILDER_TOTAL_THREADS=<number> (default 4)
-              When building platformio environments, will only pick every <BUILDER_THREAD>th
   -h          Display this message
 EOF
 }
 
-while getopts "f:lpd:h" opt; do
+while getopts "f:lrpd:h" opt; do
   case $opt in
     f)
         case "$OPTARG" in
@@ -170,11 +150,11 @@ while getopts "f:lpd:h" opt; do
         print_available
         exit
         ;;
-    p)
-        par_build=true
-        ;;
     d)
         destination=$OPTARG
+        ;;
+    r)
+        release_mode=true
         ;;
     h)
         print_getopts_help
@@ -201,9 +181,10 @@ if $script_build_environments ; then
         set_default_environments
     fi
 
-    if ${CI:-false}; then
-        print_environments
+    if $release_mode ; then
+        build_release
+    else
+        build_environments
     fi
-
-    build_environments
 fi
+

--- a/code/build.sh
+++ b/code/build.sh
@@ -57,11 +57,11 @@ fi
 
 # Available environments
 list_envs() {
-    grep env: platformio.ini | sed 's/\[env:\(.*\)\]/\1/g'
+    grep -E '^\[env:' platformio.ini | sed 's/\[env:\(.*\)\]/\1/g'
 }
 
 travis=$(list_envs | grep travis | sort)
-available=$(list_envs | grep -Ev -- '-ota$|-ssl$|^travis' | sort)
+available=$(list_envs | grep -Ev -- '-ota$|-ssl$|^esp8266-.*base' | sort)
 
 # Functions
 print_available() {

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -1694,6 +1694,43 @@
     #define ECH1560_INVERTED    0
 
 // -----------------------------------------------------------------------------
+// PZEM004T
+// -----------------------------------------------------------------------------
+
+#elif defined(GENERIC_PZEM004T)
+
+    // Info
+    #define MANUFACTURER        "GENERIC"
+    #define DEVICE              "PZEM004T"
+
+    #define PZEM004T_SUPPORT     1
+
+    #define ALEXA_SUPPORT              0
+    #define DEBUG_SERIAL_SUPPORT       0
+
+// -----------------------------------------------------------------------------
+// ESP-01 generic esp8266 board with 512 kB flash
+// -----------------------------------------------------------------------------
+
+#elif defined(GENERIC_ESP01_512KB)
+
+    // Info
+    #define MANUFACTURER        "GENERIC"
+    #define DEVICE              "ESP01_512KB"
+
+    // Relays
+    #define RELAY1_PIN          2
+    #ifndef RELAY1_TYPE
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+    #endif
+
+    // No need for OTA
+    #define OTA_WEB_SUPPORT          0
+    #define OTA_ARDUINOOTA_SUPPORT   0
+    #define OTA_CLIENT               OTA_CLIENT_NONE
+
+
+// -----------------------------------------------------------------------------
 // ESPLive
 // https://github.com/ManCaveMade/ESP-Live
 // -----------------------------------------------------------------------------
@@ -4543,27 +4580,6 @@
     #define RELAY2_TYPE             RELAY_TYPE_NORMAL
     #define RELAY3_TYPE             RELAY_TYPE_NORMAL
     #define RELAY4_TYPE             RELAY_TYPE_NORMAL
-
-// -----------------------------------------------------------------------------
-// ESP-01 generic esp8266 board with 512 kB flash
-// -----------------------------------------------------------------------------
-
-#elif defined(GENERIC_ESP01_512KB)
-
-    // Info
-    #define MANUFACTURER        "GENERIC"
-    #define DEVICE              "ESP01_512KB"
-
-    // Relays
-    #define RELAY1_PIN          2
-    #ifndef RELAY1_TYPE
-    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
-    #endif
-
-    // No need for OTA
-    #define OTA_WEB_SUPPORT          0
-    #define OTA_ARDUINOOTA_SUPPORT   0
-    #define OTA_CLIENT               OTA_CLIENT_NONE
 
 // -----------------------------------------------------------------------------
 

--- a/code/espurna/ota_asynctcp.ino
+++ b/code/espurna/ota_asynctcp.ino
@@ -146,7 +146,7 @@ void _otaClientOnConnect(void* arg, AsyncClient* client) {
 
     #if ASYNC_TCP_SSL_ENABLED
         const auto check = getSetting("otaScCheck", OTA_SECURE_CLIENT_CHECK);
-        if ((check == SECURE_CLIENT_CHECK_FINGERPRINT) && (443 == _ota_url->port)) {
+        if ((check == SECURE_CLIENT_CHECK_FINGERPRINT) && (443 == ota_client->url.port)) {
             uint8_t fp[20] = {0};
             sslFingerPrintArray(getSetting("otaFP", OTA_FINGERPRINT).c_str(), fp);
             SSL * ssl = client->getSSL();

--- a/code/ota.py
+++ b/code/ota.py
@@ -409,7 +409,7 @@ def get_platformio_env(arduino_core, size):
         )
     if arduino_core != "2_3_0":
         env_prefix = "{}-{}".format(env_prefix, arduino_core)
-    return "{env_prefix}-{size:d}m-ota".format(env_prefix=env_prefix, size=size)
+    return "{env_prefix}-{size:d}m-base".format(env_prefix=env_prefix, size=size)
 
 
 def main(args):

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -4,6 +4,17 @@ src_dir = espurna
 data_dir = espurna/data
 extra_configs =
     platformio_ota.ini
+    platformio_override.ini
+
+# ------------------------------------------------------------------------------
+# Add to or modify ANY section (env:..., common, etc.) via platformio_override.ini
+#
+# For example, to set f_cpu value for every environment:
+# $ cat platformio_override.ini
+# [env]
+# board_build.f_cpu = 160000000
+#
+# ------------------------------------------------------------------------------
 
 [common]
 # ------------------------------------------------------------------------------

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1,5 +1,5 @@
 [platformio]
-default_envs = wemos-d1mini-relayshield
+default_envs = nodemcu-lolin
 src_dir = espurna
 data_dir = espurna/data
 extra_configs =
@@ -18,9 +18,9 @@ extra_configs =
 #   arduino core 2.5.0 = platformIO 2.0.4 (not supported)
 #   arduino core 2.5.1 = platformIO 2.1.1 (not supported)
 #   arduino core 2.5.2 = platformIO 2.2.3 (not supported)
-#   arduino core 2.6.1 = platformIO 2.3.0
-#   arduino core 2.6.2 = platformIO 2.3.1
-#   arduino core 2.6.3 = platformIO 2.3.2
+#   arduino core 2.6.1 = platformIO 2.3.0 (not supported)
+#   arduino core 2.6.2 = platformIO 2.3.1 (not supported)
+#   arduino core 2.6.3 = platformIO 2.4.0
 # ------------------------------------------------------------------------------
 platform_2_3_0 = espressif8266@1.5.0
 platform_latest = espressif8266@2.4.0
@@ -29,6 +29,7 @@ platform_latest = espressif8266@2.4.0
 # FLAGS: DEBUG
 #
 # ------------------------------------------------------------------------------
+
 debug_flags = -DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP_CLIENT -DDEBUG_ESP_HTTP_UPDATE -DDEBUG_ESP_HTTP_SERVER -DDEBUG_ESP_UPDATER -DDEBUG_ESP_OTA -DDEBUG_TLS_MEM
 #if needed (for memleaks etc) also add; -DDEBUG_ESP_OOM -include "umm_malloc/umm_malloc_cfg.h"
 
@@ -57,17 +58,20 @@ debug_flags = -DDEBUG_ESP_CORE -DDEBUG_ESP_SSL -DDEBUG_ESP_WIFI -DDEBUG_ESP_HTTP
 #     TLS_RSA_WITH_AES_256_CBC_SHA / AES256-SHA
 #  This reduces the OTA size with ~45KB, so it's especially useful on low memory boards (512k/1m).
 # ------------------------------------------------------------------------------
-board_512k = esp01
-board_1m = esp01_1m
-board_2m = esp_wroom_02
-board_4m = esp12e
 
 build_flags = -g -w -DNO_GLOBAL_EEPROM -DPIO_FRAMEWORK_ARDUINO_LWIP2_HIGHER_BANDWIDTH
-build_flags_512k = ${common.build_flags} -Wl,-Teagle.flash.512k0m1s.ld
-build_flags_1m0m = ${common.build_flags} -Wl,-Teagle.flash.1m0m1s.ld
-build_flags_2m1m = ${common.build_flags} -Wl,-Teagle.flash.2m1m4s.ld
-build_flags_4m1m = ${common.build_flags} -Wl,-Teagle.flash.4m1m4s.ld
-build_flags_4m3m = ${common.build_flags} -Wl,-Teagle.flash.4m3m4s.ld
+
+board_512k = esp01
+ldscript_512k = eagle.flash.512k0m1s.ld
+
+board_1m = esp01_1m
+ldscript_1m = eagle.flash.1m0m1s.ld
+
+board_2m = esp_wroom_02
+ldscript_2m = eagle.flash.2m1m4s.ld
+
+board_4m = esp12e
+ldscript_4m = eagle.flash.4m1m4s.ld
 
 shared_libdeps_dir = libraries/
 
@@ -123,55 +127,55 @@ lib_ignore =
 
 [env:esp8266-512k-base]
 board = ${common.board_512k}
-build_flags = ${common.build_flags_512k}
+board_build.ldscript = ${common.ldscript_512k}
 
 [env:esp8266-1m-base]
 board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m}
+board_build.ldscript = ${common.ldscript_1m}
 
 [env:esp8266-2m-base]
 board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m}
+board_build.ldscript = ${common.ldscript_2m}
 
 [env:esp8266-4m-base]
 board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m}
+board_build.ldscript = ${common.ldscript_4m}
 
 [env:esp8266-latest-1m-base]
 platform = ${common.platform_latest}
 board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m}
+board_build.ldscript = ${common.ldscript_1m}
 
 [env:esp8266-latest-2m-base]
 platform = ${common.platform_latest}
 board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m}
+board_build.ldscript = ${common.ldscript_2m}
 
 [env:esp8266-latest-4m-base]
 platform = ${common.platform_latest}
 board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m}
+board_build.ldscript = ${common.ldscript_4m}
 
 [env:esp8266-git-1m-base]
 platform = ${common.platform_latest}
 board = ${common.board_1m}
 platform_packages =
     framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
-build_flags = ${common.build_flags_1m0m}
+board_build.ldscript = ${common.ldscript_1m}
 
 [env:esp8266-git-2m-base]
 platform = ${common.platform_latest}
 board = ${common.board_2m}
 platform_packages =
     framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
-build_flags = ${common.build_flags_2m1m}
+board_build.ldscript = ${common.ldscript_2m}
 
 [env:esp8266-git-4m-base]
 platform = ${common.platform_latest}
 board = ${common.board_4m}
 platform_packages =
     framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
-build_flags = ${common.build_flags_4m1m}
+board_build.ldscript = ${common.ldscript_4m}
 
 # ------------------------------------------------------------------------------
 # ESPURNA CORE BUILDS
@@ -192,32 +196,32 @@ src_build_flags = -DESPURNA_CORE
 [env:espurna-core-smartconfig-1MB]
 extends = env:esp8266-1m-base
 src_build_flags = -DESPURNA_CORE
-build_flags = ${env:esp8266-1m-base.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+build_flags = ${common.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-smartconfig-2MB]
 extends = env:esp8266-2m-base
 src_build_flags = -DESPURNA_CORE
-build_flags = ${env:esp8266-2m-base.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+build_flags = ${common.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-smartconfig-4MB]
 extends = env:esp8266-4m-base
 src_build_flags = -DESPURNA_CORE
-build_flags = ${env:esp8266-4m-base.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+build_flags = ${common.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-wps-1MB]
 extends = env:esp8266-1m-base
 src_build_flags = -DESPURNA_CORE
-build_flags = ${env:esp8266-1m-base.build_flags} -DJUSTWIFI_ENABLE_WPS=1
+build_flags = ${common.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 [env:espurna-core-wps-2MB]
 extends = env:esp8266-2m-base
 src_build_flags = -DESPURNA_CORE
-build_flags = ${env:esp8266-2m-base.build_flags} -DJUSTWIFI_ENABLE_WPS=1
+build_flags = ${common.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 [env:espurna-core-wps-4MB]
 extends = env:esp8266-4m-base
 src_build_flags = -DESPURNA_CORE
-build_flags = ${env:esp8266-4m-base.build_flags} -DJUSTWIFI_ENABLE_WPS=1
+build_flags = ${common.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 # ------------------------------------------------------------------------------
 # ESPURNA BASE BUILD (CORE with WebUI, tuya-convert)
@@ -251,9 +255,7 @@ src_build_flags = -DNODEMCU_LOLIN -DNOWSAUTH
 
 [env:nodemcu-lolin-secure-client-asynctcp]
 extends = env:esp8266-latest-4m-base
-build_flags =
-	${env:esp8266-latest-4m-base.build_flags}
-	-DASYNC_TCP_SSL_ENABLED=1
+build_flags = ${common.build_flags} -DASYNC_TCP_SSL_ENABLED=1
 src_build_flags = -DNODEMCU_LOLIN -DNOWSAUTH
 
 [env:nodemcu-lolin-secure-client]

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -82,6 +82,7 @@ shared_libdeps_dir = libraries/
 platform = ${common.platform_2_3_0}
 framework = arduino
 board_build.flash_mode = dout
+build_flags = ${common.build_flags}
 monitor_speed = 115200
 upload_speed = 115200
 extra_scripts = pre:scripts/pio_pre.py, scripts/pio_main.py

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -22,23 +22,8 @@ extra_configs =
 #   arduino core 2.6.2 = platformIO 2.3.1
 #   arduino core 2.6.3 = platformIO 2.3.2
 # ------------------------------------------------------------------------------
-arduino_core_2_3_0 = espressif8266@1.5.0
-arduino_core_2_4_0 = espressif8266@1.6.0
-arduino_core_2_4_1 = espressif8266@1.7.3
-arduino_core_2_4_2 = espressif8266@1.8.0
-arduino_core_2_5_0 = espressif8266@2.0.4
-arduino_core_2_5_1 = espressif8266@2.1.1
-arduino_core_2_5_2 = espressif8266@2.2.3
-arduino_core_2_6_1 = espressif8266@2.3.0
-arduino_core_2_6_2 = espressif8266@2.3.1
-arduino_core_2_6_3 = espressif8266@2.3.2
-
-# Development platforms
-arduino_core_develop = https://github.com/platformio/platform-espressif8266#develop
-arduino_core_git = https://github.com/platformio/platform-espressif8266#feature/stage
-
-platform = ${common.arduino_core_2_3_0}
-platform_latest = ${common.arduino_core_2_6_3}
+platform_2_3_0 = espressif8266@1.5.0
+platform_latest = espressif8266@2.4.0
 
 # ------------------------------------------------------------------------------
 # FLAGS: DEBUG
@@ -90,7 +75,7 @@ shared_libdeps_dir = libraries/
 # COMMON SETTINGS:
 # ------------------------------------------------------------------------------
 [env]
-platform = ${common.platform}
+platform = ${common.platform_latest}
 framework = arduino
 board_build.flash_mode = dout
 monitor_speed = 115200
@@ -136,162 +121,142 @@ lib_deps =
 lib_ignore =
     AsyncTCP
 
+[env:esp8266-512k-base]
+platform = ${common.platform_2_3_0}
+board = ${common.board_512k}
+build_flags = ${common.build_flags_512k}
+
+[env:esp8266-1m-base]
+platform = ${common.platform_2_3_0}
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m}
+
+[env:esp8266-2m-base]
+platform = ${common.platform_2_3_0}
+board = ${common.board_2m}
+build_flags = ${common.build_flags_2m1m}
+
+[env:esp8266-4m-base]
+platform = ${common.platform_2_3_0}
+board = ${common.board_4m}
+build_flags = ${common.build_flags_4m1m}
+
+[env:esp8266-latest-1m-base]
+platform = ${common.platform_latest}
+board = ${common.board_1m}
+build_flags = ${common.build_flags_1m0m}
+
+[env:esp8266-latest-2m-base]
+platform = ${common.platform_latest}
+board = ${common.board_2m}
+build_flags = ${common.build_flags_2m1m}
+
+[env:esp8266-latest-4m-base]
+platform = ${common.platform_latest}
+board = ${common.board_4m}
+build_flags = ${common.build_flags_4m1m}
+
+[env:esp8266-git-1m-base]
+platform = ${common.platform_latest}
+board = ${common.board_1m}
+platform_packages =
+    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+build_flags = ${common.build_flags_1m0m}
+
+[env:esp8266-git-2m-base]
+platform = ${common.platform_latest}
+board = ${common.board_2m}
+platform_packages =
+    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+build_flags = ${common.build_flags_2m1m}
+
+[env:esp8266-git-4m-base]
+platform = ${common.platform_latest}
+board = ${common.board_4m}
+platform_packages =
+    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+build_flags = ${common.build_flags_4m1m}
+
 # ------------------------------------------------------------------------------
 # ESPURNA CORE BUILDS
 # ------------------------------------------------------------------------------
 
 [env:espurna-core-1MB]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DESPURNA_CORE
+extends = env:esp8266-1m-base
+src_build_flags = -DESPURNA_CORE
 
 [env:espurna-core-2MB]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DESPURNA_CORE
+extends = env:esp8266-2m-base
+src_build_flags = -DESPURNA_CORE
 
 [env:espurna-core-4MB]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DESPURNA_CORE
+extends = env:esp8266-4m-base
+src_build_flags = -DESPURNA_CORE
 
 [env:espurna-core-smartconfig-1MB]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+extends = env:esp8266-1m-base
+build_flags = ${env:espurna-core-1MB.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-smartconfig-2MB]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+extends = env:esp8266-2m-base
+build_flags = ${env:espurna-core-2MB.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-smartconfig-4MB]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+extends = env:esp8266-4m-base
+build_flags = ${env:espurna-core-4MB.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-wps-1MB]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_WPS=1
+extends = env:esp8266-1m-base
+build_flags = ${env:espurna-core-1MB.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 [env:espurna-core-wps-2MB]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_WPS=1
+extends = env:esp8266-2m-base
+build_flags = ${env:espurna-core-2MB.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 [env:espurna-core-wps-4MB]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DESPURNA_CORE -DJUSTWIFI_ENABLE_WPS=1
+extends = env:esp8266-4m-base
+build_flags = ${env:espurna-core-4MB.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 # ------------------------------------------------------------------------------
-# ESPURNA BASE BUILDS
+# ESPURNA BASE BUILD (CORE with WebUI, tuya-convert)
 # ------------------------------------------------------------------------------
 
 [env:espurna-base-1MB]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DESPURNA_BASE
-
-# ------------------------------------------------------------------------------
-# GENERIC OTA ENVIRONMENTS
-# ------------------------------------------------------------------------------
-
-[env:esp8266-1m-ota]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m}
-
-[env:esp8266-2m-ota]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m}
-
-[env:esp8266-4m-ota]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m}
-
-[env:esp8266-latest-1m-ota]
-platform = ${common.platform_latest}
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m}
-
-[env:esp8266-latest-2m-ota]
-platform = ${common.platform_latest}
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m}
-
-[env:esp8266-latest-4m-ota]
-platform = ${common.platform_latest}
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m}
-
-[env:esp8266-git-1m-ota]
-platform = ${common.arduino_core_git}
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m}
-
-[env:esp8266-git-2m-ota]
-platform = ${common.arduino_core_git}
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m}
-
-[env:esp8266-git-4m-ota]
-platform = ${common.arduino_core_git}
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m}
-
-# ------------------------------------------------------------------------------
-# SPECIAL BUILDS - DO. NOT. USE. ever ---
-# ------------------------------------------------------------------------------
-
-[env:travis-2_3_0]
-platform = ${common.arduino_core_2_3_0}
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m}
-
-[env:travis-latest]
-platform = ${common.platform_latest}
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m}
-
-[env:travis-git]
-platform = ${common.arduino_core_git}
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m}
+extends = env:esp8266-1m-base
+src_build_flags = -DESPURNA_BASE
 
 # ------------------------------------------------------------------------------
 # DEVELOPMENT BOARDS
 # ------------------------------------------------------------------------------
 
 [env:wemos-d1mini]
+extends = env:esp8266-4m-base
 board = d1_mini
-build_flags = ${common.build_flags_4m1m} -DWEMOS_D1_MINI -DDEBUG_FAUXMO=Serial -DNOWSAUTH
+src_build_flags = -DWEMOS_D1_MINI -DNOWSAUTH
 
 [env:wemos-d1mini-relayshield]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DWEMOS_D1_MINI_RELAYSHIELD -DDEBUG_FAUXMO=Serial -DNOWSAUTH
-
-[env:wemos-d1mini-relayshield-ssl]
-platform = ${common.platform_latest}
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DWEMOS_D1_MINI_RELAYSHIELD -DDEBUG_FAUXMO=Serial -DNOWSAUTH -DASYNC_TCP_SSL_ENABLED=1
+extends = env:esp8266-4m-base
+board = d1_mini
+src_build_flags = -DWEMOS_D1_MINI_RELAYSHIELD -DNOWSAUTH
 
 [env:nodemcu-lolin]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DNODEMCU_LOLIN -DDEBUG_FAUXMO=Serial -DNOWSAUTH
+extends = env:esp8266-4m-base
+src_build_flags = -DNODEMCU_LOLIN -DNOWSAUTH
 
 [env:nodemcu-lolin-latest]
-platform = ${common.platform_latest}
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DNODEMCU_LOLIN -DDEBUG_FAUXMO=Serial -DNOWSAUTH
+extends = env:esp8266-latest-4m-base
+src_build_flags = -DNODEMCU_LOLIN -DNOWSAUTH
 
-[env:nodemcu-lolin-ssl]
-platform = ${common.platform_latest}
-board = ${common.board_4m}
+[env:nodemcu-lolin-secure-client-asynctcp]
+extends = env:esp8266-latest-4m-base
 build_flags =
-	${common.build_flags_4m1m}
-	-DDEBUG_FAUXMO=Serial
+	${env:esp8266-latest-4m-base.build_flags}
 	-DASYNC_TCP_SSL_ENABLED=1
-src_build_flags =
-	-DNODEMCU_LOLIN -DNOWSAUTH
+src_build_flags = -DNODEMCU_LOLIN -DNOWSAUTH
 
 [env:nodemcu-lolin-secure-client]
-platform = ${common.platform_latest}
-board = ${common.board_4m}
+extends = env:esp8266-latest-4m-base
 board_build.f_cpu = 160000000
-build_flags =
-	${common.build_flags_4m1m}
-	-DDEBUG_FAUXMO=Serial
 src_build_flags =
 	-DNODEMCU_LOLIN -DNOWSAUTH
 	-DSECURE_CLIENT=SECURE_CLIENT_BEARSSL
@@ -303,664 +268,678 @@ src_build_flags =
 # ------------------------------------------------------------------------------
 
 [env:tinkerman-espurna-h06]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DTINKERMAN_ESPURNA_H06
+extends = env:esp8266-latest-4m-base
+src_build_flags = -DTINKERMAN_ESPURNA_H06
 
 [env:tinkerman-espurna-h08]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DTINKERMAN_ESPURNA_H08
+extends = env:esp8266-latest-4m-base
+src_build_flags = -DTINKERMAN_ESPURNA_H08
 
 [env:tinkerman-espurna-switch]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DTINKERMAN_ESPURNA_SWITCH
+extends = env:esp8266-latest-4m-base
+src_build_flags = -DTINKERMAN_ESPURNA_SWITCH
 
 [env:wemos-d1-tarpunashield]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DWEMOS_D1_TARPUNA_SHIELD
+extends = env:esp8266-latest-4m-base
+src_build_flags = -DWEMOS_D1_TARPUNA_SHIELD
 
 [env:tinkerman-rfm69gw]
+extends = env:esp8266-latest-4m-base
 board = esp12e
-build_flags = ${common.build_flags_4m1m} -DTINKERMAN_RFM69GW -DNOWSAUTH
+src_build_flags = -DTINKERMAN_RFM69GW -DNOWSAUTH
 
 [env:nodemcu-pzem004t]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DNODEMCU_BASIC -DDEBUG_SERIAL_SUPPORT=0 -DPZEM004T_SUPPORT=1 -DDISABLE_POSTMORTEM_STACKDUMP
+extends = env:esp8266-latest-4m-base
+src_build_flags =
+    -DDEBUG_SERIAL_SUPPORT=0
+    -DPZEM004T_SUPPORT=1
+    -DDISABLE_POSTMORTEM_STACKDUMP
+    -DNODEMCU_BASIC
+
+[env:esp01-pzem004t]
+extends = env:esp8266-latest-1m-base
+src_build_flags =
+    -DDEBUG_SERIAL_SUPPORT=0
+    -DPZEM004T_SUPPORT=1
+    -DDISABLE_POSTMORTEM_STACKDUMP
+    -DNODEMCU_BASIC
 
 [env:foxel-lightfox-dual]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DFOXEL_LIGHTFOX_DUAL -DDISABLE_POSTMORTEM_STACKDUMP
-
-
-# ------------------------------------------------------------------------------
-
-[env:itead-sonoff-basic]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_BASIC
-
-[env:itead-sonoff-basic-dht]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_BASIC -DDHT_SUPPORT=1
-
-[env:itead-sonoff-basic-r2-dht]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_BASIC -DDHT_SUPPORT=1 -DDHT_PIN=2
-
-[env:itead-sonoff-basic-dallas]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_BASIC -DDALLAS_SUPPORT=1
-
-[env:itead-sonoff-basic-r2-dallas]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_BASIC -DDALLAS_SUPPORT=1 -DDALLAS_PIN=2
-
-[env:itead-sonoff-rf]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_RF
-
-[env:itead-sonoff-mini]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_MINI
-
-[env:itead-sonoff-th]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_TH
-
-[env:itead-sonoff-pow]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_POW
-
-[env:itead-sonoff-pow-r2]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_POW_R2 -DDISABLE_POSTMORTEM_STACKDUMP
-
-[env:itead-sonoff-dual]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_DUAL -DDISABLE_POSTMORTEM_STACKDUMP
-
-[env:itead-sonoff-dual-r2]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_DUAL_R2
-
-[env:itead-sonoff-4ch]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_4CH
-
-[env:itead-sonoff-4ch-pro]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_4CH_PRO
-
-[env:itead-sonoff-touch]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_TOUCH
-
-[env:itead-sonoff-b1]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_B1
-
-[env:itead-sonoff-t1-1ch]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_T1_1CH
-
-[env:itead-sonoff-t1-2ch]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_T1_2CH
-
-[env:itead-sonoff-t1-3ch]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_T1_3CH
-
-[env:itead-sonoff-led]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_LED
-
-[env:itead-sonoff-rfbridge]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_RFBRIDGE -DDISABLE_POSTMORTEM_STACKDUMP
-
-[env:itead-sonoff-rfbridge-direct]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_RFBRIDGE -DRFB_DIRECT
-
-# ------------------------------------------------------------------------------
-
-[env:itead-slampher]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SLAMPHER
-
-[env:itead-s20]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_S20
-
-[env:itead-1ch-inching]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_1CH_INCHING
-
-[env:itead-motor]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_MOTOR
-
-[env:itead-sonoff-sv]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_SV
-
-[env:itead-sonoff-s31]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_S31 -DDISABLE_POSTMORTEM_STACKDUMP
-
-[env:itead-sonoff-s31-lite]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_S31_LITE
-
-[env:itead-sonoff-ifan02]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_SONOFF_IFAN02
-
-# ------------------------------------------------------------------------------
-
-[env:electrodragon-wifi-iot]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DELECTRODRAGON_WIFI_IOT -DDHT_SUPPORT=1
-
-[env:workchoice-ecoplug]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DWORKCHOICE_ECOPLUG
-
-[env:jangoe-wifi-relay-nc]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DJANGOE_WIFI_RELAY_NC
-
-[env:jangoe-wifi-relay-no]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DJANGOE_WIFI_RELAY_NO
-
-[env:openenergymonitor-mqtt-relay]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DOPENENERGYMONITOR_MQTT_RELAY -DDALLAS_SUPPORT=1
-
-[env:jorgegarcia-wifi-relays]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DJORGEGARCIA_WIFI_RELAYS
-
-[env:aithinker-ai-light]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DAITHINKER_AI_LIGHT
-
-[env:lyasi-rgb-light]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLYASI_LIGHT
-
-[env:magichome-led-controller]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAGICHOME_LED_CONTROLLER
-
-[env:magichome-led-controller-20]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAGICHOME_LED_CONTROLLER_20
-
-[env:magichome-zj-wfmn-a-11]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_WFMN_A_11
-
-[env:magichome-zj-wfmn-b-11]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_WFMN_B_11
-
-[env:magichome-zj-espm-5ch-b-13]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_ESPM_5CH_B_13
-
-[env:magichome-zj-lb-rgbww-l]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_LB_RGBWW_L
-
-[env:magichome-zj-wfmn-c-11]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAGICHOME_ZJ_WFMN_C_11
-
-[env:huacanxing-h801]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DHUACANXING_H801
-
-[env:huacanxing-h802]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DHUACANXING_H802
-
-[env:arilux-al-lc01]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DARILUX_AL_LC01
-
-[env:arilux-al-lc02]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DARILUX_AL_LC02
-
-[env:arilux-al-lc02-v14]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DARILUX_AL_LC02_V14
-
-[env:arilux-al-lc06]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DARILUX_AL_LC06
-
-[env:arilux-al-lc11]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DARILUX_AL_LC11
-
-[env:arilux-e27]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DARILUX_E27
-
-[env:itead-bnsz01]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DITEAD_BNSZ01
-
-[env:wion-50055]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DWION_50055
-
-[env:exs-wifi-relay-v31]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DEXS_WIFI_RELAY_V31
-
-[env:exs-wifi-relay-v50]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DEXS_WIFI_RELAY_V50
-
-[env:wemos-v9261f]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DGENERIC_V9261F
-
-[env:esp01-v9261f]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_V9261F
-
-[env:wemos-ech1560]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DGENERIC_ECH1560
-
-[env:esp01-ech1560]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_ECH1560
-
-[env:mancavemade-esplive]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DMANCAVEMADE_ESPLIVE
-
-[env:tuya-generic-dimmer]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTUYA_GENERIC_DIMMER -DDEBUG_SERIAL_SUPPORT=0 -DDISABLE_POSTMORTEM_STACKDUMP
-
-[env:intermittech-quinled]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DINTERMITTECH_QUINLED
-
-[env:xenon-sm-pw702u]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DXENON_SM_PW702U
-
-[env:iselector-sm-pw702]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DISELECTOR_SM_PW702
-
-[env:authometion-lyt8266]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DAUTHOMETION_LYT8266
-
-[env:kmc-70011]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DKMC_70011
-
-[env:yjzk-switch-1ch]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DYJZK_SWITCH_1CH
-
-[env:yjzk-switch-2ch]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DYJZK_SWITCH_2CH
-
-[env:yjzk-switch-3ch]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DYJZK_SWITCH_3CH
-
-[env:generic-8ch]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DGENERIC_8CH
-
-[env:gizwits-witty-cloud]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DGIZWITS_WITTY_CLOUD
-
-[env:euromate-wifi-stecker-shuko]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DEUROMATE_WIFI_STECKER_SCHUKO
-
-[env:euromate-wifi-stecker-shuko-v2]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DEUROMATE_WIFI_STECKER_SCHUKO_V2
-
-[env:tonbux-powerstrip02]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTONBUX_POWERSTRIP02
-
-[env:lingan-swa1]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLINGAN_SWA1
-
-[env:stm-relay]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DSTM_RELAY -DDISABLE_POSTMORTEM_STACKDUMP
-
-[env:heygo-hy02]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DHEYGO_HY02
-
-[env:maxcio-wus002s]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAXCIO_WUS002S
-
-[env:maxcio-wde004]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAXCIO_WDE004
-
-[env:maxcio-wuk007s]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMAXCIO_WUK007S
-
-[env:yidian-xsssa05]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DYIDIAN_XSSSA05
-
-[env:oukitel-p1]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DOUKITEL_P1
-
-[env:tonbux-xsssa01]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_4m1m} -DTONBUX_XSSSA01
-
-[env:tonbux-xsssa06]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTONBUX_XSSSA06
-
-[env:green-esp8266relay]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DGREEN_ESP8266RELAY
-
-[env:ike-espike]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DIKE_ESPIKE
-
-[env:arniex-swifitch]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DARNIEX_SWIFITCH
-
-[env:zhilde-eu44-w]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DZHILDE_EU44_W
-
-[env:luani-hvio]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLUANI_HVIO
-
-[env:avatto-power-plug-wifi]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DAVATTO_NAS_WR01W
-
-[env:neo-coolcam-power-plug-wifi]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DNEO_COOLCAM_NAS_WR01W
-
-[env:deltaco-sh-p01]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_P01
-
-[env:deltaco-sh-p03usb]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_P03USB
-
-[env:deltaco-sh-lexxw]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXW
-
-[env:deltaco-sh-lexxrgb]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DDELTACO_SH_LEXXRGB
-
-[env:estink-wifi-power-strip]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DFORNORM_ZLD_34EU
-
-[env:iwoole-led-table-lamp]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DIWOOLE_LED_TABLE_LAMP
-
-[env:lombex-lux-nova2-tunable-white]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLOMBEX_LUX_NOVA2_TUNABLE_WHITE
-
-[env:lombex-lux-nova2-white-color]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLOMBEX_LUX_NOVA2_WHITE_COLOR
+extends = env:esp8266-1m-base
+src_build_flags = 
+    -DFOXEL_LIGHTFOX_DUAL
+    -DDISABLE_POSTMORTEM_STACKDUMP
 
 # ------------------------------------------------------------------------------
 # GENERIC / DEVELOPMENT BOARDS
 # ------------------------------------------------------------------------------
 
 [env:generic-esp01s-relay-40]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_ESP01S_RELAY_V40
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_ESP01S_RELAY_V40
 
 [env:generic-esp01s-relay-40-inv]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_ESP01S_RELAY_V40 -DRELAY1_TYPE=1
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_ESP01S_RELAY_V40 -DRELAY1_TYPE=1
 
 [env:generic-esp01s-rgbled-10]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_ESP01S_RGBLED_V10
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_ESP01S_RGBLED_V10
 
 [env:generic-esp01s-dht11-10]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_ESP01S_DHT11_V10
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_ESP01S_DHT11_V10
 
 [env:generic-esp01s-ds18b20-10]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_ESP01S_DS18B20_V10
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_ESP01S_DS18B20_V10
+
+# ------------------------------------------------------------------------------
+# ITEAD SONOFF
+# ------------------------------------------------------------------------------
+
+[env:itead-sonoff-basic]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_BASIC
+
+[env:itead-sonoff-basic-dht]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_BASIC -DDHT_SUPPORT=1
+
+[env:itead-sonoff-basic-r2-dht]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_BASIC -DDHT_SUPPORT=1 -DDHT_PIN=2
+
+[env:itead-sonoff-basic-dallas]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_BASIC -DDALLAS_SUPPORT=1
+
+[env:itead-sonoff-basic-r2-dallas]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_BASIC -DDALLAS_SUPPORT=1 -DDALLAS_PIN=2
+
+[env:itead-sonoff-rf]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_RF
+
+[env:itead-sonoff-mini]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_MINI
+
+[env:itead-sonoff-th]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_TH
+
+[env:itead-sonoff-pow]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_POW
+
+[env:itead-sonoff-pow-r2]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_POW_R2 -DDISABLE_POSTMORTEM_STACKDUMP
+
+[env:itead-sonoff-dual]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_DUAL -DDISABLE_POSTMORTEM_STACKDUMP
+
+[env:itead-sonoff-dual-r2]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_DUAL_R2
+
+[env:itead-sonoff-4ch]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_4CH
+
+[env:itead-sonoff-4ch-pro]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_4CH_PRO
+
+[env:itead-sonoff-touch]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_TOUCH
+
+[env:itead-sonoff-b1]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_B1
+
+[env:itead-sonoff-t1-1ch]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_T1_1CH
+
+[env:itead-sonoff-t1-2ch]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_T1_2CH
+
+[env:itead-sonoff-t1-3ch]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_T1_3CH
+
+[env:itead-sonoff-led]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_LED
+
+[env:itead-sonoff-rfbridge]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_RFBRIDGE -DDISABLE_POSTMORTEM_STACKDUMP
+
+[env:itead-sonoff-rfbridge-direct]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_RFBRIDGE -DRFB_DIRECT
+
+[env:itead-slampher]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SLAMPHER
+
+[env:itead-s20]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_S20
+
+[env:itead-1ch-inching]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_1CH_INCHING
+
+[env:itead-motor]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_MOTOR
+
+[env:itead-sonoff-sv]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_SV
+
+[env:itead-sonoff-s31]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_S31 -DDISABLE_POSTMORTEM_STACKDUMP
+
+[env:itead-sonoff-s31-lite]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_S31_LITE
+
+[env:itead-sonoff-ifan02]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_SONOFF_IFAN02
+
+# ------------------------------------------------------------------------------
+
+[env:electrodragon-wifi-iot]
+extends = env:esp8266-4m-base
+src_build_flags = -DELECTRODRAGON_WIFI_IOT -DDHT_SUPPORT=1
+
+[env:workchoice-ecoplug]
+extends = env:esp8266-1m-base
+src_build_flags = -DWORKCHOICE_ECOPLUG
+
+[env:jangoe-wifi-relay-nc]
+extends = env:esp8266-4m-base
+src_build_flags = -DJANGOE_WIFI_RELAY_NC
+
+[env:jangoe-wifi-relay-no]
+extends = env:esp8266-4m-base
+src_build_flags = -DJANGOE_WIFI_RELAY_NO
+
+[env:openenergymonitor-mqtt-relay]
+extends = env:esp8266-4m-base
+src_build_flags = -DOPENENERGYMONITOR_MQTT_RELAY -DDALLAS_SUPPORT=1
+
+[env:jorgegarcia-wifi-relays]
+extends = env:esp8266-1m-base
+src_build_flags = -DJORGEGARCIA_WIFI_RELAYS
+
+[env:aithinker-ai-light]
+extends = env:esp8266-1m-base
+src_build_flags = -DAITHINKER_AI_LIGHT
+
+[env:lyasi-rgb-light]
+extends = env:esp8266-1m-base
+src_build_flags = -DLYASI_LIGHT
+
+[env:magichome-led-controller]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAGICHOME_LED_CONTROLLER
+
+[env:magichome-led-controller-20]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAGICHOME_LED_CONTROLLER_20
+
+[env:magichome-zj-wfmn-a-11]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAGICHOME_ZJ_WFMN_A_11
+
+[env:magichome-zj-wfmn-b-11]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAGICHOME_ZJ_WFMN_B_11
+
+[env:magichome-zj-espm-5ch-b-13]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAGICHOME_ZJ_ESPM_5CH_B_13
+
+[env:magichome-zj-lb-rgbww-l]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAGICHOME_ZJ_LB_RGBWW_L
+
+[env:magichome-zj-wfmn-c-11]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAGICHOME_ZJ_WFMN_C_11
+
+[env:huacanxing-h801]
+extends = env:esp8266-1m-base
+src_build_flags = -DHUACANXING_H801
+
+[env:huacanxing-h802]
+extends = env:esp8266-1m-base
+src_build_flags = -DHUACANXING_H802
+
+[env:arilux-al-lc01]
+extends = env:esp8266-1m-base
+src_build_flags = -DARILUX_AL_LC01
+
+[env:arilux-al-lc02]
+extends = env:esp8266-1m-base
+src_build_flags = -DARILUX_AL_LC02
+
+[env:arilux-al-lc02-v14]
+extends = env:esp8266-1m-base
+src_build_flags = -DARILUX_AL_LC02_V14
+
+[env:arilux-al-lc06]
+extends = env:esp8266-1m-base
+src_build_flags = -DARILUX_AL_LC06
+
+[env:arilux-al-lc11]
+extends = env:esp8266-1m-base
+src_build_flags = -DARILUX_AL_LC11
+
+[env:arilux-e27]
+extends = env:esp8266-1m-base
+src_build_flags = -DARILUX_E27
+
+[env:itead-bnsz01]
+extends = env:esp8266-1m-base
+src_build_flags = -DITEAD_BNSZ01
+
+[env:wion-50055]
+extends = env:esp8266-1m-base
+src_build_flags = -DWION_50055
+
+[env:exs-wifi-relay-v31]
+extends = env:esp8266-4m-base
+src_build_flags = -DEXS_WIFI_RELAY_V31
+
+[env:exs-wifi-relay-v50]
+extends = env:esp8266-4m-base
+src_build_flags = -DEXS_WIFI_RELAY_V50
+
+[env:wemos-v9261f]
+extends = env:esp8266-4m-base
+src_build_flags = -DGENERIC_V9261F
+
+[env:esp01-v9261f]
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_V9261F
+
+[env:wemos-ech1560]
+extends = env:esp8266-4m-base
+src_build_flags = -DGENERIC_ECH1560
+
+[env:esp01-ech1560]
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_ECH1560
+
+[env:mancavemade-esplive]
+extends = env:esp8266-4m-base
+src_build_flags = -DMANCAVEMADE_ESPLIVE
+
+[env:tuya-generic-dimmer]
+extends = env:esp8266-1m-base
+src_build_flags = -DTUYA_GENERIC_DIMMER -DDEBUG_SERIAL_SUPPORT=0 -DDISABLE_POSTMORTEM_STACKDUMP
+
+[env:intermittech-quinled]
+extends = env:esp8266-1m-base
+src_build_flags = -DINTERMITTECH_QUINLED
+
+[env:xenon-sm-pw702u]
+extends = env:esp8266-1m-base
+src_build_flags = -DXENON_SM_PW702U
+
+[env:iselector-sm-pw702]
+extends = env:esp8266-1m-base
+src_build_flags = -DISELECTOR_SM_PW702
+
+[env:authometion-lyt8266]
+extends = env:esp8266-1m-base
+src_build_flags = -DAUTHOMETION_LYT8266
+
+[env:kmc-70011]
+extends = env:esp8266-1m-base
+src_build_flags = -DKMC_70011
+
+[env:yjzk-switch-1ch]
+extends = env:esp8266-1m-base
+src_build_flags = -DYJZK_SWITCH_1CH
+
+[env:yjzk-switch-2ch]
+extends = env:esp8266-1m-base
+src_build_flags = -DYJZK_SWITCH_2CH
+
+[env:yjzk-switch-3ch]
+extends = env:esp8266-1m-base
+src_build_flags = -DYJZK_SWITCH_3CH
+
+[env:generic-8ch]
+extends = env:esp8266-4m-base
+src_build_flags = -DGENERIC_8CH
+
+[env:gizwits-witty-cloud]
+extends = env:esp8266-4m-base
+src_build_flags = -DGIZWITS_WITTY_CLOUD
+
+[env:euromate-wifi-stecker-shuko]
+extends = env:esp8266-1m-base
+src_build_flags = -DEUROMATE_WIFI_STECKER_SCHUKO
+
+[env:euromate-wifi-stecker-shuko-v2]
+extends = env:esp8266-2m-base
+src_build_flags = -DEUROMATE_WIFI_STECKER_SCHUKO_V2
+
+[env:tonbux-powerstrip02]
+extends = env:esp8266-1m-base
+src_build_flags = -DTONBUX_POWERSTRIP02
+
+[env:lingan-swa1]
+extends = env:esp8266-1m-base
+src_build_flags = -DLINGAN_SWA1
+
+[env:stm-relay]
+extends = env:esp8266-1m-base
+src_build_flags = -DSTM_RELAY -DDISABLE_POSTMORTEM_STACKDUMP
+
+[env:heygo-hy02]
+extends = env:esp8266-1m-base
+src_build_flags = -DHEYGO_HY02
+
+[env:maxcio-wus002s]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAXCIO_WUS002S
+
+[env:maxcio-wde004]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAXCIO_WDE004
+
+[env:maxcio-wuk007s]
+extends = env:esp8266-1m-base
+src_build_flags = -DMAXCIO_WUK007S
+
+[env:yidian-xsssa05]
+extends = env:esp8266-1m-base
+src_build_flags = -DYIDIAN_XSSSA05
+
+[env:oukitel-p1]
+extends = env:esp8266-1m-base
+src_build_flags = -DOUKITEL_P1
+
+[env:tonbux-xsssa01]
+extends = env:esp8266-1m-base
+src_build_flags = -DTONBUX_XSSSA01
+
+[env:tonbux-xsssa06]
+extends = env:esp8266-1m-base
+src_build_flags = -DTONBUX_XSSSA06
+
+[env:green-esp8266relay]
+extends = env:esp8266-4m-base
+src_build_flags = -DGREEN_ESP8266RELAY
+
+[env:ike-espike]
+extends = env:esp8266-4m-base
+src_build_flags = -DIKE_ESPIKE
+
+[env:arniex-swifitch]
+extends = env:esp8266-4m-base
+src_build_flags = -DARNIEX_SWIFITCH
+
+[env:zhilde-eu44-w]
+extends = env:esp8266-1m-base
+src_build_flags = -DZHILDE_EU44_W
+
+[env:luani-hvio]
+extends = env:esp8266-1m-base
+src_build_flags = -DLUANI_HVIO
+
+[env:avatto-power-plug-wifi]
+extends = env:esp8266-1m-base
+src_build_flags = -DAVATTO_NAS_WR01W
+
+[env:neo-coolcam-power-plug-wifi]
+extends = env:esp8266-1m-base
+src_build_flags = -DNEO_COOLCAM_NAS_WR01W
+
+[env:deltaco-sh-p01]
+extends = env:esp8266-1m-base
+src_build_flags = -DDELTACO_SH_P01
+
+[env:deltaco-sh-p03usb]
+extends = env:esp8266-1m-base
+src_build_flags = -DDELTACO_SH_P03USB
+
+[env:deltaco-sh-lexxw]
+extends = env:esp8266-1m-base
+src_build_flags = -DDELTACO_SH_LEXXW
+
+[env:deltaco-sh-lexxrgb]
+extends = env:esp8266-1m-base
+src_build_flags = -DDELTACO_SH_LEXXRGB
+
+[env:estink-wifi-power-strip]
+extends = env:esp8266-1m-base
+src_build_flags = -DFORNORM_ZLD_34EU
+
+[env:iwoole-led-table-lamp]
+extends = env:esp8266-1m-base
+src_build_flags = -DIWOOLE_LED_TABLE_LAMP
+
+[env:lombex-lux-nova2-tunable-white]
+extends = env:esp8266-1m-base
+src_build_flags = -DLOMBEX_LUX_NOVA2_TUNABLE_WHITE
+
+[env:lombex-lux-nova2-white-color]
+extends = env:esp8266-1m-base
+src_build_flags = -DLOMBEX_LUX_NOVA2_WHITE_COLOR
 
 [env:heltec-touch-relay]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DHELTEC_TOUCHRELAY
+extends = env:esp8266-1m-base
+src_build_flags = -DHELTEC_TOUCHRELAY
 
 [env:allnet-4duino-iot-wlan-relais]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DALLNET_4DUINO_IOT_WLAN_RELAIS
+extends = env:esp8266-4m-base
+src_build_flags = -DALLNET_4DUINO_IOT_WLAN_RELAIS
 
 [env:tonbux-mosquito-killer]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTONBUX_MOSQUITO_KILLER
+extends = env:esp8266-1m-base
+src_build_flags = -DTONBUX_MOSQUITO_KILLER
 
 [env:pilotak-esp-din-v1]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DPILOTAK_ESP_DIN_V1
+extends = env:esp8266-1m-base
+src_build_flags = -DPILOTAK_ESP_DIN_V1
 
 [env:nodemcu-geiger]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DNODEMCU_BASIC -DGEIGER_SUPPORT=1 -DEVENTS_SUPPORT=0 -DINFLUXDB_SUPPORT=1 -DALEXA_SUPPORT=0 -DALEXA_ENABLED=0
+extends = env:esp8266-4m-base
+src_build_flags = -DNODEMCU_BASIC -DGEIGER_SUPPORT=1 -DEVENTS_SUPPORT=0 -DINFLUXDB_SUPPORT=1 -DALEXA_SUPPORT=0 -DALEXA_ENABLED=0
 
 [env:blitzwolf-bwshpx]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DBLITZWOLF_BWSHPX
+extends = env:esp8266-1m-base
+src_build_flags = -DBLITZWOLF_BWSHPX
 
 [env:blitzwolf-bwshpx-v23]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DBLITZWOLF_BWSHPX_V23
+extends = env:esp8266-1m-base
+src_build_flags = -DBLITZWOLF_BWSHPX_V23
 
 [env:blitzwolf-bwshp5]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DBLITZWOLF_BWSHP5
+extends = env:esp8266-1m-base
+src_build_flags = -DBLITZWOLF_BWSHP5
 
 [env:teckin-sp21]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTECKIN_SP21
+extends = env:esp8266-1m-base
+src_build_flags = -DTECKIN_SP21
 
 [env:teckin-sp22-v14]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTECKIN_SP22_V14
+extends = env:esp8266-1m-base
+src_build_flags = -DTECKIN_SP22_V14
 
 [env:teckin-sp23-v13]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTECKIN_SP23_V13
+extends = env:esp8266-1m-base
+src_build_flags = -DTECKIN_SP23_V13
 
 [env:gosund-wp3]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGOSUND_WP3
+extends = env:esp8266-1m-base
+src_build_flags = -DGOSUND_WP3
 
 [env:gosund-ws1]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGOSUND_WS1
+extends = env:esp8266-1m-base
+src_build_flags = -DGOSUND_WS1
 
 [env:digoo-nx-sp202]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DDIGOO_NX_SP202
+extends = env:esp8266-1m-base
+src_build_flags = -DDIGOO_NX_SP202
 
 [env:tflag-nx-smx00]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTFLAG_NX_SMX00
+extends = env:esp8266-1m-base
+src_build_flags = -DTFLAG_NX_SMX00
 
 [env:homecube-16a]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DHOMECUBE_16A
+extends = env:esp8266-1m-base
+src_build_flags = -DHOMECUBE_16A
 
 [env:bh-onofre]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DBH_ONOFRE
+extends = env:esp8266-4m-base
+src_build_flags = -DBH_ONOFRE
 
 [env:generic-ag-l4]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_AG_L4
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_AG_L4
 
 [env:lohas-e27-9w]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLOHAS_E27_9W
+extends = env:esp8266-1m-base
+src_build_flags = -DLOHAS_E27_9W
 
 [env:lohas-e26-a19]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLOHAS_E26_A19
+extends = env:esp8266-1m-base
+src_build_flags = -DLOHAS_E26_A19
 
 [env:teckin-sb53]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTECKIN_SB53
+extends = env:esp8266-1m-base
+src_build_flags = -DTECKIN_SB53
 
 [env:allterco-shelly1]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DALLTERCO_SHELLY1
+extends = env:esp8266-2m-base
+src_build_flags = -DALLTERCO_SHELLY1
 
 [env:allterco-shelly2]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DALLTERCO_SHELLY2
+extends = env:esp8266-2m-base
+src_build_flags = -DALLTERCO_SHELLY2
 
 [env:allterco-shelly1pm]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DALLTERCO_SHELLY1PM
+extends = env:esp8266-2m-base
+src_build_flags = -DALLTERCO_SHELLY1PM
 
 [env:allterco-shelly25]
-board = ${common.board_2m}
-build_flags = ${common.build_flags_2m1m} -DALLTERCO_SHELLY25
+extends = env:esp8266-2m-base
+src_build_flags = -DALLTERCO_SHELLY25
 
 [env:xiaomi-smart-desk-lamp]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DXIAOMI_SMART_DESK_LAMP
+extends = env:esp8266-1m-base
+src_build_flags = -DXIAOMI_SMART_DESK_LAMP
 
 [env:phyx-esp12-rgb]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DPHYX_ESP12_RGB
+extends = env:esp8266-1m-base
+src_build_flags = -DPHYX_ESP12_RGB
 
 [env:bestek-mrj1011]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DBESTEK_MRJ1011
+extends = env:esp8266-1m-base
+src_build_flags = -DBESTEK_MRJ1011
 
 [env:gblife-rgbw-socket]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGBLIFE_RGBW_SOCKET
+extends = env:esp8266-1m-base
+src_build_flags = -DGBLIFE_RGBW_SOCKET
 
 [env:smartlife-mini-smart-socket]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DSMARTLIFE_MINI_SMART_SOCKET
+extends = env:esp8266-1m-base
+src_build_flags = -DSMARTLIFE_MINI_SMART_SOCKET
 
 [env:hama-wifi-steckdose-00176533]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DHAMA_WIFI_STECKDOSE_00176533
+extends = env:esp8266-1m-base
+src_build_flags = -DHAMA_WIFI_STECKDOSE_00176533
 
 [env:teckin-sp20]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DTECKIN_SP20
+extends = env:esp8266-1m-base
+src_build_flags = -DTECKIN_SP20
 
 [env:litesun-la-wf3]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLITESUN_LA_WF3
+extends = env:esp8266-1m-base
+src_build_flags = -DLITESUN_LA_WF3
 
 [env:generic-gu10]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_GU10
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_GU10
 
 [env:generic-e14]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DGENERIC_E14
+extends = env:esp8266-1m-base
+src_build_flags = -DGENERIC_E14
 
 [env:nexete-a19]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DNEXETE_A19
+extends = env:esp8266-1m-base
+src_build_flags = -DNEXETE_A19
 
 [env:psh-wifi-plug]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DPSH_WIFI_PLUG
+extends = env:esp8266-1m-base
+src_build_flags = -DPSH_WIFI_PLUG
 
 [env:psh-rgbw-controller]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DPSH_RGBW_CONTROLLER
+extends = env:esp8266-4m-base
+src_build_flags = -DPSH_RGBW_CONTROLLER
 
 [env:psh-wifi-sensor]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DPSH_WIFI_SENSOR
+extends = env:esp8266-4m-base
+src_build_flags = -DPSH_WIFI_SENSOR
 
 [env:jinvoo-valve-sm-aw713]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DJINVOO_VALVE_SM_AW713
+extends = env:esp8266-1m-base
+src_build_flags = -DJINVOO_VALVE_SM_AW713
 
 [env:etekcity-esw01-usa]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DETEKCITY_ESW01_USA
+extends = env:esp8266-1m-base
+src_build_flags = -DETEKCITY_ESW01_USA
 
 [env:fs-uap1]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DFS_UAP1
+extends = env:esp8266-4m-base
+src_build_flags = -DFS_UAP1
 
 [env:muvit-io-miobulb001]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DMUVIT_IO_MIOBULB001
+extends = env:esp8266-1m-base
+src_build_flags = -DMUVIT_IO_MIOBULB001
 
 [env:hykker-smart-home-power-plug]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DHYKKER_SMART_HOME_POWER_PLUG
+extends = env:esp8266-1m-base
+src_build_flags = -DHYKKER_SMART_HOME_POWER_PLUG
 
 [env:kogan-smarter-home-plug-w-pow]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DKOGAN_SMARTER_HOME_PLUG_W_POW
+extends = env:esp8266-1m-base
+src_build_flags = -DKOGAN_SMARTER_HOME_PLUG_W_POW
 
 [env:lsc-smart-led-light-strip]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DLSC_SMART_LED_LIGHT_STRIP
+extends = env:esp8266-1m-base
+src_build_flags = -DLSC_SMART_LED_LIGHT_STRIP
 
 [env:linksprite-linknode-r4]
-board = ${common.board_4m}
-build_flags = ${common.build_flags_4m1m} -DLINKSPRITE_LINKNODE_R4
+extends = env:esp8266-4m-base
+src_build_flags = -DLINKSPRITE_LINKNODE_R4
 
 [env:ehomediy-wt02]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DEHOMEDIY_WT02
+extends = env:esp8266-1m-base
+src_build_flags = -DEHOMEDIY_WT02
 
 [env:ehomediy-wt03]
-board = ${common.board_1m}
-build_flags = ${common.build_flags_1m0m} -DEHOMEDIY_WT03
+extends = env:esp8266-1m-base
+src_build_flags = -DEHOMEDIY_WT03
 
 [env:generic-esp01-512kb]
-board = ${common.board_512k}
-build_flags = ${common.build_flags_512k} -DGENERIC_ESP01_512KB
+extends = env:esp8266-512k-base
+src_build_flags = -DGENERIC_ESP01_512KB

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -75,7 +75,7 @@ shared_libdeps_dir = libraries/
 # COMMON SETTINGS:
 # ------------------------------------------------------------------------------
 [env]
-platform = ${common.platform_latest}
+platform = ${common.platform_2_3_0}
 framework = arduino
 board_build.flash_mode = dout
 monitor_speed = 115200
@@ -122,22 +122,18 @@ lib_ignore =
     AsyncTCP
 
 [env:esp8266-512k-base]
-platform = ${common.platform_2_3_0}
 board = ${common.board_512k}
 build_flags = ${common.build_flags_512k}
 
 [env:esp8266-1m-base]
-platform = ${common.platform_2_3_0}
 board = ${common.board_1m}
 build_flags = ${common.build_flags_1m0m}
 
 [env:esp8266-2m-base]
-platform = ${common.platform_2_3_0}
 board = ${common.board_2m}
 build_flags = ${common.build_flags_2m1m}
 
 [env:esp8266-4m-base]
-platform = ${common.platform_2_3_0}
 board = ${common.board_4m}
 build_flags = ${common.build_flags_4m1m}
 
@@ -195,27 +191,33 @@ src_build_flags = -DESPURNA_CORE
 
 [env:espurna-core-smartconfig-1MB]
 extends = env:esp8266-1m-base
-build_flags = ${env:espurna-core-1MB.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+src_build_flags = -DESPURNA_CORE
+build_flags = ${env:esp8266-1m-base.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-smartconfig-2MB]
 extends = env:esp8266-2m-base
-build_flags = ${env:espurna-core-2MB.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+src_build_flags = -DESPURNA_CORE
+build_flags = ${env:esp8266-2m-base.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-smartconfig-4MB]
 extends = env:esp8266-4m-base
-build_flags = ${env:espurna-core-4MB.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
+src_build_flags = -DESPURNA_CORE
+build_flags = ${env:esp8266-4m-base.build_flags} -DJUSTWIFI_ENABLE_SMARTCONFIG=1
 
 [env:espurna-core-wps-1MB]
 extends = env:esp8266-1m-base
-build_flags = ${env:espurna-core-1MB.build_flags} -DJUSTWIFI_ENABLE_WPS=1
+src_build_flags = -DESPURNA_CORE
+build_flags = ${env:esp8266-1m-base.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 [env:espurna-core-wps-2MB]
 extends = env:esp8266-2m-base
-build_flags = ${env:espurna-core-2MB.build_flags} -DJUSTWIFI_ENABLE_WPS=1
+src_build_flags = -DESPURNA_CORE
+build_flags = ${env:esp8266-2m-base.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 [env:espurna-core-wps-4MB]
 extends = env:esp8266-4m-base
-build_flags = ${env:espurna-core-4MB.build_flags} -DJUSTWIFI_ENABLE_WPS=1
+src_build_flags = -DESPURNA_CORE
+build_flags = ${env:esp8266-4m-base.build_flags} -DJUSTWIFI_ENABLE_WPS=1
 
 # ------------------------------------------------------------------------------
 # ESPURNA BASE BUILD (CORE with WebUI, tuya-convert)
@@ -288,22 +290,6 @@ extends = env:esp8266-latest-4m-base
 board = esp12e
 src_build_flags = -DTINKERMAN_RFM69GW -DNOWSAUTH
 
-[env:nodemcu-pzem004t]
-extends = env:esp8266-latest-4m-base
-src_build_flags =
-    -DDEBUG_SERIAL_SUPPORT=0
-    -DPZEM004T_SUPPORT=1
-    -DDISABLE_POSTMORTEM_STACKDUMP
-    -DNODEMCU_BASIC
-
-[env:esp01-pzem004t]
-extends = env:esp8266-latest-1m-base
-src_build_flags =
-    -DDEBUG_SERIAL_SUPPORT=0
-    -DPZEM004T_SUPPORT=1
-    -DDISABLE_POSTMORTEM_STACKDUMP
-    -DNODEMCU_BASIC
-
 [env:foxel-lightfox-dual]
 extends = env:esp8266-1m-base
 src_build_flags = 
@@ -313,6 +299,10 @@ src_build_flags =
 # ------------------------------------------------------------------------------
 # GENERIC / DEVELOPMENT BOARDS
 # ------------------------------------------------------------------------------
+
+[env:generic-esp01-512kb]
+extends = env:esp8266-512k-base
+src_build_flags = -DGENERIC_ESP01_512KB
 
 [env:generic-esp01s-relay-40]
 extends = env:esp8266-1m-base
@@ -333,6 +323,14 @@ src_build_flags = -DGENERIC_ESP01S_DHT11_V10
 [env:generic-esp01s-ds18b20-10]
 extends = env:esp8266-1m-base
 src_build_flags = -DGENERIC_ESP01S_DS18B20_V10
+
+[env:generic-esp01s-pzem004t]
+extends = env:esp8266-latest-1m-base
+src_build_flags = -DGENERIC_PZEM004T -DDISABLE_POSTMORTEM_STACKDUMP
+
+[env:generic-esp12e-pzem004t]
+extends = env:esp8266-latest-4m-base
+src_build_flags = -DGENERIC_PZEM004T -DDISABLE_POSTMORTEM_STACKDUMP
 
 # ------------------------------------------------------------------------------
 # ITEAD SONOFF
@@ -939,7 +937,3 @@ src_build_flags = -DEHOMEDIY_WT02
 [env:ehomediy-wt03]
 extends = env:esp8266-1m-base
 src_build_flags = -DEHOMEDIY_WT03
-
-[env:generic-esp01-512kb]
-extends = env:esp8266-512k-base
-src_build_flags = -DGENERIC_ESP01_512KB

--- a/code/scripts/espurna_utils/__init__.py
+++ b/code/scripts/espurna_utils/__init__.py
@@ -25,6 +25,7 @@ from .ldscripts import ldscripts_inject_libpath
 from .lwip import lwip_inject_patcher
 from .postmortem import dummy_ets_printf
 from .git import app_inject_revision
+from .release import copy_release
 from .flags import app_inject_flags
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "dummy_ets_printf",
     "app_inject_revision",
     "app_inject_flags",
+    "copy_release",
 ]

--- a/code/scripts/espurna_utils/copy_release.py
+++ b/code/scripts/espurna_utils/copy_release.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+
+def copy_release(target, source, env):
+    # target filename and subdir for release files
+    name = env["ESPURNA_NAME"]
+    version = env["ESPURNA_VERSION"]
+
+    if not name or not version:
+        raise ValueError("Cannot set up release without release variables present")
+
+    destdir = os.path.join("release", version)
+    if not os.path.exists(destdir):
+        os.makedirs(destdir)
+
+    dest = os.path.join(
+        destdir, "espurna-{name}-{version}.bin".format(name=name, version=version)
+    )
+    src = env.subst("$BUILD_DIR/${PROGNAME}.bin")
+
+    shutil.copy(src, dest)
+

--- a/code/scripts/espurna_utils/release.py
+++ b/code/scripts/espurna_utils/release.py
@@ -14,7 +14,7 @@ def copy_release(target, source, env):
         os.makedirs(destdir)
 
     dest = os.path.join(
-        destdir, "espurna-{name}-{version}.bin".format(name=name, version=version)
+        destdir, "espurna-{version}-{name}.bin".format(version=version, name=name)
     )
     src = env.subst("$BUILD_DIR/${PROGNAME}.bin")
 

--- a/code/scripts/espurna_utils/release.py
+++ b/code/scripts/espurna_utils/release.py
@@ -9,7 +9,7 @@ def copy_release(target, source, env):
     if not name or not version:
         raise ValueError("Cannot set up release without release variables present")
 
-    destdir = os.path.join("release", version)
+    destdir = os.path.join(env.subst("$PROJECT_DIR"), "..", "firmware", version)
     if not os.path.exists(destdir):
         os.makedirs(destdir)
 

--- a/code/scripts/generate_release_sh.py
+++ b/code/scripts/generate_release_sh.py
@@ -1,7 +1,6 @@
 import os
 import argparse
 import re
-import sys
 import shlex
 import configparser
 import collections

--- a/code/scripts/generate_release_sh.py
+++ b/code/scripts/generate_release_sh.py
@@ -4,7 +4,7 @@ import sys
 import configparser
 import collections
 
-CI = any(os.environ.get("TRAVIS"), os.environ.get("CI"))
+CI = any([os.environ.get("TRAVIS"), os.environ.get("CI")])
 Build = collections.namedtuple("Build", "env extends build_flags src_build_flags")
 
 
@@ -80,6 +80,7 @@ def every(seq, nth, total):
             yield value
         index = (index + 1) % total
 
+
 if __name__ == "__main__":
     if not CI:
         raise SystemExit("* Not in CI *")
@@ -87,7 +88,7 @@ if __name__ == "__main__":
         raise SystemExit("* Invalid arguments *")
 
     Config = configparser.ConfigParser()
-    with open("code/platformio.ini", "r") as f:
+    with open("platformio.ini", "r") as f:
         Config.read_file(f)
 
     builder_total_threads = int(os.environ["BUILDER_TOTAL_THREADS"])
@@ -96,7 +97,7 @@ if __name__ == "__main__":
 
     print("#!/bin/bash")
     print("set -e -x")
-    print("trap \"ls -l ${TRAVIS_BUILD_DIR}/firmware\" EXIT")
+    print('trap "ls -l ${TRAVIS_BUILD_DIR}/firmware/${ESPURNA_VERSION}" EXIT')
     print(
         'echo "Selected thread #{} out of {}"'.format(
             builder_thread, builder_total_threads
@@ -104,4 +105,3 @@ if __name__ == "__main__":
     )
     for line in generate_lines(sys.argv[1], builds):
         print(line)
-    

--- a/code/scripts/generate_release_sh.py
+++ b/code/scripts/generate_release_sh.py
@@ -1,0 +1,103 @@
+import os
+import re
+import sys
+import configparser
+import collections
+
+Build = collections.namedtuple("Build", "env extends build_flags src_build_flags")
+
+
+def get_builds(cfg):
+    RE_STRIP_VARS = re.compile("\$\{.*\}")
+    RE_STRIP_NEWLINE = re.compile("\r\n|\n")
+
+    for section in cfg.sections():
+        if (not section.startswith("env:")) or (
+            section.startswith("env:esp8266-") and section.endswith("-base")
+        ):
+            continue
+
+        build_flags = None
+        src_build_flags = None
+
+        try:
+            build_flags = cfg.get(section, "build_flags")
+            build_flags = RE_STRIP_VARS.sub("", build_flags).strip()
+            build_flags = RE_STRIP_NEWLINE.sub(" ", build_flags).strip()
+        except configparser.NoOptionError:
+            pass
+
+        try:
+            src_build_flags = cfg.get(section, "src_build_flags")
+            src_build_flags = RE_STRIP_VARS.sub("", src_build_flags).strip()
+            src_build_flags = RE_STRIP_NEWLINE.sub(" ", src_build_flags).strip()
+        except configparser.NoOptionError:
+            pass
+
+        yield Build(
+            section.replace("env:", ""),
+            cfg.get(section, "extends").replace("env:", ""),
+            build_flags,
+            src_build_flags,
+        )
+
+
+def generate_lines(version, builds):
+    cores = []
+    generic = []
+
+    for build in builds:
+
+        flags = []
+        if build.build_flags:
+            flags.append('PLATFORMIO_BUILD_FLAGS="{}"'.format(build.build_flags))
+        if build.src_build_flags:
+            flags.append('ESPURNA_FLAGS="{}"'.format(build.src_build_flags))
+        flags.append('ESPURNA_NAME="{env}"'.format(env=build.env))
+        flags.append('ESPURNA_VERSION="{version}"'.format(version=version))
+
+        cmd = ["env"]
+        cmd.extend(flags)
+        cmd.extend(["pio", "run", "-e", build.extends, "-s", "-t", "release"])
+
+        line = " ".join(cmd)
+
+        # push core variants to the front as they definetly include global build_flags
+        output = generic
+        if "ESPURNA_CORE" in build.src_build_flags:
+            output = cores
+
+        output.append(line)
+
+    return cores + generic
+
+
+def every(seq, nth, total):
+    index = 0
+    for value in seq:
+        if index == nth:
+            yield value
+        index = (index + 1) % total
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        raise SystemError("Invalid arguments")
+
+    Config = configparser.ConfigParser()
+    with open("platformio.ini", "r") as f:
+        Config.read_file(f)
+
+    builder_total_threads = int(os.environ["BUILDER_TOTAL_THREADS"])
+    builder_thread = int(os.environ["BUILDER_THREAD"])
+    builds = every(get_builds(Config), builder_thread, builder_total_threads)
+
+    print("#!/bin/bash")
+    print("set -e -x")
+    print(
+        'echo "Selected thread #{} out of {}"'.format(
+            builder_thread, builder_total_threads
+        )
+    )
+    for line in generate_lines(sys.argv[1], builds):
+        print(line)

--- a/code/scripts/generate_release_sh.py
+++ b/code/scripts/generate_release_sh.py
@@ -43,7 +43,7 @@ def get_builds(cfg):
         )
 
 
-def generate_lines(version, builds):
+def generate_lines(builds):
     cores = []
     generic = []
 
@@ -55,7 +55,6 @@ def generate_lines(version, builds):
         if build.src_build_flags:
             flags.append('ESPURNA_FLAGS="{}"'.format(build.src_build_flags))
         flags.append('ESPURNA_NAME="{env}"'.format(env=build.env))
-        flags.append('ESPURNA_VERSION="{version}"'.format(version=version))
 
         cmd = ["env"]
         cmd.extend(flags)
@@ -93,15 +92,18 @@ if __name__ == "__main__":
 
     builder_total_threads = int(os.environ["BUILDER_TOTAL_THREADS"])
     builder_thread = int(os.environ["BUILDER_THREAD"])
+    version = sys.argv[1]
+
     builds = every(get_builds(Config), builder_thread, builder_total_threads)
 
     print("#!/bin/bash")
     print("set -e -x")
+    print('export ESPURNA_VERSION="{}"'.format(version))
     print('trap "ls -l ${TRAVIS_BUILD_DIR}/firmware/${ESPURNA_VERSION}" EXIT')
     print(
         'echo "Selected thread #{} out of {}"'.format(
             builder_thread, builder_total_threads
         )
     )
-    for line in generate_lines(sys.argv[1], builds):
+    for line in generate_lines(builds):
         print(line)

--- a/code/scripts/generate_release_sh.py
+++ b/code/scripts/generate_release_sh.py
@@ -14,7 +14,7 @@ def expand_variables(cfg, value):
     RE_VARS = re.compile("\$\{.*?\}")
 
     for var in RE_VARS.findall(value):
-        section, option = var.replace("${", "").replace("}","").split(".", 1)
+        section, option = var.replace("${", "").replace("}", "").split(".", 1)
         value = value.replace(var, expand_variables(cfg, cfg.get(section, option)))
 
     return value
@@ -22,7 +22,9 @@ def expand_variables(cfg, value):
 
 def get_builds(cfg):
     RE_NEWLINE = re.compile("\r\n|\n")
-    BASE_BUILD_FLAGS = set(shlex.split(expand_variables(cfg,cfg.get("env", "build_flags"))))
+    BASE_BUILD_FLAGS = set(
+        shlex.split(expand_variables(cfg, cfg.get("env", "build_flags")))
+    )
 
     for section in cfg.sections():
         if (not section.startswith("env:")) or (
@@ -36,7 +38,9 @@ def get_builds(cfg):
         try:
             build_flags = cfg.get(section, "build_flags")
             build_flags = RE_NEWLINE.sub(" ", build_flags).strip()
-            build_flags = " ".join(BASE_BUILD_FLAGS ^ set(shlex.split(expand_variables(cfg, build_flags))))
+            build_flags = " ".join(
+                BASE_BUILD_FLAGS ^ set(shlex.split(expand_variables(cfg, build_flags)))
+            )
         except configparser.NoOptionError:
             pass
 

--- a/code/scripts/pio_main.py
+++ b/code/scripts/pio_main.py
@@ -27,7 +27,7 @@ projenv.ProcessUnFlags("-w")
 
 # XXX: note that this will also break %d format with floats and print raw memory contents as int
 # Cores after 2.3.0 can disable %f in the printf / scanf to reduce .bin size
-# remove_float_support(env)
+remove_float_support(env)
 ldscripts_inject_libpath(env)
 
 # two-step update hint when using 1MB boards

--- a/code/scripts/pio_main.py
+++ b/code/scripts/pio_main.py
@@ -17,6 +17,7 @@ from espurna_utils import (
     app_inject_revision,
     dummy_ets_printf,
     app_inject_flags,
+    copy_release,
 )
 
 Import("env", "projenv")
@@ -26,7 +27,7 @@ projenv.ProcessUnFlags("-w")
 
 # XXX: note that this will also break %d format with floats and print raw memory contents as int
 # Cores after 2.3.0 can disable %f in the printf / scanf to reduce .bin size
-remove_float_support(env)
+# remove_float_support(env)
 ldscripts_inject_libpath(env)
 
 # two-step update hint when using 1MB boards
@@ -50,3 +51,6 @@ app_inject_revision(projenv)
 
 # handle OTA board and flags here, since projenv is not available in pre-scripts
 app_inject_flags(projenv)
+
+# handle `-t release` when CI does a tagged build
+env.AlwaysBuild(env.Alias("release", "${BUILD_DIR}/${PROGNAME}.bin", copy_release))

--- a/travis_script.sh
+++ b/travis_script.sh
@@ -12,7 +12,7 @@ elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Test PlatformIO Build" ]; then
     # shellcheck disable=SC2086
     scripts/test_build.py -e "$TEST_ENV" $TEST_EXTRA_ARGS
 elif [ "${TRAVIS_BUILD_STAGE_NAME}" = "Release" ]; then
-    ./build.sh -p
+    ./build.sh -r
 else
     echo -e "\e[1;33mUnknown stage name, exiting!\e[0m"
     exit 1


### PR DESCRIPTION
2nd try for #2099
Resolve #2197 

Move base envs to the same model as travis-{2_3_0,latest,git}:
- define env that sets platform, framework and build flags
- define 1m, 2m and 4m per each env
- every hw env sets `extends = esp8266-{,latest,git}-SIZE-base` instead of `build_flags = ${common.build_flags_SIZE}`

Additionally:
- remove esp8266-...-ota, Docs need adjustments
- remove every platform but 1.5.0 and 'latest', prepare to deprecate 1.5.0

Since we <s>can't</s> don't know how to force PIO to respect our wishes to not destroy build directory when our settings change or we add / remove files to project directory. Or, have any way of caching intermediate files that have the same source+build_flags but different env: https://community.platformio.org/t/build-cache-dir-will-not-share-object-files-between-envs/10011

So, instead, adjust build script to use another script that compiles env list into a compatible `pio run` calls that will re-use environment .o files cutting build time in half:
https://travis-ci.com/github/mcspr/espurna/builds/158421380 (~12-14min)
https://travis-ci.org/github/xoseperez/espurna/builds/631168730 (~27-28min)
But this forces us to use a very strict structure in .ini

TODO:
- I'll try to find another way of merging build_flags variables (or use the same mechanism as pio does + filter through uniq(). may even using pio config class directly, but we will depend on sort-of private api and we don't depend on a specific version)
- base-esp8266-1m-latest? esp8266-1m-latest-base?
- (?) instead of creating shell script, call `pio run` right in the python script

*(
NOTE:
There is another approach that patches platformio internals at runtime:
https://github.com/esphome/esphome/blob/dev/esphome/platformio_api.py
Not sure I want to do that
)*