### PR TITLE
Fix rfbridge function names and order

### DIFF
--- a/code/test/build/rfbridge.h
+++ b/code/test/build/rfbridge.h
@@ -1,0 +1,4 @@
+#define DUMMY_RELAY_COUNT       8
+#define RF_SUPPORT              1
+#define SERIAL_BAUDRATE         19200
+#define DEBUG_SERIAL_SUPPORT    0


### PR DESCRIPTION
resolve #2234 

fix naming, don't rfbsend everything
trying out small change to rfb hex<->uint8_t (not tested with everything, will check tomorrow morning)
test build serial rfbridge
