### PR TITLE
Update pH unit decimals to 3

### DIFF
--- a/code/espurna/sensor.cpp
+++ b/code/espurna/sensor.cpp
@@ -574,6 +574,8 @@ unsigned char _sensorUnitDecimals(sensor::Unit unit) {
             return 1;
         case sensor::Unit::UltravioletIndex:
             return 3;
+        case sensor::Unit::Ph:
+            return 3;
         case sensor::Unit::None:
         default:
             return 0;

--- a/code/espurna/sensor.h
+++ b/code/espurna/sensor.h
@@ -57,6 +57,7 @@ enum class Unit : int {
     MicrosievertPerHour,       // 2nd unit of local dose rate (Geiger counting)
     Meter,
     Hertz,
+    Ph,
     Max_
 };
 

--- a/code/espurna/sensors/BaseSensor.h
+++ b/code/espurna/sensors/BaseSensor.h
@@ -135,6 +135,8 @@ class BaseSensor {
                     return sensor::Unit::Meter;
                 case MAGNITUDE_FREQUENCY:
                     return sensor::Unit::Hertz;
+                case MAGNITUDE_PH:
+                    return sensor::Unit::Ph;
                 default:
                     return sensor::Unit::None;
             }


### PR DESCRIPTION
This PR brings back pH unit decimals to 3 (as opposed to 0). In the future it might may sense to make these configurable as different probes will have different resolutions. Right now, the Atlas Scientific pH Probes come with 0.001 resolution.