### PR TITLE
rpn: update to rpnlib 0.24.1

### DIFF
--- a/code/espurna/rpnrules.cpp
+++ b/code/espurna/rpnrules.cpp
@@ -440,7 +440,7 @@ void _rpnInitCommands() {
         terminalOK(ctx);
     });
 
-    terminalRegisterCommand(F("RPN.VARS"), [](const terminal::CommandContext&) {
+    terminalRegisterCommand(F("RPN.VARS"), [](const terminal::CommandContext& ctx) {
         rpn_variables_foreach(_rpn_ctxt, [&ctx](const String& name, const rpn_value& value) {
             char buffer[256] = {0};
             snprintf_P(buffer, sizeof(buffer), PSTR("      %s: %s"), name.c_str(), _rpnValueToString(value).c_str());
@@ -449,7 +449,7 @@ void _rpnInitCommands() {
         terminalOK(ctx);
     });
 
-    terminalRegisterCommand(F("RPN.OPS"), [](const terminal::CommandContext&) {
+    terminalRegisterCommand(F("RPN.OPS"), [](const terminal::CommandContext& ctx) {
         rpn_operators_foreach(_rpn_ctxt, [&ctx](const String& name, size_t argc, rpn_operator::callback_type) {
             char buffer[128] = {0};
             snprintf_P(buffer, sizeof(buffer), PSTR("      %s (%d)"), name.c_str(), argc);

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -148,7 +148,7 @@ lib_deps =
     PubSubClient
     rc-switch
     https://github.com/LowPowerLab/RFM69#7008d57a
-    https://github.com/mcspr/rpnlib.git#0.23.0
+    https://github.com/mcspr/rpnlib.git#0.24.1
     NewPing
     https://github.com/sparkfun/SparkFun_VEML6075_Arduino_Library#V_1.0.3
     https://github.com/pololu/vl53l1x-arduino#1.0.1


### PR DESCRIPTION
- `i` and `u` suffixes for numbers in expressions, parse as Integer or Unsigned respectively
- `checkedTo...()` method variants for numeric conversions
- strings can contain escape sequences (\x61\x62\x63, \n, \t, \r)
- improve float number parsing
- more consistent whitespace checks, tokens also can be separated by \n or \t
- various parser fixes