### PR TITLE
dcz: add workaround for pressure and digital sensors

### DIFF
--- a/code/espurna/broker.h
+++ b/code/espurna/broker.h
@@ -15,12 +15,12 @@ Copyright (C) 2017-2019 by Xose Pérez <xose dot perez at gmail dot com>
 #include <utility>
 
 enum class TBrokerType {
-    SYSTEM,
-    STATUS,
-    SENSOR_READ,
-    SENSOR_REPORT,
-    DATETIME,
-    CONFIG
+    System,
+    Status,
+    SensorRead,
+    SensorReport,
+    Datetime,
+    Config
 };
 
 template <typename... TArgs>
@@ -49,11 +49,11 @@ TBrokerCallbacks<TArgs...> TBroker<type, TArgs...>::callbacks;
 
 // --- Some known types. Bind them here to avoid .ino screwing with order ---
 
-using StatusBroker = TBroker<TBrokerType::STATUS, const String&, unsigned char, unsigned int>;
+using StatusBroker = TBroker<TBrokerType::Status, const String&, unsigned char, unsigned int>;
 
-using SensorReadBroker = TBroker<TBrokerType::SENSOR_READ, const String&, unsigned char, double, const char*>;
-using SensorReportBroker = TBroker<TBrokerType::SENSOR_REPORT, const String&, unsigned char, double, const char*>;
+using SensorReadBroker = TBroker<TBrokerType::SensorRead, const String&, unsigned char, double, const char*>;
+using SensorReportBroker = TBroker<TBrokerType::SensorReport, const String&, unsigned char, double, const char*>;
 
-using ConfigBroker = TBroker<TBrokerType::CONFIG, const String&, const String&>;
+using ConfigBroker = TBroker<TBrokerType::Config, const String&, const String&>;
 
 #endif // BROKER_SUPPORT == 1

--- a/code/espurna/domoticz.h
+++ b/code/espurna/domoticz.h
@@ -19,6 +19,7 @@ void domoticzSend(const char * key, T value);
 template<typename T>
 void domoticzSend(const char * key, T nvalue, const char * svalue);
 
+void domoticzSendMagnitude(unsigned char type, unsigned char index, double value, const char* buffer);
 void domoticzSendRelay(unsigned char relayID, bool status);
 void domoticzSendRelays();
 

--- a/code/espurna/ntp.h
+++ b/code/espurna/ntp.h
@@ -42,7 +42,7 @@ struct NtpCalendarWeekday {
     int utc_minute;
 };
 
-using NtpBroker = TBroker<TBrokerType::DATETIME, const NtpTick, time_t, const String&>;
+using NtpBroker = TBroker<TBrokerType::Datetime, const NtpTick, time_t, const String&>;
 
 String ntpDateTime(time_t ts);
 String ntpDateTime();

--- a/code/espurna/sensor.ino
+++ b/code/espurna/sensor.ino
@@ -12,6 +12,7 @@ Copyright (C) 2016-2019 by Xose Pérez <xose dot perez at gmail dot com>
 #include <float.h>
 
 #include "broker.h"
+#include "domoticz.h"
 #include "mqtt.h"
 #include "ntp.h"
 #include "relay.h"
@@ -1859,30 +1860,10 @@ void _sensorReport(unsigned char index, double value) {
 
     #if THINGSPEAK_SUPPORT
         tspkEnqueueMeasurement(index, buffer);
-    #endif
+    #endif // THINGSPEAK_SUPPORT
 
     #if DOMOTICZ_SUPPORT
-    {
-        char key[15];
-        snprintf_P(key, sizeof(key), PSTR("dczMagnitude%d"), index);
-        if (magnitude.type == MAGNITUDE_HUMIDITY) {
-            int status;
-            if (value > 70) {
-                status = HUMIDITY_WET;
-            } else if (value > 45) {
-                status = HUMIDITY_COMFORTABLE;
-            } else if (value > 30) {
-                status = HUMIDITY_NORMAL;
-            } else {
-                status = HUMIDITY_DRY;
-            }
-            char status_buf[5];
-            itoa(status, status_buf, 10);
-            domoticzSend(key, buffer, status_buf);
-        } else {
-            domoticzSend(key, 0, buffer);
-        }
-    }
+        domoticzSendMagnitude(magnitude.type, index, value, buffer);
     #endif // DOMOTICZ_SUPPORT
 
 }


### PR DESCRIPTION
See #2208 and #2192
- Domoticz only accepts svalue `<pressure>;<forecast>`, failing to display anything otherwise.
  We don't have any forecast calculation (yet?), simply send dummy value.
- Domoticz integration has a weird quirk only sending sensor data as svalue. Add workaround for Digital sensors to also send nvalue, so that we can also use it for switches.
- Move Domoticz specific code outside of sensor.ino
- Small refactoring of broker module consts