### PR TITLE
Add sleep support for Nova Fitness SDS011 sensor

### DIFF
--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -1001,6 +1001,19 @@
 #define SDS011_TX_PIN                    12
 #endif
 
+#ifndef SDS011_REPORTING_MODE
+#define SDS011_REPORTING_MODE            1   // Mode 0 = query, 1 = active. Default mode is 'active' where data is
+#endif                                       // read from software serial instead of querying the sensor.
+
+#ifndef SDS011_CUSTOM_WORKING_PERIOD
+#define SDS011_CUSTOM_WORKING_PERIOD     300 // Duration of the cycle in seconds. Each cycle works as follows:
+#endif                                       // for each working period, 30 seconds will be reserved for waking up
+                                             // the sensor, measuring and at the end of cycle, a new reading will be
+                                             // provided. For example, for a working period of 300 second (5 minutes)
+                                             // the sensor will wake up after 4.5 minutes, work for 0.5 minutes
+                                             // (completing the working period of 5 minutes) and sleep for another
+                                             // 4.5 minutes. This is the recommended setting.
+
 //------------------------------------------------------------------------------
 // SenseAir CO2 sensor
 // Enable support by passing SENSEAIR_SUPPORT=1 build flag

--- a/code/espurna/sensors/BaseSensor.h
+++ b/code/espurna/sensors/BaseSensor.h
@@ -111,6 +111,7 @@ class BaseSensor {
                     return sensor::Unit::KilowattHour;
                 case MAGNITUDE_PM1dot0:
                 case MAGNITUDE_PM2dot5:
+                case MAGNITUDE_PM10:
                     return sensor::Unit::MicrogrammPerCubicMeter;
                 case MAGNITUDE_CO:
                 case MAGNITUDE_CO2:

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -153,6 +153,7 @@ lib_deps =
     https://github.com/ThingPulse/esp8266-oled-ssd1306#3398c97
     Adafruit SI1145 Library@~1.1.1
     https://github.com/BoschSensortec/BSEC-Arduino-library.git#c5503e0
+    https://github.com/lewapek/sds-dust-sensors-arduino-library#154c711
 
 # ------------------------------------------------------------------------------
 # COMMON ENVIRONMENT SETTINGS:


### PR DESCRIPTION
The Nova Fitness SDS011 sensor has a limited lifespan time of 8000 hours, or roughly 1 year of continuous operation. This lifespan can be largely extended if the sensor is configured to sleep for a certain amount of time (the so called 'working cycles'), wake up to take a measurement, and then going back to sleep again.

This PR changes the default behaviour of this integration to benefit from these working cycles as users might inadvertently be 'killing' their sensors by an overly aggressive continuous reading strategy. 