### PR TITLE
alexa: fix device discovery / state callback

### DIFF
--- a/code/espurna/api.cpp
+++ b/code/espurna/api.cpp
@@ -223,37 +223,8 @@ bool _apiRequestCallback(AsyncWebServerRequest* request) {
         return true;
     }
 
-    bool needAuth = true;
-    if ( getSetting("alexaEnabled", 1 == ALEXA_ENABLED) )
-    {
-        String alexaHash = getSetting("alexaHash", "none");
-        if ( (url.startsWith("/api/" + alexaHash)) && (alexaHash != "none") )
-        {
-
-            needAuth = false;
-        } else
-        {
-            if (url.equals("/description.xml")) {
-                if ( alexaHash != "in_progress" )
-                {
-                    setSetting("alexaHash", "in_progress");
-                }
-            } else if ( (url.startsWith("/api/")) && (url.endsWith("/lights")) && (alexaHash == "in_progress") )
-            {
-                alexaHash = url;
-                alexaHash.remove(alexaHash.length()-7,7); // strip "/lights"
-                alexaHash.remove(0,5); // strip "/api/"
-                setSetting("alexaHash", alexaHash);
-                needAuth = false;
-            } else if (alexaHash == "in_progress")
-            {
-                setSetting("alexaHash", "none");
-            }
-        }
-    }
-
     if (!url.startsWith("/api/")) return false;
-    if (needAuth && !apiAuthenticate(request)) return false;
+    if (!apiAuthenticate(request)) return false;
 
     return _apiDispatchRequest(url, request);
 

--- a/code/espurna/api.cpp
+++ b/code/espurna/api.cpp
@@ -224,6 +224,12 @@ bool _apiRequestCallback(AsyncWebServerRequest* request) {
     }
 
     if (!url.startsWith("/api/")) return false;
+
+// [alexa] don't call the http api -> response for alexa is done by fauxmoesp lib
+#ifdef ALEXA_SUPPORT
+    if (url.indexOf("/lights") > 14 ) return false;
+#endif
+
     if (!apiAuthenticate(request)) return false;
 
     return _apiDispatchRequest(url, request);

--- a/code/espurna/api.cpp
+++ b/code/espurna/api.cpp
@@ -226,7 +226,7 @@ bool _apiRequestCallback(AsyncWebServerRequest* request) {
     if (!url.startsWith("/api/")) return false;
 
 // [alexa] don't call the http api -> response for alexa is done by fauxmoesp lib
-#ifdef ALEXA_SUPPORT
+#if ALEXA_SUPPORT
     if (url.indexOf("/lights") > 14 ) return false;
 #endif
 

--- a/code/espurna/api.cpp
+++ b/code/espurna/api.cpp
@@ -223,8 +223,37 @@ bool _apiRequestCallback(AsyncWebServerRequest* request) {
         return true;
     }
 
+    bool needAuth = true;
+    if ( getSetting("alexaEnabled", 1 == ALEXA_ENABLED) )
+    {
+        String alexaHash = getSetting("alexaHash", "none");
+        if ( (url.startsWith("/api/" + alexaHash)) && (alexaHash != "none") )
+        {
+
+            needAuth = false;
+        } else
+        {
+            if (url.equals("/description.xml")) {
+                if ( alexaHash != "in_progress" )
+                {
+                    setSetting("alexaHash", "in_progress");
+                }
+            } else if ( (url.startsWith("/api/")) && (url.endsWith("/lights")) && (alexaHash == "in_progress") )
+            {
+                alexaHash = url;
+                alexaHash.remove(alexaHash.length()-7,7); // strip "/lights"
+                alexaHash.remove(0,5); // strip "/api/"
+                setSetting("alexaHash", alexaHash);
+                needAuth = false;
+            } else if (alexaHash == "in_progress")
+            {
+                setSetting("alexaHash", "none");
+            }
+        }
+    }
+
     if (!url.startsWith("/api/")) return false;
-    if (!apiAuthenticate(request)) return false;
+    if (needAuth && !apiAuthenticate(request)) return false;
 
     return _apiDispatchRequest(url, request);
 


### PR DESCRIPTION
alexa device discovery/state calls use URL of type
/api/hash_id_key_whatever/lights

This is blocked when API is disabled and fails
also when http API is enabled because no apikey is
sent by amazon calls

This commit grabs the "whatever Amazon Hash" during
device recognition and save it. All requets to URLS
starting with /api/hash_id_key_whatever are now
passing the auth check