### PR TITLE
webui: Improve Scheduler type interface

### DIFF
--- a/code/html/src/template-sch.html
+++ b/code/html/src/template-sch.html
@@ -8,9 +8,9 @@
         <div class="pure-g">
             <div class="pure-control-group pure-u-1 pure-u-lg-1-4">
                 <select class="pure-input-2-3" name="schType" required>
-                    <option selected disabled value=""></option>
+                    <option selected disabled value="">Select Option</option>
                     <option value="1">Disabled</option>
-                    <option value="2">Calendar</option>
+                    <option value="2">Enabled (Calendar)</option>
                 </select>
             </div>
 


### PR DESCRIPTION
The scheduler type selection is not intuitive as there is no prompt to change the empty drop-down box to another value. This makes it obvious that something needs to be selected.