### PR TITLE
PIO: fix git, bump versions

### DIFF
--- a/code/espurna/pwm.c
+++ b/code/espurna/pwm.c
@@ -122,7 +122,7 @@ pwm_intr_handler(void)
 
 	do {
 		// force write to GPIO registers on each loop
-		asm volatile ("" : : : "memory");
+		__asm__ volatile ("" : : : "memory");
 
 		gpio->out_w1ts = (uint32_t)(pwm_state.current_set[pwm_state.current_phase].on_mask);
 		gpio->out_w1tc = (uint32_t)(pwm_state.current_set[pwm_state.current_phase].off_mask);
@@ -144,7 +144,7 @@ pwm_intr_handler(void)
 			do {
 				ticks -= 1;
 				// stop compiler from optimizing delay loop to noop
-				asm volatile ("" : : : "memory");
+				__asm__ volatile ("" : : : "memory");
 			} while (ticks > 0);
 		}
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -179,7 +179,8 @@ lib_deps =
 
 lib_ignore =
     AsyncTCP
-    ${common.legacy_lib_deps}
+    Time
+    NtpClientLib
 
 # ------------------------------------------------------------------------------
 # Base enrivonments, -DMANUFACTURER=..., -DDEVICE=... must be set:

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -179,6 +179,7 @@ lib_deps =
 
 lib_ignore =
     AsyncTCP
+    Brzo I2C
     Time
     NtpClientLib
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -123,6 +123,39 @@ git_platform_packages =
     framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
     toolchain-xtensa @ https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu12/x86_64-linux-gnu.xtensa-lx106-elf-0474ae9.200706.tar.gz
 
+# XXX: 2.3.0 depends on these
+legacy_lib_deps =
+    https://github.com/xoseperez/Time
+    https://github.com/xoseperez/NtpClient.git#0942ebc
+
+lib_deps =
+    ArduinoJson@5.13.4
+    https://github.com/marvinroger/async-mqtt-client#v0.8.1
+    https://github.com/xoseperez/eeprom_rotate#0.9.2
+    https://github.com/plerup/espsoftwareserial#3.4.1
+    https://github.com/me-no-dev/ESPAsyncTCP#7e9ed22
+    https://github.com/me-no-dev/ESPAsyncWebServer#b0c6144
+    https://bitbucket.org/xoseperez/fauxmoesp.git#3.1.0
+    https://github.com/xoseperez/hlw8012.git#1.1.0
+    IRremoteESP8266@2.7.4
+    https://github.com/xoseperez/justwifi.git#2.0.2
+    https://github.com/madpilot/mDNSResolver#4cfcda1
+    https://github.com/xoseperez/my92xx#3.0.1
+    https://github.com/256dpi/arduino-mqtt#196556b6
+    https://bitbucket.org/xoseperez/nofuss.git#0.3.0
+    OneWire
+    PZEM004T
+    PubSubClient
+    rc-switch
+    https://github.com/LowPowerLab/RFM69#7008d57a
+    https://github.com/xoseperez/rpnlib.git#0.3.0
+    NewPing
+    https://github.com/sparkfun/SparkFun_VEML6075_Arduino_Library#V_1.0.3
+    https://github.com/pololu/vl53l1x-arduino#1.0.1
+    https://github.com/mcleng/MAX6675-Library#2.0.1
+    https://github.com/ThingPulse/esp8266-oled-ssd1306#3398c97
+    Adafruit SI1145 Library@~1.1.1
+
 # ------------------------------------------------------------------------------
 # COMMON ENVIRONMENT SETTINGS:
 # ------------------------------------------------------------------------------
@@ -142,36 +175,11 @@ lib_extra_dirs =
 #   Please note that we don't always use the latest version of a library.
 # ------------------------------------------------------------------------------
 lib_deps =
-    ArduinoJson@5.13.4
-    https://github.com/marvinroger/async-mqtt-client#v0.8.1
-    https://github.com/xoseperez/eeprom_rotate#0.9.2
-    https://github.com/plerup/espsoftwareserial#3.4.1
-    https://github.com/me-no-dev/ESPAsyncTCP#7e9ed22
-    https://github.com/me-no-dev/ESPAsyncWebServer#b0c6144
-    https://bitbucket.org/xoseperez/fauxmoesp.git#3.1.0
-    https://github.com/xoseperez/hlw8012.git#1.1.0
-    IRremoteESP8266@2.7.4
-    https://github.com/xoseperez/justwifi.git#2.0.2
-    https://github.com/madpilot/mDNSResolver#4cfcda1
-    https://github.com/xoseperez/my92xx#3.0.1
-    https://github.com/256dpi/arduino-mqtt#196556b6
-    https://bitbucket.org/xoseperez/nofuss.git#0.3.0
-    https://github.com/xoseperez/NtpClient.git#0942ebc
-    OneWire
-    PZEM004T
-    PubSubClient
-    rc-switch
-    https://github.com/LowPowerLab/RFM69#7008d57a
-    https://github.com/xoseperez/rpnlib.git#0.3.0
-    https://github.com/xoseperez/Time
-    NewPing
-    https://github.com/sparkfun/SparkFun_VEML6075_Arduino_Library#V_1.0.3
-    https://github.com/pololu/vl53l1x-arduino#1.0.1
-    https://github.com/mcleng/MAX6675-Library#2.0.1
-    https://github.com/ThingPulse/esp8266-oled-ssd1306#3398c97
-    Adafruit SI1145 Library@~1.1.1
+    ${common.lib_deps}
+
 lib_ignore =
     AsyncTCP
+    ${common.legacy_lib_deps}
 
 # ------------------------------------------------------------------------------
 # Base enrivonments, -DMANUFACTURER=..., -DDEVICE=... must be set:
@@ -183,18 +191,38 @@ lib_ignore =
 [env:esp8266-512k-base]
 board = ${common.board_512k}
 board_build.ldscript = ${common.ldscript_512k}
+lib_deps =
+    ${common.legacy_lib_deps}
+    ${common.lib_deps}
+lib_ignore =
+    AsyncTCP
 
 [env:esp8266-1m-base]
 board = ${common.board_1m}
 board_build.ldscript = ${common.ldscript_1m}
+lib_deps =
+    ${common.legacy_lib_deps}
+    ${common.lib_deps}
+lib_ignore =
+    AsyncTCP
 
 [env:esp8266-2m-base]
 board = ${common.board_2m}
 board_build.ldscript = ${common.ldscript_2m}
+lib_deps =
+    ${common.legacy_lib_deps}
+    ${common.lib_deps}
+lib_ignore =
+    AsyncTCP
 
 [env:esp8266-4m-base]
 board = ${common.board_4m}
 board_build.ldscript = ${common.ldscript_4m}
+lib_deps =
+    ${common.legacy_lib_deps}
+    ${common.lib_deps}
+lib_ignore =
+    AsyncTCP
 
 [env:esp8266-1m-latest-base]
 platform = ${common.platform_latest}

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -32,10 +32,10 @@ extra_configs =
 #   arduino core 2.6.1 = platformIO 2.3.0 (not supported)
 #   arduino core 2.6.2 = platformIO 2.3.1 (not supported)
 #   arduino core 2.6.3 = platformIO 2.4.0
-#   arduino core 2.7.1 = platformIO 2.5.1
+#   arduino core 2.7.1 = platformIO 2.5.3
 # ------------------------------------------------------------------------------
 platform_2_3_0 = espressif8266@1.5.0
-platform_latest = espressif8266@2.5.1
+platform_latest = espressif8266@2.5.3
 
 # ------------------------------------------------------------------------------
 # FLASH SIZE:
@@ -118,6 +118,11 @@ debug_flags =
 
 shared_libdeps_dir = libraries/
 
+# TODO: right now we depend on external toolchain url b/c toolchain version is hard-coded into the platform
+git_platform_packages =
+    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+    toolchain-xtensa @ https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu12/x86_64-linux-gnu.xtensa-lx106-elf-0474ae9.200706.tar.gz
+
 # ------------------------------------------------------------------------------
 # COMMON ENVIRONMENT SETTINGS:
 # ------------------------------------------------------------------------------
@@ -139,7 +144,6 @@ lib_extra_dirs =
 lib_deps =
     ArduinoJson@5.13.4
     https://github.com/marvinroger/async-mqtt-client#v0.8.1
-    Brzo I2C
     https://github.com/xoseperez/eeprom_rotate#0.9.2
     https://github.com/plerup/espsoftwareserial#3.4.1
     https://github.com/me-no-dev/ESPAsyncTCP#7e9ed22
@@ -211,21 +215,21 @@ board_build.ldscript = ${common.ldscript_4m}
 platform = ${common.platform_latest}
 board = ${common.board_1m}
 platform_packages =
-    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+    ${common.git_platform_packages}
 board_build.ldscript = ${common.ldscript_1m}
 
 [env:esp8266-2m-git-base]
 platform = ${common.platform_latest}
 board = ${common.board_2m}
 platform_packages =
-    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+    ${common.git_platform_packages} 
 board_build.ldscript = ${common.ldscript_2m}
 
 [env:esp8266-4m-git-base]
 platform = ${common.platform_latest}
 board = ${common.board_4m}
 platform_packages =
-    framework-arduinoespressif8266 @ https://github.com/esp8266/Arduino.git
+    ${common.git_platform_packages}
 board_build.ldscript = ${common.ldscript_4m}
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
- bump to espressif8266@2.5.3 (but, 2.5.4 will be here soon...)
- pwm asm -> \_\_asm\_\_
- re-shuffle dependencies a bit, remove brzo from -git and -latest, ref https://github.com/pasko-zh/brzo_i2c/issues/40
