### PR TITLE
relay + api refactoring

### DIFF
--- a/code/espurna/api.h
+++ b/code/espurna/api.h
@@ -22,14 +22,71 @@ String apiKey();
 
 #if WEB_SUPPORT && API_SUPPORT
 
-#include <functional>
+#include <vector>
 
-using api_get_callback_f = std::function<void(char * buffer, size_t size)>;
-using api_put_callback_f = std::function<void(const char * payload)> ;
+constexpr unsigned char ApiUnusedArg = 0u;
 
-void apiRegister(const String& key, api_get_callback_f getFn, api_put_callback_f putFn = nullptr);
+struct ApiBuffer {
+    constexpr static size_t size = API_BUFFER_SIZE;
+    char data[size];
+
+    void erase() {
+        std::fill(data, data + size, '\0');
+    }
+};
+
+struct Api {
+    using BasicHandler = void(*)(const Api& api, ApiBuffer& buffer);
+    using JsonHandler = void(*)(const Api& api, JsonObject& root);
+
+    enum class Type {
+        Basic,
+        Json
+    };
+
+    Api() = delete;
+
+    Api(const String& path_, Type type_, unsigned char arg_, BasicHandler get_, BasicHandler put_ = nullptr) :
+        path(path_),
+        type(type_),
+        arg(arg_)
+    {
+        get.basic = get_;
+        put.basic = put_;
+    }
+
+    Api(const String& path_, Type type_, unsigned char arg_, JsonHandler get_, JsonHandler put_ = nullptr) :
+        path(path_),
+        type(type_),
+        arg(arg_)
+    {
+        get.json = get_;
+        put.json = put_;
+    }
+
+    String path;
+    Type type;
+    unsigned char arg;
+
+    union {
+        BasicHandler basic;
+        JsonHandler json;
+    } get;
+
+    union {
+        BasicHandler basic;
+        JsonHandler json;
+    } put;
+};
+
+void apiRegister(const Api& api);
 
 void apiCommonSetup();
 void apiSetup();
+
+void apiReserve(size_t);
+
+void apiError(const Api&, ApiBuffer& buffer);
+void apiOk(const Api&, ApiBuffer& buffer);
 
 #endif // API_SUPPORT == 1


### PR DESCRIPTION
- share relay dummypin instance between relay objects, replace unique_ptr with basic pointer (as we never destroy things, everything is brought up on boot and is essentially static)
- reduce overall size of the Api (web_api_t) structure, store a single required unsigned char id inside of the Api object itself.
- drop std::function for the same reason, current implementation only needs a single u8 ID in all cases
- tweak internal functions to expect a certain path size, drop strange comparisons with sprintf return value
- (kind of a hack) add manual calls to vector<Api>::reserve() as we go over the current capacity and vector increases it's size times 2. e.g. for 9 relays, we would allocate space for 32 Api objects as vector size goes from 16 to 32, after we add 18 Api objects with relay + pulse
- (breaking) json calls on a separate path, don't waste time encoding a single entity as json object when we can encode more things
- rfbridge API learn will return the current status instead of a plain OK