### PR TITLE
Hlw8012 early config

### DIFF
--- a/code/espurna/sensor.cpp
+++ b/code/espurna/sensor.cpp
@@ -1491,9 +1491,6 @@ void _sensorLoad() {
         sensor->setSEL(getSetting("snsHlw8012SelGPIO", HLW8012_SEL_PIN));
         sensor->setCF(getSetting("snsHlw8012CfGPIO", HLW8012_CF_PIN));
         sensor->setCF1(getSetting("snsHlw8012Cf1GPIO", HLW8012_CF1_PIN));
-        sensor->setCurrentRatio(HLW8012_CURRENT_RATIO);
-        sensor->setVoltageRatio(HLW8012_VOLTAGE_RATIO);
-        sensor->setPowerRatio(HLW8012_POWER_RATIO);
         sensor->setSELCurrent(HLW8012_SEL_CURRENT);
         _sensors.push_back(sensor);
     }

--- a/code/espurna/sensor.cpp
+++ b/code/espurna/sensor.cpp
@@ -1858,19 +1858,19 @@ void _sensorInit() {
             for (size_t index = 0; index < sensor->countDevices(); ++index) {
                 sensor->resetEnergy(index, _sensorEnergyTotal(index));
                 sensor->setCurrentRatio(
-                    get_ratio("pwrRatioC", index, sensor->getCurrentRatio(index))
+                    index, get_ratio("pwrRatioC", index, sensor->getCurrentRatio(index))
                 );
                 sensor->setVoltageRatio(
-                    get_ratio("pwrRatioV", index, sensor->getVoltageRatio(index))
+                    index, get_ratio("pwrRatioV", index, sensor->getVoltageRatio(index))
                 );
                 sensor->setPowerRatio(
-                    get_ratio("pwrRatioP", index, sensor->getPowerRatio(index))
+                    index, get_ratio("pwrRatioP", index, sensor->getPowerRatio(index))
                 );
                 sensor->setEnergyRatio(
-                    get_ratio("pwrRatioE", index, sensor->getEnergyRatio(index))
+                    index, get_ratio("pwrRatioE", index, sensor->getEnergyRatio(index))
                 );
                 sensor->setVoltage(
-                    get_ratio("pwrVoltage", index, sensor->getVoltage(index))
+                    index, get_ratio("pwrVoltage", index, sensor->getVoltage(index))
                 );
             }
 

--- a/code/espurna/sensors/BaseEmonSensor.h
+++ b/code/espurna/sensors/BaseEmonSensor.h
@@ -70,8 +70,15 @@ class BaseEmonSensor : public BaseSensor {
         
         // when sensor needs explicit mains voltage value
         virtual void setVoltage(double) {}
-        virtual double getVoltage() { return 0.0; }
-        virtual double getVoltage(unsigned char index) { return getVoltage(); }
+        virtual void setVoltage(unsigned char index, double value) {
+            setVoltage(value);
+        }
+        virtual double getVoltage() {
+            return 0.0;
+        }
+        virtual double getVoltage(unsigned char index) {
+            return getVoltage();
+        }
 
         // when sensor implements ratios / multipliers
         virtual void setCurrentRatio(double) {}
@@ -80,22 +87,46 @@ class BaseEmonSensor : public BaseSensor {
         virtual void setEnergyRatio(double) {}
 
         // when sensor implements ratios / multipliers
-        virtual void setCurrentRatio(unsigned char index, double) {}
-        virtual void setVoltageRatio(unsigned char index, double) {}
-        virtual void setPowerRatio(unsigned char index, double) {}
-        virtual void setEnergyRatio(unsigned char index, double) {}
+        virtual void setCurrentRatio(unsigned char index, double value) {
+            setCurrentRatio(value);
+        }
+        virtual void setVoltageRatio(unsigned char index, double value) {
+            setVoltageRatio(value);
+        }
+        virtual void setPowerRatio(unsigned char index, double value) {
+            setPowerRatio(value);
+        }
+        virtual void setEnergyRatio(unsigned char index, double value) {
+            setEnergyRatio(value);
+        }
 
         // when sensor implements a single device
-        virtual double getCurrentRatio() { return 0.0; }
-        virtual double getVoltageRatio() { return 0.0; }
-        virtual double getPowerRatio() { return 0.0; }
-        virtual double getEnergyRatio() { return 0.0; }
+        virtual double getCurrentRatio() {
+            return 0.0;
+        }
+        virtual double getVoltageRatio() {
+            return 0.0;
+        }
+        virtual double getPowerRatio() {
+            return 0.0;
+        }
+        virtual double getEnergyRatio() {
+            return 0.0;
+        }
 
         // when sensor implements more than one device
-        virtual double getCurrentRatio(unsigned char index) { return getCurrentRatio(); }
-        virtual double getVoltageRatio(unsigned char index) { return getCurrentRatio(); }
-        virtual double getPowerRatio(unsigned char index) { return getCurrentRatio(); }
-        virtual double getEnergyRatio(unsigned char index) { return getCurrentRatio(); }
+        virtual double getCurrentRatio(unsigned char index) {
+            return getCurrentRatio();
+        }
+        virtual double getVoltageRatio(unsigned char index) {
+            return getVoltageRatio();
+        }
+        virtual double getPowerRatio(unsigned char index) {
+            return getPowerRatio();
+        }
+        virtual double getEnergyRatio(unsigned char index) {
+            return getEnergyRatio();
+        }
 
         virtual void expectedCurrent(double value) {}
         virtual void expectedVoltage(unsigned int value) {}

--- a/code/espurna/sensors/HLW8012Sensor.h
+++ b/code/espurna/sensors/HLW8012Sensor.h
@@ -142,6 +142,11 @@ class HLW8012Sensor : public BaseEmonSensor {
             // * The VOLTAGE_RESISTOR_DOWNSTREAM is the 1kOhm resistor in the voltage divider that feeds the V2P pin in the HLW8012
             _hlw8012->setResistors(HLW8012_CURRENT_R, HLW8012_VOLTAGE_R_UP, HLW8012_VOLTAGE_R_DOWN);
 
+            // Also, adjust with ratio values that could be set in hardware profile
+            if (HLW8012_CURRENT_RATIO > 0.0) _hlw8012->setCurrentMultiplier(HLW8012_CURRENT_RATIO);
+            if (HLW8012_VOLTAGE_RATIO > 0.0) _hlw8012->setVoltageMultiplier(HLW8012_VOLTAGE_RATIO);
+            if (HLW8012_POWER_RATIO > 0.0) _hlw8012->setPowerMultiplier(HLW8012_POWER_RATIO);
+
             // Handle interrupts
             #if HLW8012_USE_INTERRUPTS && (!HLW8012_WAIT_FOR_WIFI)
                 _enableInterrupts(false);


### PR DESCRIPTION
- fix ratios getting lost when not using generic hlw resistor values. move initialization to sensor itself (@reaper7)
- emon methods now follow default setters when not overriden
(todo: mark levels above as override would be a nice touch too, to actually hint about what is happening)
as noted in the #2219, we can't call such indexed methods in child directly when it implements one of the method types and must use baseemon cast to resolve them properly.