### PR TITLE
SHT3X: add 0x44 address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix setting up GPIO0 as INPUT when preparing to use analogRead(A0) ([ff11e581](https://github.com/xoseperez/espurna/commit/ff11e5814ff1fc938afa439c15f57fa9909b9e4a))
 - Only change EventSensor counter from the ISR ([735e5c0e](https://github.com/xoseperez/espurna/commit/735e5c0ec22fabfdcfa55123b9bceaa3d8f917b8))
 - Fix a typo when getting local index for Nth magnitude ([6ba5f95e](https://github.com/xoseperez/espurna/commit/6ba5f95e875468f2b7a93c69b45fc6f6c62f390f))
+- SHT3X: add missing I2C address A (0x44) ([#2484](https://github.com/xoseperez/espurna/issues/2484), thanks to **[@drc38](https://github.com/drc38)**)
 #### Settings
 - Fix saving base2 integers ([71ddf350](https://github.com/xoseperez/espurna/commit/71ddf35022678667d0269ecc9c60c69bdab68079))
 #### System

--- a/code/espurna/sensors/SHT3XI2CSensor.h
+++ b/code/espurna/sensors/SHT3XI2CSensor.h
@@ -41,7 +41,7 @@ class SHT3XI2CSensor : public I2CSensor<> {
             nice_delay(500);
             _ready = true;
             _dirty = false;
-            
+
         }
 
         // Descriptive name of the sensor

--- a/code/espurna/sensors/SHT3XI2CSensor.h
+++ b/code/espurna/sensors/SHT3XI2CSensor.h
@@ -34,13 +34,14 @@ class SHT3XI2CSensor : public I2CSensor<> {
             if (!_dirty) return;
 
             // I2C auto-discover
-            unsigned char addresses[] = {0x45};
+            unsigned char addresses[] = {0x44,0x45};
             _address = _begin_i2c(_address, sizeof(addresses), addresses);
             if (_address == 0) return;
-
+            i2c_write_uint8(_address, 0x30, 0xA2); // Soft reset to ensure sensor in default state
+            nice_delay(500);
             _ready = true;
             _dirty = false;
-
+            
         }
 
         // Descriptive name of the sensor
@@ -63,7 +64,7 @@ class SHT3XI2CSensor : public I2CSensor<> {
             _error = SENSOR_ERROR_OK;
 
             unsigned char buffer[6];
-            i2c_write_uint8(_address, 0x2C, 0x06);
+            i2c_write_uint8(_address, 0x2C, 0x06); // Measurement High Repeatability with Clock Stretch Enabled
             nice_delay(500);
             i2c_read_buffer(_address, buffer, 6);
 


### PR DESCRIPTION
amend code to work with both i2c addresses as per datasheet https://dfimg.dfrobot.com/nobody/wiki/88b31350da4f54d00989c74c6fa392f7.pdf