### PR TITLE
Add Teckin SB53 env

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -881,6 +881,10 @@ src_build_flags = -DTECKIN_SP22_V14
 extends = env:esp8266-1m-base
 src_build_flags = -DTECKIN_SP23_V13
 
+[env:teckin-sb53]
+extends = env:esp8266-1m-base
+src_build_flags = -DTECKIN_SB53
+
 [env:gosund-wp3]
 extends = env:esp8266-1m-base
 src_build_flags = -DGOSUND_WP3


### PR DESCRIPTION
This PR adds `TECKIN_SB53` environment to `platformio.ini` to support that bulb and an equivalent one, the [Bakibo 9W E27](https://github.com/xoseperez/espurna/wiki/Hardware-Bakibo-9W-E27-RGB-CCT-bulb) bulb.