### PR TITLE
fauxmoesp new repository

### DIFF
--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -133,7 +133,7 @@ lib_deps =
     https://github.com/xoseperez/eeprom_rotate#0.9.2
     https://github.com/plerup/espsoftwareserial#3.4.1
     https://github.com/me-no-dev/ESPAsyncWebServer#b0c6144
-    https://bitbucket.org/xoseperez/fauxmoesp.git#3.1.0
+    https://github.com/vintlabs/fauxmoESP#3.1.2
     https://github.com/xoseperez/hlw8012.git#1.1.0
     IRremoteESP8266@2.7.4
     https://github.com/mcspr/justwifi.git#2cb9e769


### PR DESCRIPTION
Accodding to notice at https://bitbucket.org/xoseperez/fauxmoesp it's currently maintained elsewhere.
> As of October 2020, this project is now being maintained at https://github.com/vintlabs/fauxmoESP

(found out after being struck by vintlabs/fauxmoESP#120 which is fixed in release 3.1.2)