### PR TITLE
Fixes HomeAssistant deprecation warning

### DIFF
--- a/code/espurna/homeassistant.cpp
+++ b/code/espurna/homeassistant.cpp
@@ -621,7 +621,6 @@ public:
             //   'rgbww' - we receive and map 'c' to our 'cold' and 'w' to our 'warm'
             //   'cw' / 'ww' without 'rgb' are not supported; see 'brightness' or 'color_temp'
             json["brightness"] = true;
-            json["color_mode"] = true;
             JsonArray& modes = json.createNestedArray("supported_color_modes");
 
             if (lightHasColor()) {


### PR DESCRIPTION
Fixes:

> Deprecated flag `color_mode` used in MQTT JSON light config , the `color_mode` flag is not used anymore and should be removed.
> ...
> This will stop working in Home Assistant Core 2025.3
> 

According to https://github.com/home-assistant/core/pull/111676, the color_mode flag isn't used anymore in HA since 2024.04. There has been enough grace time, so this flag can safely be removed from the MQTT JSON light config.

Tested with HA 2025.01 and a handful of H801 devices.