### PR TITLE
wifi: softap dhcp leases

### DIFF
--- a/code/espurna/config/general.h
+++ b/code/espurna/config/general.h
@@ -529,6 +529,11 @@
                                                            // By default or when empty, admin password is used instead.
 #endif
 
+#ifndef WIFI_AP_LEASES_SUPPORT
+#define WIFI_AP_LEASES_SUPPORT      0                      // (optional) Specify softAp MAC<->IP DHCP reservations
+                                                           // Use `set wifiApLease# MAC`, where MAC is a valid 12-byte HEX number without colons
+#endif
+
 #ifndef WIFI_SLEEP_MODE
 #define WIFI_SLEEP_MODE             WIFI_NONE_SLEEP        // WIFI_NONE_SLEEP, WIFI_LIGHT_SLEEP or WIFI_MODEM_SLEEP
 #endif

--- a/code/espurna/wifi.cpp
+++ b/code/espurna/wifi.cpp
@@ -764,6 +764,25 @@ void wifiSetup() {
         jw.enableSTA(true);
     }
 
+    // Note that maximum amount of stations is set by `WiFi.softAP(...)` call, but justwifi handles that.
+    // Default is 4, which we use here. However, maximum is 8. ref:
+    // https://arduino-esp8266.readthedocs.io/en/latest/esp8266wifi/soft-access-point-class.html#softap
+    #if WIFI_AP_LEASES_SUPPORT
+        for (unsigned char index = 0; index < 4; ++index) {
+            auto lease = getSetting({"wifiApLease", index});
+            if (12 != lease.length()) {
+                break;
+            }
+
+            uint8_t mac[6] = {0};
+            if (!hexDecode(lease.c_str(), lease.length(), mac, sizeof(mac))) {
+                break;
+            }
+
+            wifi_softap_add_dhcps_lease(mac);
+        }
+    #endif
+
     #if JUSTWIFI_ENABLE_SMARTCONFIG
         if (_wifi_smartconfig_initial) jw.startSmartConfig();
     #endif


### PR DESCRIPTION
Remember MAC for the current IP sequence number
(e.g. lease 0 -> xxx.xxx.xxx.2, lease 1 -> xxx.xxx.xxx.3 and etc.)

~500 bytes of code