### PR TITLE
Allow domoticz dimmer device to control LIGHT_PROVIDER_DIMMER brightness

### DIFF
--- a/code/espurna/domoticz.cpp
+++ b/code/espurna/domoticz.cpp
@@ -153,10 +153,10 @@ void _domoticzMqtt(unsigned int type, const char * topic, char * payload) {
 
             // IDX
             unsigned int idx = root["idx"];
-            String stype = root["stype"];
-            String switchType = root["switchType"];
 
             #if LIGHT_PROVIDER != LIGHT_PROVIDER_NONE
+                String stype = root["stype"];
+                String switchType = root["switchType"];
                 if ((_domoticzIdx(0) == idx) && (stype.startsWith("RGB") || (switchType.equals("Dimmer")))) {
                     _domoticzLight(idx, root);
                 }


### PR DESCRIPTION
I'm running simple 1-channel led dimmer and couldn't get brightness control working, as it was called only if `lightHasColor()`.
This PR changes conditions slightly, and allows domoticz's dimmer device to control brightness as well. I think this device type is more appropriate/comfortable in this case.