### PR TITLE
wifi: separate softAp settings

### DIFF
--- a/code/espurna/config/deprecated.h
+++ b/code/espurna/config/deprecated.h
@@ -98,3 +98,13 @@
 #warning "BUTTON[1-8]_MODE is deprecated! Please use BUTTON[1-8]_CONFIG instead"
 #define BUTTON8_CONFIG BUTTON8_MODE
 #endif
+
+#ifdef CSE7766_PIN
+#warning "CSE7766_PIN is deprecated! Please use CSE7766_RX_PIN instead"
+#define CSE7766_RX_PIN CSE7766_PIN
+#endif
+
+#ifdef WIFI_FALLBACK_APMODE
+#warning "WIFI_FALLBACK_APMODE is deprecated! Please use WIFI_AP_MODE instead"
+#define WIFI_AP_MODE ((1 == WIFI_FALLBACK_APMODE) ? WiFiApMode::Fallback : WiFiApMode::Disabled)
+#endif

--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -497,31 +497,43 @@
 // -----------------------------------------------------------------------------
 
 #ifndef WIFI_CONNECT_TIMEOUT
-#define WIFI_CONNECT_TIMEOUT        60000               // Connecting timeout for WIFI in ms
+#define WIFI_CONNECT_TIMEOUT        60000                  // Connecting timeout for WIFI in ms
 #endif
 
 #ifndef WIFI_RECONNECT_INTERVAL
-#define WIFI_RECONNECT_INTERVAL     180000              // If could not connect to WIFI, retry after this time in ms
+#define WIFI_RECONNECT_INTERVAL     180000                 // If could not connect to WIFI, retry after this time in ms
 #endif
 
 #ifndef WIFI_MAX_NETWORKS
-#define WIFI_MAX_NETWORKS           5                   // Max number of WIFI connection configurations
+#define WIFI_MAX_NETWORKS           5                      // Max number of WIFI connection configurations
 #endif
 
 #ifndef WIFI_AP_CAPTIVE
-#define WIFI_AP_CAPTIVE             1                   // Captive portal enabled when in AP mode
+#define WIFI_AP_CAPTIVE             1                      // Captive portal enabled when in AP mode
 #endif
 
-#ifndef WIFI_FALLBACK_APMODE
-#define WIFI_FALLBACK_APMODE        1                   // Fallback to AP mode if no STA connection
+#ifndef WIFI_AP_MODE
+#define WIFI_AP_MODE                WiFiApMode::Fallback   // By default, fallback to AP mode if no STA connection
+                                                           // Use WiFiApMode::Enabled to start it when the device boots
+                                                           // Use WiFiApMode::Disabled to disable AP mode completely
+#endif
+
+#ifndef WIFI_AP_SSID
+#define WIFI_AP_SSID                ""                     // (optional) Specify softAp SSID.
+                                                           // By default or when empty, hostname (or device identifier) is used instead.
+#endif
+
+#ifndef WIFI_AP_PASS
+#define WIFI_AP_PASS                ""                     // (optional) Specify softAp passphrase
+                                                           // By default or when empty, admin password is used instead.
 #endif
 
 #ifndef WIFI_SLEEP_MODE
-#define WIFI_SLEEP_MODE             WIFI_NONE_SLEEP     // WIFI_NONE_SLEEP, WIFI_LIGHT_SLEEP or WIFI_MODEM_SLEEP
+#define WIFI_SLEEP_MODE             WIFI_NONE_SLEEP        // WIFI_NONE_SLEEP, WIFI_LIGHT_SLEEP or WIFI_MODEM_SLEEP
 #endif
 
 #ifndef WIFI_SCAN_NETWORKS
-#define WIFI_SCAN_NETWORKS          1                   // Perform a network scan before connecting
+#define WIFI_SCAN_NETWORKS          1                      // Perform a network scan before connecting
 #endif
 
 // Optional hardcoded configuration (up to 5 networks, depending on WIFI_MAX_NETWORKS and espurna/wifi_config.h)

--- a/code/espurna/config/types.h
+++ b/code/espurna/config/types.h
@@ -15,9 +15,6 @@
 #define WIFI_STATE_WPS              4
 #define WIFI_STATE_SMARTCONFIG      8
 
-#define WIFI_AP_ALLWAYS             1
-#define WIFI_AP_FALLBACK            2
-
 //------------------------------------------------------------------------------
 // BUTTONS
 //------------------------------------------------------------------------------

--- a/code/espurna/wifi.h
+++ b/code/espurna/wifi.h
@@ -40,7 +40,13 @@ extern "C" {
 #define TCP_MSS (1460)
 #endif
 
-using wifi_callback_f = std::function<void(justwifi_messages_t code, char * parameter)>;
+using wifi_callback_f = void(*)(justwifi_messages_t code, char * parameter);
+
+enum class WiFiApMode {
+    Disabled,
+    Enabled,
+    Fallback
+};
 
 uint8_t wifiState();
 void wifiReconnectCheck();
@@ -52,6 +58,7 @@ String getIP();
 void wifiDebug();
 void wifiDebug(WiFiMode_t modes);
 
+WiFiApMode wifiApMode();
 void wifiStartAP();
 void wifiStartSTA();
 void wifiDisconnect();


### PR DESCRIPTION
- replace `apmode` with `wifiApMode`
- deprecate `WIFI_FALLBACK_APMODE` in favour of the AP mode setting
- allow to set custom SSID and passphrase for the softAP via `wifiApSsid` & `wifiApPass`
- identifier fallback for hostname