### PR TITLE
general.h: fix comment typo

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -79,7 +79,7 @@
 //------------------------------------------------------------------------------
 
 // UDP debug log
-// To receive the message son the destination computer use nc:
+// To receive the message on the destination computer use nc:
 // nc -ul 8113
 
 #ifndef DEBUG_UDP_SUPPORT


### PR DESCRIPTION
`son` -> `on`