### PR TITLE
Use #include for single source build

### DIFF
--- a/code/scripts/espurna_utils/release.py
+++ b/code/scripts/espurna_utils/release.py
@@ -39,9 +39,8 @@ def merge_cpp(sources, output):
         tmp.write(b"// !!! Automatically generated file; DO NOT EDIT !!! \n")
         tmp.write(b'#include "espurna.h"\n')
         for source in sources:
-            with open(source, "rb") as fobj:
-                tmp.write('# 1 "{}"\n'.format(source.replace("\\", "/")).encode('utf-8'));
-                shutil.copyfileobj(fobj, tmp)
+            src_include = '#include "{}"\n'.format(source)
+            tmp.write(src_include.encode('utf-8'))
 
         tmp.seek(0)
 

--- a/code/scripts/pio_pre.py
+++ b/code/scripts/pio_pre.py
@@ -156,7 +156,7 @@ if os.environ.get("ESPURNA_BUILD_SINGLE_SOURCE"):
         for name in filenames:
             if not name.endswith(".cpp"):
                 continue
-            path = os.path.join(root, name)
+            path = os.path.relpath(os.path.join(root, name), "espurna")
             env.AddBuildMiddleware(lambda node: None, "*?/{}".format(path))
             cpp_files.append(path)
     merge_cpp(cpp_files, "espurna/espurna_single_source.cpp")


### PR DESCRIPTION
No need to manually add line markers when gcc can do it for you