### PR TITLE
sns: eventsensor clean-up

### DIFF
--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -504,11 +504,6 @@
 #define EVENTS_SUPPORT                  0       // Do not build with counter support by default
 #endif
 
-#ifndef EVENTS1_TRIGGER
-#define EVENTS1_TRIGGER                  1       // 1 to trigger callback on events,
-                                                // 0 to only count them and report periodically
-#endif
-
 #ifndef EVENTS1_PIN
 #define EVENTS1_PIN                      2       // GPIO to monitor
 #endif
@@ -523,11 +518,6 @@
 
 #ifndef EVENTS1_DEBOUNCE
 #define EVENTS1_DEBOUNCE                 50      // Do not register events within less than 50 millis
-#endif
-
-#ifndef EVENTS2_TRIGGER
-#define EVENTS2_TRIGGER                  1       // 1 to trigger callback on events,
-                                                // 0 to only count them and report periodically
 #endif
 
 #ifndef EVENTS2_PIN
@@ -546,11 +536,6 @@
 #define EVENTS2_DEBOUNCE                 50      // Do not register events within less than 50 millis
 #endif
 
-#ifndef EVENTS3_TRIGGER
-#define EVENTS3_TRIGGER                  1       // 1 to trigger callback on events,
-                                                // 0 to only count them and report periodically
-#endif
-
 #ifndef EVENTS3_PIN
 #define EVENTS3_PIN                      2       // GPIO to monitor
 #endif
@@ -565,11 +550,6 @@
 
 #ifndef EVENTS3_DEBOUNCE
 #define EVENTS3_DEBOUNCE                 50      // Do not register events within less than 50 millis
-#endif
-
-#ifndef EVENTS4_TRIGGER
-#define EVENTS4_TRIGGER                  1       // 1 to trigger callback on events,
-                                                // 0 to only count them and report periodically
 #endif
 
 #ifndef EVENTS4_PIN
@@ -588,11 +568,6 @@
 #define EVENTS4_DEBOUNCE                 50      // Do not register events within less than 50 millis
 #endif
 
-#ifndef EVENTS5_TRIGGER
-#define EVENTS5_TRIGGER                  1       // 1 to trigger callback on events,
-                                                // 0 to only count them and report periodically
-#endif
-
 #ifndef EVENTS5_PIN
 #define EVENTS5_PIN                      2       // GPIO to monitor
 #endif
@@ -607,11 +582,6 @@
 
 #ifndef EVENTS5_DEBOUNCE
 #define EVENTS5_DEBOUNCE                 50      // Do not register events within less than 50 millis
-#endif
-
-#ifndef EVENTS6_TRIGGER
-#define EVENTS6_TRIGGER                  1       // 1 to trigger callback on events,
-                                                // 0 to only count them and report periodically
 #endif
 
 #ifndef EVENTS6_PIN
@@ -630,11 +600,6 @@
 #define EVENTS6_DEBOUNCE                 50      // Do not register events within less than 50 millis
 #endif
 
-#ifndef EVENTS7_TRIGGER
-#define EVENTS7_TRIGGER                  1       // 1 to trigger callback on events,
-                                                // 0 to only count them and report periodically
-#endif
-
 #ifndef EVENTS7_PIN
 #define EVENTS7_PIN                      2       // GPIO to monitor
 #endif
@@ -649,11 +614,6 @@
 
 #ifndef EVENTS7_DEBOUNCE
 #define EVENTS7_DEBOUNCE                 50      // Do not register events within less than 50 millis
-#endif
-
-#ifndef EVENTS8_TRIGGER
-#define EVENTS8_TRIGGER                  1       // 1 to trigger callback on events,
-                                                // 0 to only count them and report periodically
 #endif
 
 #ifndef EVENTS8_PIN

--- a/code/espurna/sensor.cpp
+++ b/code/espurna/sensor.cpp
@@ -520,17 +520,14 @@ BaseFilter* _magnitudeCreateFilter(unsigned char type, size_t size) {
     case MAGNITUDE_ENERGY:
         filter = new LastFilter();
         break;
+    case MAGNITUDE_COUNT:
+    case MAGNITUDE_GEIGER_CPM:
+    case MAGNITUDE_GEIGER_SIEVERT:
     case MAGNITUDE_ENERGY_DELTA:
         filter = new SumFilter();
         break;
     case MAGNITUDE_DIGITAL:
         filter = new MaxFilter();
-        break;
-    // For geiger counting moving average filter is the most appropriate if needed at all.
-    case MAGNITUDE_COUNT:
-    case MAGNITUDE_GEIGER_CPM:
-    case MAGNITUDE_GEIGER_SIEVERT:
-        filter = new MovingAverageFilter();
         break;
     default:
         filter = new MedianFilter();
@@ -2752,23 +2749,7 @@ void sensorLoop() {
             }
 
             magnitude.last = value_raw;
-
-            // -------------------------------------------------------------
-            // Processing (filters)
-            // -------------------------------------------------------------
-
             magnitude.filter->add(value_raw);
-
-            // Special case for MovingAverageFilter
-            switch (magnitude.type) {
-                case MAGNITUDE_COUNT:
-                case MAGNITUDE_GEIGER_CPM:
-                case MAGNITUDE_GEIGER_SIEVERT:
-                    value_raw = magnitude.filter->result();
-                    break;
-                default:
-                    break;
-            }
 
             // -------------------------------------------------------------
             // Procesing (units and decimals)

--- a/code/espurna/sensor.cpp
+++ b/code/espurna/sensor.cpp
@@ -1777,101 +1777,73 @@ void _sensorLoad() {
 
     #if EVENTS_SUPPORT
     {
-        #if (EVENTS1_PIN != GPIO_NONE)
-        {
-            EventSensor * sensor = new EventSensor();
-            sensor->setGPIO(EVENTS1_PIN);
-            sensor->setTrigger(EVENTS1_TRIGGER);
-            sensor->setPinMode(EVENTS1_PIN_MODE);
-            sensor->setDebounceTime(EVENTS1_DEBOUNCE);
-            sensor->setInterruptMode(EVENTS1_INTERRUPT_MODE);
-            _sensors.push_back(sensor);
-        }
-        #endif
+        auto getPin = [](unsigned char index) -> int {
+            switch (index) {
+            case 0: return EVENTS1_PIN;
+            case 1: return EVENTS2_PIN;
+            case 2: return EVENTS3_PIN;
+            case 3: return EVENTS4_PIN;
+            case 4: return EVENTS5_PIN;
+            case 5: return EVENTS6_PIN;
+            case 6: return EVENTS7_PIN;
+            case 7: return EVENTS8_PIN;
+            default: return GPIO_NONE;
+            }
+        };
 
-        #if (EVENTS2_PIN != GPIO_NONE)
-        {
-            EventSensor * sensor = new EventSensor();
-            sensor->setGPIO(EVENTS2_PIN);
-            sensor->setTrigger(EVENTS2_TRIGGER);
-            sensor->setPinMode(EVENTS2_PIN_MODE);
-            sensor->setDebounceTime(EVENTS2_DEBOUNCE);
-            sensor->setInterruptMode(EVENTS2_INTERRUPT_MODE);
-            _sensors.push_back(sensor);
-        }
-        #endif
+        auto getMode = [](unsigned char index) -> int {
+            switch (index) {
+            case 0: return EVENTS1_PIN_MODE;
+            case 1: return EVENTS2_PIN_MODE;
+            case 2: return EVENTS3_PIN_MODE;
+            case 3: return EVENTS4_PIN_MODE;
+            case 4: return EVENTS5_PIN_MODE;
+            case 5: return EVENTS6_PIN_MODE;
+            case 6: return EVENTS7_PIN_MODE;
+            case 7: return EVENTS8_PIN_MODE;
+            default: return INPUT;
+            }
+        };
 
-        #if (EVENTS3_PIN != GPIO_NONE)
-        {
-            EventSensor * sensor = new EventSensor();
-            sensor->setGPIO(EVENTS3_PIN);
-            sensor->setTrigger(EVENTS3_TRIGGER);
-            sensor->setPinMode(EVENTS3_PIN_MODE);
-            sensor->setDebounceTime(EVENTS3_DEBOUNCE);
-            sensor->setInterruptMode(EVENTS3_INTERRUPT_MODE);
-            _sensors.push_back(sensor);
-        }
-        #endif
+        auto getDebounce = [](unsigned char index) -> unsigned long {
+            switch (index) {
+            case 0: return EVENTS1_DEBOUNCE;
+            case 1: return EVENTS2_DEBOUNCE;
+            case 2: return EVENTS3_DEBOUNCE;
+            case 3: return EVENTS4_DEBOUNCE;
+            case 4: return EVENTS5_DEBOUNCE;
+            case 5: return EVENTS6_DEBOUNCE;
+            case 6: return EVENTS7_DEBOUNCE;
+            case 7: return EVENTS8_DEBOUNCE;
+            default: return 50;
+            }
+        };
 
-        #if (EVENTS4_PIN != GPIO_NONE)
-        {
-            EventSensor * sensor = new EventSensor();
-            sensor->setGPIO(EVENTS4_PIN);
-            sensor->setTrigger(EVENTS4_TRIGGER);
-            sensor->setPinMode(EVENTS4_PIN_MODE);
-            sensor->setDebounceTime(EVENTS4_DEBOUNCE);
-            sensor->setInterruptMode(EVENTS4_INTERRUPT_MODE);
-            _sensors.push_back(sensor);
-        }
-        #endif
+        auto getIsrMode = [](unsigned char index) -> int {
+            switch (index) {
+            case 0: return EVENTS1_INTERRUPT_MODE;
+            case 1: return EVENTS2_INTERRUPT_MODE;
+            case 2: return EVENTS3_INTERRUPT_MODE;
+            case 3: return EVENTS4_INTERRUPT_MODE;
+            case 4: return EVENTS5_INTERRUPT_MODE;
+            case 5: return EVENTS6_INTERRUPT_MODE;
+            case 6: return EVENTS7_INTERRUPT_MODE;
+            case 7: return EVENTS8_INTERRUPT_MODE;
+            default: return RISING;
+            }
+        };
 
-        #if (EVENTS5_PIN != GPIO_NONE)
-        {
-            EventSensor * sensor = new EventSensor();
-            sensor->setGPIO(EVENTS5_PIN);
-            sensor->setTrigger(EVENTS5_TRIGGER);
-            sensor->setPinMode(EVENTS5_PIN_MODE);
-            sensor->setDebounceTime(EVENTS5_DEBOUNCE);
-            sensor->setInterruptMode(EVENTS5_INTERRUPT_MODE);
-            _sensors.push_back(sensor);
-        }
-        #endif
+        for (unsigned char index = 0; index < GpioPins; ++index) {
+            const auto pin = getPin(index);
+            if (pin == GPIO_NONE) break;
 
-        #if (EVENTS6_PIN != GPIO_NONE)
-        {
             EventSensor * sensor = new EventSensor();
-            sensor->setGPIO(EVENTS6_PIN);
-            sensor->setTrigger(EVENTS6_TRIGGER);
-            sensor->setPinMode(EVENTS6_PIN_MODE);
-            sensor->setDebounceTime(EVENTS6_DEBOUNCE);
-            sensor->setInterruptMode(EVENTS6_INTERRUPT_MODE);
+            sensor->setGPIO(pin);
+            sensor->setPinMode(getMode(index));
+            sensor->setDebounceTime(getDebounce(index));
+            sensor->setInterruptMode(getIsrMode(index));
             _sensors.push_back(sensor);
         }
-        #endif
-
-        #if (EVENTS7_PIN != GPIO_NONE)
-        {
-            EventSensor * sensor = new EventSensor();
-            sensor->setGPIO(EVENTS7_PIN);
-            sensor->setTrigger(EVENTS7_TRIGGER);
-            sensor->setPinMode(EVENTS7_PIN_MODE);
-            sensor->setDebounceTime(EVENTS7_DEBOUNCE);
-            sensor->setInterruptMode(EVENTS7_INTERRUPT_MODE);
-            _sensors.push_back(sensor);
-        }
-        #endif
-
-        #if (EVENTS8_PIN != GPIO_NONE)
-        {
-            EventSensor * sensor = new EventSensor();
-            sensor->setGPIO(EVENTS8_PIN);
-            sensor->setTrigger(EVENTS8_TRIGGER);
-            sensor->setPinMode(EVENTS8_PIN_MODE);
-            sensor->setDebounceTime(EVENTS8_DEBOUNCE);
-            sensor->setInterruptMode(EVENTS8_INTERRUPT_MODE);
-            _sensors.push_back(sensor);
-        }
-        #endif
     }
     #endif
 


### PR DESCRIPTION
- use SumFilter by default for the counter, since most of the time we don't want the value to aggregate between reports
(especially, when we don't know for how long at a glance), same as energy delta.
ref. https://gitter.im/tinkerman-cat/espurna?at=5f6661a1f969413294f7404d
- always do digitalRead() after ISR, since we don't have triggers anymore. we need some further changes to make it more dynamic though, as the reading speed can only be as low as every 1s
- (untested!) try to use atomics instead of volatile, based on the espsoftwareserial example