### PR TITLE
sns: fix slash removal in modules

### DIFF
--- a/code/espurna/prometheus.cpp
+++ b/code/espurna/prometheus.cpp
@@ -57,7 +57,7 @@ void handler(AsyncWebServerRequest* request) {
         for (size_t index = 0; index < magnitudeCount(); ++index) {
             auto value = magnitudeValue(index);
             if (value) {
-                value.topic.replace('/', '_');
+                value.topic.replace("/", "");
                 response->printf_P(PSTR("%s %s\n"),
                     value.topic.c_str(), value.repr.c_str());
             }

--- a/code/espurna/prometheus.cpp
+++ b/code/espurna/prometheus.cpp
@@ -57,7 +57,7 @@ void handler(AsyncWebServerRequest* request) {
         for (size_t index = 0; index < magnitudeCount(); ++index) {
             auto value = magnitudeValue(index);
             if (value) {
-                value.topic.remove('/');
+                value.topic.replace('/', '_');
                 response->printf_P(PSTR("%s %s\n"),
                     value.topic.c_str(), value.repr.c_str());
             }

--- a/code/espurna/rpnrules.cpp
+++ b/code/espurna/rpnrules.cpp
@@ -1104,7 +1104,7 @@ void updateVariables(const espurna::sensor::Value& value) {
     static_assert(std::is_same<decltype(value.value), rpn_float>::value, "");
 
     auto topic = value.topic;
-    topic.remove('/');
+    topic.replace("/", "");
 
     rpn_variable_set(internal::context,
             topic, rpn_value(static_cast<rpn_float>(value.value)));


### PR DESCRIPTION
fix invalid prometheus syntax `strconv.ParseFloat: parsing "/0": invalid syntax`