### PR TITLE
fix RNTC measurement equation

### DIFF
--- a/code/espurna/config/sensors.h
+++ b/code/espurna/config/sensors.h
@@ -888,6 +888,10 @@
 #define NTC_T0                          298.15  // 25 Celsius
 #endif
 
+#ifndef NTC_VIN
+#define NTC_VIN                         3.3  // Vcc
+#endif
+
 #ifndef NTC_R0
 #define NTC_R0                          10000   // Resistance at T0
 #endif

--- a/code/espurna/sensors/INA219Sensor.h
+++ b/code/espurna/sensors/INA219Sensor.h
@@ -281,7 +281,7 @@ private:
         BusVoltage busVoltage() const {
             const int16_t value = readRegister(INA219_BUS_REG);
             return {
-                .value = static_cast<int16_t>((value & ~(0b11)) >> 1),
+                .value = static_cast<int16_t>(value >> 3),
                 .ready = (value & 0b10) != 0,
                 .overflow = (value & 0b1) != 0,
             };


### PR DESCRIPTION
As the NTC Vin is not equal to ADC reference voltage then we need a new equation that takes the Vin into the calculation of the NTC Resistance. 