### PR TITLE
Add support for Yagusmart 1, 2 ad 3 gang switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Add support for Gosund P1 Power Strip ([#2391](https://github.com/xoseperez/espurna/issues/2391), thanks to **[@alextircovnicu](https://github.com/alextircovnicu)**)
 - Add support for Mirabella Genio White A60 globe ([#2439](https://github.com/xoseperez/espurna/issues/2439], [2fc559fa](https://github.com/xoseperez/espurna/commit/2fc559fa5596c6ae3f3cc906177e287c38c6333e), thanks to **[@andrewleech](https://github.com/andrewleech)**)
 - Refactor iFan into a separate module ([a40eca30](https://github.com/xoseperez/espurna/commit/a40eca30ad79315afdb67afa0b0743d4c0087e93))
+- Add support for Yagusmart switches ([#2488](https://github.com/xoseperez/espurna/pull/2488), thanks to **[@MelanieT](https://github.com/MelanieT)**)
 #### HomeAssistant
 - Advertise lights transition support in the discovery message ([4d157ccd5](https://github.com/xoseperez/espurna/commit/4d157ccd5bd5ffefa8b0bca79c4b2196c8a3e5dc))
 - Reworked discovery, implement retries and queueing using the MQTT broker ACKs ([59269789](https://github.com/xoseperez/espurna/commit/59269789dc80308e9afc1e4b3051d9d33e13bf8f))

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -825,116 +825,6 @@
     // Only used when RFB_PROVIDER is RCSWITCH
     #define RFB_RX_PIN          4
     #define RFB_TX_PIN          5
-#elif defined(YAGUSMART_TOUCH_HWMOD_1G)
-    // Info
-    #define MANUFACTURER        "YAGUSMART"
-    #define DEVICE              "TOUCH_HWMOD_1G"
-
-    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
-    #define BUTTON1_PIN         3
-    #define BUTTON1_RELAY       1
-    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
-    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
-
-    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
-    #define RELAY1_PIN          13
-
-    #define LED2_PIN                    14
-    #define LED2_PIN_INVERSE            1
-    #define LED2_MODE                   LED_MODE_FOLLOW
-    #define LED2_RELAY                  1
-
-    #define LED1_PIN                    0
-    #define LED1_PIN_INVERSE            1
-    #define LED1_MODE                   LED_MODE_WIFI
-
-    #define DEBUG_SERIAL_SUPPORT        0
-
-#elif defined(YAGUSMART_TOUCH_HWMOD_2G)
-    // Info
-    #define MANUFACTURER        "YAGUSMART"
-    #define DEVICE              "TOUCH_HWMOD_2G"
-
-    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
-    #define BUTTON1_PIN         3
-    #define BUTTON1_RELAY       1
-    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
-    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
-
-    #define BUTTON2_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
-    #define BUTTON2_PIN         5
-    #define BUTTON2_RELAY       2
-    #define BUTTON2_PRESS       BUTTON_ACTION_TOGGLE
-    #define BUTTON2_CLICK       BUTTON_ACTION_NONE
-
-    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
-    #define RELAY1_PIN          13
-    #define RELAY2_TYPE         RELAY_TYPE_NORMAL
-    #define RELAY2_PIN          4
-
-    #define LED2_PIN                    14
-    #define LED2_PIN_INVERSE            1
-    #define LED2_MODE                   LED_MODE_FOLLOW
-    #define LED2_RELAY                  1
-
-    #define LED3_PIN                    1
-    #define LED3_PIN_INVERSE            1
-    #define LED3_MODE                   LED_MODE_FOLLOW
-    #define LED3_RELAY                  2
-
-    #define LED1_PIN                    0
-    #define LED1_PIN_INVERSE            1
-    #define LED1_MODE                   LED_MODE_WIFI
-
-    #define DEBUG_SERIAL_SUPPORT        0
-
-#elif defined(YAGUSMART_TOUCH_HWMOD_3G)
-    // Info
-    #define MANUFACTURER        "YAGUSMART"
-    #define DEVICE              "TOUCH_HWMOD_3G"
-
-    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
-    #define BUTTON1_PIN         12
-    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
-    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
-
-    #define BUTTON2_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
-    #define BUTTON2_PIN         3
-    #define BUTTON2_PRESS       BUTTON_ACTION_TOGGLE
-    #define BUTTON2_CLICK       BUTTON_ACTION_NONE
-
-    #define BUTTON3_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
-    #define BUTTON3_PIN         5
-    #define BUTTON3_PRESS       BUTTON_ACTION_TOGGLE
-    #define BUTTON3_CLICK       BUTTON_ACTION_NONE
-
-    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
-    #define RELAY1_PIN          13
-    #define RELAY2_TYPE         RELAY_TYPE_NORMAL
-    #define RELAY2_PIN          4
-    #define RELAY3_TYPE         RELAY_TYPE_NORMAL
-    #define RELAY3_PIN          15
-
-    #define LED2_PIN                    16
-    #define LED2_PIN_INVERSE            1
-    #define LED2_MODE                   LED_MODE_FOLLOW
-    #define LED2_RELAY                  1
-
-    #define LED3_PIN                    14
-    #define LED3_PIN_INVERSE            1
-    #define LED3_MODE                   LED_MODE_FOLLOW
-    #define LED3_RELAY                  2
-
-    #define LED4_PIN                    1
-    #define LED4_PIN_INVERSE            1
-    #define LED4_MODE                   LED_MODE_FOLLOW
-    #define LED4_RELAY                  3
-
-    #define LED1_PIN                    0
-    #define LED1_PIN_INVERSE            1
-    #define LED1_MODE                   LED_MODE_WIFI
-
-    #define DEBUG_SERIAL_SUPPORT        0
 
 #elif defined(ITEAD_SONOFF_B1)
 
@@ -5122,6 +5012,128 @@
 
     // Light
     #define LIGHT_CH1_PIN       14       // WHITE
+
+// -----------------------------------------------------------------------------
+// https://www.amazon.co.uk/gp/product/B086MV5MC8
+//
+// These don't come with an esp8266 anymore, but can be trivially converted
+// as the new chip is pin compatible. Note, GPIO15 needs to be connected to
+// GND on 1 and 2 gang switches in order to enable the ESP to boot.
+//
+// Older versions and some US models may still ship with ESP8266.
+//
+// Caution, do NOT solder a serial port while the board is connected to the mains baseboard,
+// it will blow your fuse and your USB!
+// If you need to flash with a programmer, use a bench power supply on the logic board only!
+// -----------------------------------------------------------------------------
+
+#elif defined(YAGUSMART_TOUCH_HWMOD_1G)
+    #define MANUFACTURER        "YAGUSMART"
+    #define DEVICE              "TOUCH_HWMOD_1G"
+
+    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_PIN         3
+    #define BUTTON1_RELAY       1
+    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
+
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY1_PIN          13
+
+    #define LED2_PIN                    14
+    #define LED2_PIN_INVERSE            1
+    #define LED2_MODE                   LED_MODE_FOLLOW
+    #define LED2_RELAY                  1
+
+    #define LED1_PIN                    0
+    #define LED1_PIN_INVERSE            1
+    #define LED1_MODE                   LED_MODE_WIFI
+
+    #define DEBUG_SERIAL_SUPPORT        0
+
+#elif defined(YAGUSMART_TOUCH_HWMOD_2G)
+    #define MANUFACTURER        "YAGUSMART"
+    #define DEVICE              "TOUCH_HWMOD_2G"
+
+    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_PIN         3
+    #define BUTTON1_RELAY       1
+    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
+
+    #define BUTTON2_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON2_PIN         5
+    #define BUTTON2_RELAY       2
+    #define BUTTON2_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON2_CLICK       BUTTON_ACTION_NONE
+
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY1_PIN          13
+    #define RELAY2_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY2_PIN          4
+
+    #define LED2_PIN                    14
+    #define LED2_PIN_INVERSE            1
+    #define LED2_MODE                   LED_MODE_FOLLOW
+    #define LED2_RELAY                  1
+
+    #define LED3_PIN                    1
+    #define LED3_PIN_INVERSE            1
+    #define LED3_MODE                   LED_MODE_FOLLOW
+    #define LED3_RELAY                  2
+
+    #define LED1_PIN                    0
+    #define LED1_PIN_INVERSE            1
+    #define LED1_MODE                   LED_MODE_WIFI
+
+    #define DEBUG_SERIAL_SUPPORT        0
+
+#elif defined(YAGUSMART_TOUCH_HWMOD_3G)
+    #define MANUFACTURER        "YAGUSMART"
+    #define DEVICE              "TOUCH_HWMOD_3G"
+
+    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
+    #define BUTTON1_PIN         12
+    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
+
+    #define BUTTON2_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
+    #define BUTTON2_PIN         3
+    #define BUTTON2_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON2_CLICK       BUTTON_ACTION_NONE
+
+    #define BUTTON3_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
+    #define BUTTON3_PIN         5
+    #define BUTTON3_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON3_CLICK       BUTTON_ACTION_NONE
+
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY1_PIN          13
+    #define RELAY2_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY2_PIN          4
+    #define RELAY3_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY3_PIN          15
+
+    #define LED2_PIN                    16
+    #define LED2_PIN_INVERSE            1
+    #define LED2_MODE                   LED_MODE_FOLLOW
+    #define LED2_RELAY                  1
+
+    #define LED3_PIN                    14
+    #define LED3_PIN_INVERSE            1
+    #define LED3_MODE                   LED_MODE_FOLLOW
+    #define LED3_RELAY                  2
+
+    #define LED4_PIN                    1
+    #define LED4_PIN_INVERSE            1
+    #define LED4_MODE                   LED_MODE_FOLLOW
+    #define LED4_RELAY                  3
+
+    #define LED1_PIN                    0
+    #define LED1_PIN_INVERSE            1
+    #define LED1_MODE                   LED_MODE_WIFI
+
+    #define DEBUG_SERIAL_SUPPORT        0
 
 #else
 

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -828,7 +828,7 @@
 #elif defined(YAGUSMART_TOUCH_HWMOD_1G)
     // Info
     #define MANUFACTURER        "YAGUSMART"
-    #define DEVICE              "1_GANG_SWITCH"
+    #define DEVICE              "TOUCH_HWMOD_1G"
 
     #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
     #define BUTTON1_PIN         3
@@ -853,7 +853,7 @@
 #elif defined(YAGUSMART_TOUCH_HWMOD_2G)
     // Info
     #define MANUFACTURER        "YAGUSMART"
-    #define DEVICE              "2_GANG_SWITCH"
+    #define DEVICE              "TOUCH_HWMOD_2G"
 
     #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
     #define BUTTON1_PIN         3
@@ -891,7 +891,7 @@
 #elif defined(YAGUSMART_TOUCH_HWMOD_3G)
     // Info
     #define MANUFACTURER        "YAGUSMART"
-    #define DEVICE              "3_GANG_SWITCH"
+    #define DEVICE              "TOUCH_HWMOD_3G"
 
     #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
     #define BUTTON1_PIN         12

--- a/code/espurna/config/hardware.h
+++ b/code/espurna/config/hardware.h
@@ -825,6 +825,116 @@
     // Only used when RFB_PROVIDER is RCSWITCH
     #define RFB_RX_PIN          4
     #define RFB_TX_PIN          5
+#elif defined(YAGUSMART_TOUCH_HWMOD_1G)
+    // Info
+    #define MANUFACTURER        "YAGUSMART"
+    #define DEVICE              "1_GANG_SWITCH"
+
+    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_PIN         3
+    #define BUTTON1_RELAY       1
+    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
+
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY1_PIN          13
+
+    #define LED2_PIN                    14
+    #define LED2_PIN_INVERSE            1
+    #define LED2_MODE                   LED_MODE_FOLLOW
+    #define LED2_RELAY                  1
+
+    #define LED1_PIN                    0
+    #define LED1_PIN_INVERSE            1
+    #define LED1_MODE                   LED_MODE_WIFI
+
+    #define DEBUG_SERIAL_SUPPORT        0
+
+#elif defined(YAGUSMART_TOUCH_HWMOD_2G)
+    // Info
+    #define MANUFACTURER        "YAGUSMART"
+    #define DEVICE              "2_GANG_SWITCH"
+
+    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON1_PIN         3
+    #define BUTTON1_RELAY       1
+    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
+
+    #define BUTTON2_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH
+    #define BUTTON2_PIN         5
+    #define BUTTON2_RELAY       2
+    #define BUTTON2_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON2_CLICK       BUTTON_ACTION_NONE
+
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY1_PIN          13
+    #define RELAY2_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY2_PIN          4
+
+    #define LED2_PIN                    14
+    #define LED2_PIN_INVERSE            1
+    #define LED2_MODE                   LED_MODE_FOLLOW
+    #define LED2_RELAY                  1
+
+    #define LED3_PIN                    1
+    #define LED3_PIN_INVERSE            1
+    #define LED3_MODE                   LED_MODE_FOLLOW
+    #define LED3_RELAY                  2
+
+    #define LED1_PIN                    0
+    #define LED1_PIN_INVERSE            1
+    #define LED1_MODE                   LED_MODE_WIFI
+
+    #define DEBUG_SERIAL_SUPPORT        0
+
+#elif defined(YAGUSMART_TOUCH_HWMOD_3G)
+    // Info
+    #define MANUFACTURER        "YAGUSMART"
+    #define DEVICE              "3_GANG_SWITCH"
+
+    #define BUTTON1_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
+    #define BUTTON1_PIN         12
+    #define BUTTON1_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON1_CLICK       BUTTON_ACTION_NONE
+
+    #define BUTTON2_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
+    #define BUTTON2_PIN         3
+    #define BUTTON2_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON2_CLICK       BUTTON_ACTION_NONE
+
+    #define BUTTON3_CONFIG      BUTTON_PUSHBUTTON | BUTTON_DEFAULT_HIGH | BUTTON_SET_PULLUP
+    #define BUTTON3_PIN         5
+    #define BUTTON3_PRESS       BUTTON_ACTION_TOGGLE
+    #define BUTTON3_CLICK       BUTTON_ACTION_NONE
+
+    #define RELAY1_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY1_PIN          13
+    #define RELAY2_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY2_PIN          4
+    #define RELAY3_TYPE         RELAY_TYPE_NORMAL
+    #define RELAY3_PIN          15
+
+    #define LED2_PIN                    16
+    #define LED2_PIN_INVERSE            1
+    #define LED2_MODE                   LED_MODE_FOLLOW
+    #define LED2_RELAY                  1
+
+    #define LED3_PIN                    14
+    #define LED3_PIN_INVERSE            1
+    #define LED3_MODE                   LED_MODE_FOLLOW
+    #define LED3_RELAY                  2
+
+    #define LED4_PIN                    1
+    #define LED4_PIN_INVERSE            1
+    #define LED4_MODE                   LED_MODE_FOLLOW
+    #define LED4_RELAY                  3
+
+    #define LED1_PIN                    0
+    #define LED1_PIN_INVERSE            1
+    #define LED1_MODE                   LED_MODE_WIFI
+
+    #define DEBUG_SERIAL_SUPPORT        0
 
 #elif defined(ITEAD_SONOFF_B1)
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1,5 +1,5 @@
 [platformio]
-default_envs = nodemcu-lolin
+default_envs = yagusmart-touch-hwmod-1g
 src_dir = espurna
 data_dir = espurna/data
 extra_configs =
@@ -496,6 +496,18 @@ src_build_flags = -DITEAD_SONOFF_S31_LITE
 [env:itead-sonoff-ifan02]
 extends = env:esp8266-1m-base
 src_build_flags = -DITEAD_SONOFF_IFAN02
+
+[env:yagusmart-touch-hwmod-1g]
+extends = env:esp8266-1m-base
+src_build_flags = -DYAGUSMART_TOUCH_HWMOD_1G
+
+[env:yagusmart-touch-hwmod-2g]
+extends = env:esp8266-1m-base
+src_build_flags = -DYAGUSMART_TOUCH_HWMOD_2G
+
+[env:yagusmart-touch-hwmod-3g]
+extends = env:esp8266-1m-base
+src_build_flags = -DYAGUSMART_TOUCH_HWMOD_3G
 
 # ------------------------------------------------------------------------------
 

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -497,18 +497,6 @@ src_build_flags = -DITEAD_SONOFF_S31_LITE
 extends = env:esp8266-1m-base
 src_build_flags = -DITEAD_SONOFF_IFAN02
 
-[env:yagusmart-touch-hwmod-1g]
-extends = env:esp8266-1m-base
-src_build_flags = -DYAGUSMART_TOUCH_HWMOD_1G
-
-[env:yagusmart-touch-hwmod-2g]
-extends = env:esp8266-1m-base
-src_build_flags = -DYAGUSMART_TOUCH_HWMOD_2G
-
-[env:yagusmart-touch-hwmod-3g]
-extends = env:esp8266-1m-base
-src_build_flags = -DYAGUSMART_TOUCH_HWMOD_3G
-
 # ------------------------------------------------------------------------------
 
 [env:electrodragon-wifi-iot]
@@ -1059,3 +1047,15 @@ src_build_flags = -DLSC_E27_10W_WHITE
 extends = env:esp8266-4m-base
 board = d1_mini
 src_build_flags = -DWEMOS_D1_MINI -DGARLAND_SUPPORT=1
+
+[env:yagusmart-touch-hwmod-1g]
+extends = env:esp8266-1m-base
+src_build_flags = -DYAGUSMART_TOUCH_HWMOD_1G
+
+[env:yagusmart-touch-hwmod-2g]
+extends = env:esp8266-1m-base
+src_build_flags = -DYAGUSMART_TOUCH_HWMOD_2G
+
+[env:yagusmart-touch-hwmod-3g]
+extends = env:esp8266-1m-base
+src_build_flags = -DYAGUSMART_TOUCH_HWMOD_3G

--- a/code/platformio.ini
+++ b/code/platformio.ini
@@ -1,5 +1,5 @@
 [platformio]
-default_envs = yagusmart-touch-hwmod-1g
+default_envs = nodemcu-lolin
 src_dir = espurna
 data_dir = espurna/data
 extra_configs =


### PR DESCRIPTION
https://www.amazon.co.uk/gp/product/B086MV5MC8

These don't come with an esp8266 anymore, but can be trivially converted
as the new chip is pin compatible. Note, GPIO15 needs to be connected to
GND on 1 and 2 gang switches in order to enable the ESP to boot.

Older versions and some US models may still ship with ESP8266.

Caution, do NOT solder a serial port while the board is connected to the mains baseboard, it will blow your fuse and your USB! If you need to flash with a programmer, use a bench power supply on the logic board only!