### PR TITLE
Revert "Power factor fixes"

### DIFF
--- a/code/espurna/sensors/BaseSensor.h
+++ b/code/espurna/sensors/BaseSensor.h
@@ -95,7 +95,8 @@ class BaseSensor {
             switch (type(index)) {
                 case MAGNITUDE_TEMPERATURE:
                     return sensor::Unit::Celcius;
-		case MAGNITUDE_HUMIDITY:
+                case MAGNITUDE_HUMIDITY:
+                case MAGNITUDE_POWER_FACTOR:
                     return sensor::Unit::Percentage;
                 case MAGNITUDE_PRESSURE:
                     return sensor::Unit::Hectopascal;

--- a/code/espurna/sensors/PZEM004TV30Sensor.h
+++ b/code/espurna/sensors/PZEM004TV30Sensor.h
@@ -362,8 +362,8 @@ class PZEM004TV30Sensor : public BaseEmonSensor {
             if (std::distance(it, end) >= 2) {
                 value = (static_cast<uint32_t>(*(it)) << 8)
                       | static_cast<uint32_t>(*(it + 1));
+                it += 2;
             }
-            it += 2;
             return value;
         };
 
@@ -375,8 +375,8 @@ class PZEM004TV30Sensor : public BaseEmonSensor {
                      | (static_cast<uint32_t>(*(it + 3)) << 16))
                     | ((static_cast<uint32_t>(*it) << 8)
                      | static_cast<uint32_t>(*(it + 1))));
+                it += 4;
             }
-            it += 4;
             return value;
         };
 
@@ -400,9 +400,8 @@ class PZEM004TV30Sensor : public BaseEmonSensor {
         _frequency = take_2();
         _frequency /= 10.0;
 
-        // - Power Factor: 2 bytes in 0.1% (we return %)
+        // - Power Factor: 2 bytes in 0.01 (we return %)
         _power_factor = take_2();
-        _power_factor /= 10.0;
 
         // - Alarms: 2 bytes, (NOT IMPLEMENTED)
         // XXX: it seems it can only be either 0xffff or 0 for ON and OFF respectively

--- a/code/espurna/sensors/PZEM004TV30Sensor.h
+++ b/code/espurna/sensors/PZEM004TV30Sensor.h
@@ -402,7 +402,7 @@ class PZEM004TV30Sensor : public BaseEmonSensor {
 
         // - Power Factor: 2 bytes in 0.1% (we return %)
         _power_factor = take_2();
-        _power_factor /= 100.0;
+        _power_factor /= 10.0;
 
         // - Alarms: 2 bytes, (NOT IMPLEMENTED)
         // XXX: it seems it can only be either 0xffff or 0 for ON and OFF respectively


### PR DESCRIPTION
Reverts xoseperez/espurna#2303

While it is true for raw value as cos θ , we don't specifically have any other sensors using it as such. As comment suggest (huh), we *want* to express the thing as percentage. 