### PR TITLE
sns: more magnitude settings

### DIFF
--- a/code/espurna/settings.cpp
+++ b/code/espurna/settings.cpp
@@ -268,10 +268,10 @@ String settingsQueryDefaults(const String& key) {
 // -----------------------------------------------------------------------------
 
 String settings_key_t::toString() const {
-    if (index < 0) {
-        return value;
+    if (_index < 0) {
+        return _value;
     } else {
-        return value + index;
+        return _value + _index;
     }
 }
 

--- a/code/espurna/settings.h
+++ b/code/espurna/settings.h
@@ -27,30 +27,33 @@ class settings_key_t {
 
     public:
         settings_key_t(const char* value, unsigned char index) :
-            value(value), index(index)
+            _value(value), _index(index)
         {}
         settings_key_t(const String& value, unsigned char index) :
-            value(value), index(index)
+            _value(value), _index(index)
+        {}
+        settings_key_t(String&& value, unsigned char index) :
+            _value(std::move(value)), _index(index)
         {}
         settings_key_t(const char* value) :
-            value(value), index(-1)
+            _value(value), _index(-1)
         {}
         settings_key_t(const String& value) :
-            value(value), index(-1)
+            _value(value), _index(-1)
         {}
         settings_key_t(const __FlashStringHelper* value) :
-            value(value), index(-1)
+            _value(value), _index(-1)
         {}
         settings_key_t() :
-            value(), index(-1)
+            _value(), _index(-1)
         {}
 
-        bool match(const char* _value) const {
-            return (value == _value) || (toString() == _value);
+        bool match(const char* value) const {
+            return (_value == value) || (toString() == value);
         }
 
-        bool match(const String& _value) const {
-            return (value == _value) || (toString() == _value);
+        bool match(const String& value) const {
+            return (_value == value) || (toString() == value);
         }
 
         String toString() const;
@@ -60,8 +63,8 @@ class settings_key_t {
         }
 
     private:
-        const String value;
-        int index;
+        const String _value;
+        int _index;
 };
 
 using settings_move_key_t = std::pair<settings_key_t, settings_key_t>;


### PR DESCRIPTION
- introduce zero threshold setting to reset value to 0 below a certain point (resolve #2264)
for example, `set pwrPZeroThreshold0 10.0` for active power (or `pwrQ...` for apparent, `pwrModS...` for reactive) will reset always reset value to 0, similar to what turned off relay does. Default value is `nan`, since we can't use 0.0 on account of negative values.   
- fix energy magnitude indexes usage, properly reset in API
- simplify sending pwr and emon Visible flags
- allow to use settings prefixes more, remove snsMinDelta & snsMaxDelta and use relative magnitude indexes