### PR TITLE
relay(api): status applies only when active

### DIFF
--- a/code/espurna/relay.cpp
+++ b/code/espurna/relay.cpp
@@ -1911,12 +1911,14 @@ Stream* StmProvider::_port = nullptr;
 // -----------------------------------------------------------------------------
 
 bool _relayTryParseId(espurna::StringView value, size_t& id) {
-    return tryParseId(value, _relayCount(), id);
+    const auto out = tryParseId(value, _relayCount(), id);
+    return _relays_active[id] && out;
 }
 
 [[gnu::unused]]
 bool _relayTryParseIdFromPath(espurna::StringView value, size_t& id) {
-    return tryParseIdPath(value, _relayCount(), id);
+    const auto out = tryParseIdPath(value, _relayCount(), id);
+    return _relays_active[id] && out;
 }
 
 void _relayHandleStatus(size_t id, PayloadStatus status, uint8_t flags) {
@@ -2574,15 +2576,15 @@ bool _relayToggle(size_t id) {
 } // namespace
 
 bool relayStatus(size_t id, bool status) {
-    if (id < _relays.size()) {
-        return _relayStatus(id, status, RelayCommonStatusFlags);
+    if (_relays_active[id]) {
+        return _relayStatus(id, status);
     }
 
     return false;
 }
 
 bool relayToggle(size_t id) {
-    if (id < _relays.size()) {
+    if (_relays_active[id]) {
         return _relayToggle(id);
     }
 
@@ -2600,7 +2602,7 @@ bool relayStatus() {
 }
 
 bool relayStatus(size_t id) {
-    if (id < _relays.size()) {
+    if (_relays_active[id]) {
         return _relayStatus(id);
     }
 
@@ -2608,7 +2610,7 @@ bool relayStatus(size_t id) {
 }
 
 bool relayTargetStatus(size_t id) {
-    if (id < _relays.size()) {
+    if (_relays_active[id]) {
         return _relayTargetStatus(id);
     }
 


### PR DESCRIPTION
(maybe) resolves #2653

while #2654 commit mentioned 'internal' methods vs. 'external', only reporting is filteted through active relays bitmask. original code was using it more actively, but also modifying 'relayCount()' dynamically. this I did not like, so the change was reverted. including this commit below