### PR TITLE
Wrong shift in ADC gain configuration bits

### DIFF
--- a/code/espurna/pwm.cpp
+++ b/code/espurna/pwm.cpp
@@ -17,7 +17,7 @@ Copyright (C) 2019-2022 by Maxim Prokhorov <prokhorov dot max at outlook dot com
 #endif
 
 #if defined(ESP8266) and (PWM_PROVIDER == PWM_PROVIDER_ARDUINO)
-extern "C" bool _stopPWM(uint8_t pin);
+extern "C" bool stopWaveform(uint8_t pin);
 #endif
 
 namespace espurna {
@@ -161,7 +161,7 @@ void update() {
     for (auto channel : internal::channels) {
         ::analogWrite(channel.pin, channel.duty);
         if (!channel.duty) {
-            _stopPWM(channel.pin);
+            stopWaveform(channel.pin);
         }
     }
 }

--- a/code/espurna/sensors/INA219Sensor.h
+++ b/code/espurna/sensors/INA219Sensor.h
@@ -258,7 +258,7 @@ private:
             value |= (conf.bus_mode << 7) | (conf.shunt_mode << 3);
 
             value &= ~GainMask;
-            value |= (conf.gain << 12);
+            value |= (conf.gain << 11);
 
             value &= ~BusRangeMask;
             value |= (conf.bus_range << 13);


### PR DESCRIPTION
According to the datasheet, ADC gain bits are [11...12] so we need to shift the value 11 times.