### PR TITLE
Fix initialization of _adc_counts for BaseAnalogEmonSensor

### DIFF
--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -508,6 +508,10 @@
 #define EMON_ANALOG_SUPPORT             0       // Do not build support by default
 #endif
 
+#ifndef EMON_ANALOG_RESOLUTION
+#define EMON_ANALOG_RESOLUTION          10      // ADC resolution (in bits)
+#endif
+
 //------------------------------------------------------------------------------
 // Counter sensor
 // Enable support by passing EVENTS_SUPPORT=1 build flag

--- a/code/espurna/sensor.cpp
+++ b/code/espurna/sensor.cpp
@@ -1926,6 +1926,7 @@ void _sensorLoad() {
         auto* sensor = new EmonAnalogSensor();
         sensor->setVoltage(EMON_MAINS_VOLTAGE);
         sensor->setReferenceVoltage(EMON_REFERENCE_VOLTAGE);
+        sensor->setResolution(EMON_ANALOG_RESOLUTION);
         _sensors.push_back(sensor);
     }
     #endif

--- a/code/espurna/sensors/BaseAnalogEmonSensor.h
+++ b/code/espurna/sensors/BaseAnalogEmonSensor.h
@@ -236,8 +236,8 @@ private:
     size_t _samples_max { EMON_MAX_SAMPLES };       // Number of samples, will be adjusted at runtime
     size_t _samples { _samples_max };               // based on the maximum value
 
-    size_t _resolution { 10 };                      // ADC resolution (in bits)
-    size_t _adc_counts { _resolution << 1 };        // Max count
+    size_t _resolution { EMON_ANALOG_RESOLUTION };  // ADC resolution (in bits)
+    size_t _adc_counts { static_cast<size_t>(1) << _resolution };       // Max count
 };
 
 // Provide EMON API helper where we don't care about specifics of how the values are stored


### PR DESCRIPTION
`_adc_counts` is not initialized correctly in [BaseAnalogEmonSensor.h](https://github.com/xoseperez/espurna/blob/f748b6487ca172824266c873916e76786a0080df/code/espurna/sensors/BaseAnalogEmonSensor.h#L239) 

https://github.com/xoseperez/espurna/blob/f748b6487ca172824266c873916e76786a0080df/code/espurna/sensors/BaseAnalogEmonSensor.h#L239-L240

It produces 20 instead of 1024 when the resolution is 10 bits.

This PR fixes `_adc_counts`, restores `EMON_ANALOG_RESOLUTION` and sets the resolution of `EmonAnalogSensor` when instantiated. 