### PR TITLE
Stop leaking light provider config to all switches

### DIFF
--- a/code/espurna/homeassistant.cpp
+++ b/code/espurna/homeassistant.cpp
@@ -293,10 +293,10 @@ void _haSendSwitch(unsigned char i, JsonObject& config) {
 
 void ha_discovery_t::prepareSwitches(ha_config_t& config) {
 
-    // Note: because none of the keys are erased, use a separate object to avoid accidentally sending magnitude data
-    JsonObject& root = config.jsonBuffer.createObject();
-
     for (unsigned char i=0; i<relayCount(); i++) {
+        
+        // Note: because none of the keys are erased, use a separate object to avoid accidentally sending magnitude or light provider data
+        JsonObject& root = config.jsonBuffer.createObject();
 
         String topic = getSetting("haPrefix", HOMEASSISTANT_PREFIX) +
             "/" + switchType +


### PR DESCRIPTION
Bug being fixed: If the first message has an associated LED, but the second does not, then the light provider data is leaked into the second discovery message and both are presented as having an associated LED.

My C++ memory management knowledge is a little weak: I'm not sure if putting a stack variable declaration inside a loop like this works as expected or results in a leak. Experimentally, it seems to be working fine on my devices, but I'm not sure if there is a better way of executing this fix. This is also my first time touching the espurna code, so redirection is welcome :-)

My `custom.h` for reference:
```
#if defined(NETVIP_XSSSA06)


    // Info
    #define MANUFACTURER        "NETVIP"
    #define DEVICE              "XSSSA06"

    // Buttons
    #define BUTTON1_PIN         13
    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
    #define BUTTON1_RELAY       1

    // Relays
    #define RELAY1_PIN          15
    #define RELAY1_TYPE         RELAY_TYPE_NORMAL

    // Light
    #define RELAY_PROVIDER              RELAY_PROVIDER_LIGHT
    #define LIGHT_PROVIDER              LIGHT_PROVIDER_DIMMER
    #define DUMMY_RELAY_COUNT           1
    #define LIGHT_CHANNELS              3
    #define LIGHT_CH1_PIN       0   // RED
    #define LIGHT_CH2_PIN       2   // GREEN
    #define LIGHT_CH3_PIN       5   // BLUE

#endif
```

The bad discovery messages with leaked light data (should only be on one of the switches instead of both):
```
homeassistant/light/ESPURNA-26500F_0/config {"name":"ESPURNA_26500F_0","state_topic":"ESPURNA-26500F/relay/0","command_topic":"ESPURNA-26500F/relay/0/set","payload_on":"1","payload_off":"0","availability_topic":"ESPURNA-26500F/status","payload_available":"1","payload_not_available":"0","brightness_state_topic":"ESPURNA-26500F/brightness","brightness_command_topic":"ESPURNA-26500F/brightness/set","rgb_state_topic":"ESPURNA-26500F/rgb","rgb_command_topic":"ESPURNA-26500F/rgb/set","color_temp_command_topic":"ESPURNA-26500F/mired/set","color_temp_state_topic":"ESPURNA-26500F/mired","uniq_id":"ESPURNA-26500F_light_0","device":{"identifiers":["ESPURNA-26500F"],"name":"ESPURNA-26500F","sw_version":"ESPURNA 1.15.0-dev (2.7.1)","manufacturer":"NETVIP","model":"XSSSA06"}} 
homeassistant/light/ESPURNA-26500F_1/config {"name":"ESPURNA_26500F_1","state_topic":"ESPURNA-26500F/relay/1","command_topic":"ESPURNA-26500F/relay/1/set","payload_on":"1","payload_off":"0","availability_topic":"ESPURNA-26500F/status","payload_available":"1","payload_not_available":"0","brightness_state_topic":"ESPURNA-26500F/brightness","brightness_command_topic":"ESPURNA-26500F/brightness/set","rgb_state_topic":"ESPURNA-26500F/rgb","rgb_command_topic":"ESPURNA-26500F/rgb/set","color_temp_command_topic":"ESPURNA-26500F/mired/set","color_temp_state_topic":"ESPURNA-26500F/mired","uniq_id":"ESPURNA-26500F_light_1","device":{"identifiers":["ESPURNA-26500F"],"name":"ESPURNA-26500F","sw_version":"ESPURNA 1.15.0-dev (2.7.1)","manufacturer":"NETVIP","model":"XSSSA06"}}
```

The fixed output that shows up properly in HA:
```
homeassistant/light/ESPURNA-2646DE_1/config {"name":"ESPURNA_2646DE_1","state_topic":"ESPURNA-2646DE/relay/1","command_topic":"ESPURNA-2646DE/relay/1/set","payload_on":"1","payload_off":"0","availability_topic":"ESPURNA-2646DE/status","payload_available":"1","payload_not_available":"0","uniq_id":"ESPURNA-2646DE_light_1","device":{"identifiers":["ESPURNA-2646DE"],"name":"ESPURNA-2646DE","sw_version":"ESPURNA 1.15.0-dev (2.7.4)","manufacturer":"NETVIP","model":"XSSSA06"}}
homeassistant/light/ESPURNA-2646DE_0/config {"name":"ESPURNA_2646DE_0","state_topic":"ESPURNA-2646DE/relay/0","command_topic":"ESPURNA-2646DE/relay/0/set","payload_on":"1","payload_off":"0","availability_topic":"ESPURNA-2646DE/status","payload_available":"1","payload_not_available":"0","brightness_state_topic":"ESPURNA-2646DE/brightness","brightness_command_topic":"ESPURNA-2646DE/brightness/set","rgb_state_topic":"ESPURNA-2646DE/rgb","rgb_command_topic":"ESPURNA-2646DE/rgb/set","color_temp_command_topic":"ESPURNA-2646DE/mired/set","color_temp_state_topic":"ESPURNA-2646DE/mired","uniq_id":"ESPURNA-2646DE_light_0","device":{"identifiers":["ESPURNA-2646DE"],"name":"ESPURNA-2646DE","sw_version":"ESPURNA 1.15.0-dev (2.7.4)","manufacturer":"NETVIP","model":"XSSSA06"}}
```